### PR TITLE
board: name the volume's origin, and the endpoint behind the proof

### DIFF
--- a/ops/compose.yml
+++ b/ops/compose.yml
@@ -577,6 +577,15 @@ services:
       # settled-minus-confirmed gap tolerated as a window-boundary artifact — the
       # product's rolling 24h and the block window don't share a clock.
       PRODUCT_HEALTH_PAYOUT_TOLERANCE: ${PRODUCT_HEALTH_PAYOUT_TOLERANCE:-1}
+      # A SECOND provider, so "independent on-chain proof" is not one endpoint's
+      # opinion. Point it at a DIFFERENT operator than the primary — two hosts
+      # behind the same infrastructure agree for reasons that have nothing to do
+      # with the chain.
+      #
+      # Unset by default, and absent reads as "no second endpoint configured",
+      # which the panel states plainly and does NOT treat as a fault. The
+      # comparison is weekly and three RPC calls, so enabling it costs nothing.
+      PRODUCT_HEALTH_PAYOUT_CROSSCHECK_RPC_URL: ${PRODUCT_HEALTH_PAYOUT_CROSSCHECK_RPC_URL:-}
       # Gas attribution — what the signer's burn went ON, by operation.
       #
       # OFF by default and deliberately opt-in: one pass is ~174 RPC calls (a

--- a/packages/monitor-ui/src/components/mobile/MobileBoard.tsx
+++ b/packages/monitor-ui/src/components/mobile/MobileBoard.tsx
@@ -21,7 +21,13 @@
 
 import type { ProductHealth } from "../../lib/monitor/product-health.js";
 import { formatAgo, formatAmount } from "../../lib/monitor/ops-model.js";
-import { flowFunnel, payoutRunwayNote, payoutView, splitPools } from "../../lib/monitor/ops-spec.js";
+import {
+  flowFunnel,
+  payoutRunwayNote,
+  payoutView,
+  splitPools,
+  volumeMixNote,
+} from "../../lib/monitor/ops-spec.js";
 import {
   breachCard,
   isUntrusted,
@@ -307,6 +313,7 @@ function FlowPanel({ health, emphasise, nowMs }: { health: ProductHealth; emphas
   const funnel = flowFunnel(health.flow);
   const evidence = payoutView(health.flow?.payout);
   const timing = lifecycleNote(health.lifecycle);
+  const mix = volumeMixNote({ lifecycle: health.lifecycle, settledCount: health.flow?.settled24h ?? null });
   const clock = disputeClockLine(health.externalFunnel, nowMs);
   return (
     <section
@@ -324,6 +331,14 @@ function FlowPanel({ health, emphasise, nowMs }: { health: ProductHealth; emphas
         <span className="hm-ph-quiet">
           stuck {funnel.stuck} · failed {funnel.failed}
         </span>
+        {/* Who posted the work. Belongs on BOTH surfaces: the phone is the
+            screen most likely to be glanced at by someone who does not carry
+            the context, and self-posted volume reads as demand without it. */}
+        {mix ? (
+          <span data-tone={mix.tone} data-testid="mobile-volume-mix">
+            {mix.text}
+          </span>
+        ) : null}
         {/* Same facts as the desktop flow panel: how long the funnel above
             actually takes, split by who posted the work, plus the dispute clock
             when a bond is counting down. The phone is where this is read when

--- a/packages/monitor-ui/src/components/ops/FlowPanel.tsx
+++ b/packages/monitor-ui/src/components/ops/FlowPanel.tsx
@@ -16,7 +16,15 @@ import {
   type FunnelView,
 } from "../../lib/monitor/ops-spec.js";
 import type { MoneyPathSnapshot } from "../../lib/monitor/product-health.js";
-import { disputeClockLine, lifecycleNote, settledByHourReason, settledByHourView } from "../../lib/monitor/ops-spec.js";
+import {
+  crossCheckLine,
+  disputeClockLine,
+  lifecycleNote,
+  payoutProvenanceLine,
+  settledByHourReason,
+  settledByHourView,
+  volumeMixNote,
+} from "../../lib/monitor/ops-spec.js";
 import type { ExternalFunnelView, LifecycleView } from "../../lib/monitor/product-health.js";
 
 export interface FlowPanelProps {
@@ -34,8 +42,14 @@ export function FlowPanel({ flow, externalFunnel, lifecycle, nowMs }: FlowPanelP
   const clock = disputeClockLine(externalFunnel, nowMs ?? Date.now());
   // How long the funnel above actually takes, split by who posted the work.
   const timing = lifecycleNote(lifecycle);
+  // Reconciled against the LEDGER's settled count, not against itself — the
+  // split is read from the chain and the total from the product, and where
+  // they disagree that gap is the information.
+  const mix = volumeMixNote({ lifecycle, settledCount: flow?.settled24h ?? null });
   const funnel = flowFunnel(flow);
   const evidence = payoutView(flow?.payout);
+  const provenance = payoutProvenanceLine(flow?.payout);
+  const cross = crossCheckLine(flow?.payout, nowMs ?? Date.now());
 
   return (
     <section className="ops-flow" aria-label="Flow — money path over 24 hours" data-testid="ops-flow">
@@ -53,6 +67,16 @@ export function FlowPanel({ flow, externalFunnel, lifecycle, nowMs }: FlowPanelP
             : "gaps between stages are the signal"}
         </span>
       </header>
+
+      {/* Who posted the work, beside the count of it. "18 settled" is honest
+          and unexplained, and volume Averray posted to itself reads as demand
+          to anyone who does not already know better — including a future
+          reader of a screenshot. */}
+      {mix ? (
+        <p className="ops-volume-mix" data-tone={mix.tone} data-testid="ops-volume-mix">
+          {mix.text}
+        </p>
+      ) : null}
 
       {timing ? (
         <p className="ops-lifecycle" data-tone={timing.tone} data-testid="ops-lifecycle">
@@ -95,6 +119,20 @@ export function FlowPanel({ flow, externalFunnel, lifecycle, nowMs }: FlowPanelP
             {evidence.delta}
           </div>
         </div>
+
+        {/* Where this proof came from, and whether anyone else can see the
+            same thing. "Independent" has meant "whatever RPC we were pointed
+            at" — proof without provenance is one endpoint's opinion. */}
+        {provenance || cross ? (
+          <div className="ops-evidence-provenance" data-testid="ops-evidence-provenance">
+            {provenance ? <span className="ops-evidence-source">{provenance}</span> : null}
+            {cross ? (
+              <span data-tone={cross.tone} data-testid="ops-evidence-crosscheck">
+                {cross.text}
+              </span>
+            ) : null}
+          </div>
+        ) : null}
 
         {/* Permanent key. "we cannot see" and "we can see, and it is short" are
             different facts, and the operator should never have to remember

--- a/packages/monitor-ui/src/components/ops/money-lines-wired.test.ts
+++ b/packages/monitor-ui/src/components/ops/money-lines-wired.test.ts
@@ -57,6 +57,10 @@ describe("every money line is actually rendered", () => {
       "24 bars is a shape you study, not a fact you act on — and 24 columns across 390px is a smear. The phone keeps the funnel counts and the proof, which are the actionable parts.",
     economicsLine:
       "unit economics is a question you sit down with. Nothing about 0.163 USDC per job changes what you would do in the next ten minutes, which is the only thing the phone is for.",
+    payoutProvenanceLine:
+      "which host served the read is forensics for when a number is disputed, and the dispute happens at a desk. The phone already carries the window fit, which is the part that qualifies the number.",
+    crossCheckLine:
+      "a weekly agreement between providers is not a 2am fact. The one case that IS — endpoints disagreeing — reaches the phone anyway, because it overrides the evidence status itself.",
   };
 
   for (const fn of MONEY_LINE_RENDERERS) {

--- a/packages/monitor-ui/src/lib/monitor/ops-spec.test.ts
+++ b/packages/monitor-ui/src/lib/monitor/ops-spec.test.ts
@@ -2,6 +2,9 @@ import { describe, expect, test } from "vitest";
 
 import {
   DATA_STALE_FALLBACK_MS,
+  EVIDENCE_KEY,
+  crossCheckLine,
+  payoutProvenanceLine,
   METER_RUNGS,
   shortEndpoint,
   staleAfterMs,
@@ -13,6 +16,7 @@ import {
   settledByHourView,
   splitPools,
   trustRows,
+  volumeMixNote,
 } from "./ops-spec.js";
 import type { ProductHealth, SolvencyPool } from "./product-health.js";
 import { OPS_FIXTURE_NOMINAL, OPS_FIXTURE_STRESS } from "./ops-fixtures.js";
@@ -191,6 +195,179 @@ describe("payoutView — whether to believe the comparison at all", () => {
 
   test("nothing read from the chain is not a passing window", () => {
     expect(payoutView(undefined).fit.text).toContain("no comparison window");
+  });
+});
+
+describe("provenance — proof without a source is one endpoint's opinion", () => {
+  const base = {
+    status: "confirmed" as const, detail: "ok", confirmedCount: 18, confirmedUsdc: 3.1,
+    settledCount: 18, windowBlocks: 40909,
+  };
+
+  test("names the host and the height it was read at", () => {
+    const line = payoutProvenanceLine({
+      ...base,
+      endpoint: { host: "services.polkadothub-rpc.com", block: 19_000_081 },
+    });
+    expect(line).toBe("proved via services.polkadothub-rpc.com · block 19,000,081");
+  });
+
+  test("an older payload claims no source rather than a wrong one", () => {
+    expect(payoutProvenanceLine(base)).toBeNull();
+    expect(payoutProvenanceLine({ ...base, endpoint: { host: null, block: 19_000_081 } })).toBeNull();
+  });
+});
+
+describe("crossCheckLine — a tick must never age silently", () => {
+  const base = {
+    status: "confirmed" as const, detail: "ok", confirmedCount: 18, confirmedUsdc: 3.1,
+    settledCount: 18, windowBlocks: 40909,
+  };
+  const at = (over: Record<string, unknown>) => ({ ...base, crossCheck: { overdue: false, lastAgreedAtMs: null, ...over } as never });
+
+  test("an agreement carries its age, so a stale tick cannot pass as fresh", () => {
+    const line = crossCheckLine(
+      at({ status: "agree", detail: "A and B agree on 18", lastAgreedAtMs: NOW - 3 * 24 * 3600_000 }),
+      NOW,
+    )!;
+    expect(line.text).toContain("cross-checked ✓");
+    expect(line.text).toContain("ago");
+    expect(line.tone).toBe("awaiting");
+  });
+
+  test("an overdue check says so and goes amber", () => {
+    const line = crossCheckLine(
+      at({ status: "unavailable", detail: "cross-check could not run — unreachable", overdue: true }),
+      NOW,
+    )!;
+    expect(line.text).toContain("CROSS-CHECK OVERDUE");
+    expect(line.tone).toBe("degraded");
+  });
+
+  test("a check that failed once is not overdue and stays quiet", () => {
+    const line = crossCheckLine(at({ status: "unavailable", detail: "429 rate limited", overdue: false }), NOW)!;
+    expect(line.text).not.toContain("OVERDUE");
+    expect(line.tone).toBe("awaiting");
+  });
+
+  test("not configured is stated, not alarmed", () => {
+    // A check nobody enabled is not a check that broke.
+    const line = crossCheckLine(at({ status: "not-configured", detail: "no second endpoint configured" }), NOW)!;
+    expect(line.tone).toBe("awaiting");
+  });
+
+  test("an older payload invents no cross-check state", () => {
+    expect(crossCheckLine(base, NOW)).toBeNull();
+  });
+});
+
+describe("a disagreement suspends the comparison in BOTH directions", () => {
+  const disagree = {
+    status: "disagree" as const,
+    detail: "A reads 18 · B reads 15 — same range, two answers",
+    overdue: false,
+    lastAgreedAtMs: null,
+  };
+
+  test("it overrides CONFIRMED — the instrument cannot vouch for itself", () => {
+    const view = payoutView({
+      status: "confirmed", detail: "ok", confirmedCount: 18, confirmedUsdc: 3.1,
+      settledCount: 18, windowBlocks: 40909, crossCheck: disagree,
+    });
+    expect(view.status).toBe("ENDPOINTS DISAGREE");
+    expect(view.delta).toContain("two answers");
+  });
+
+  test("it ALSO overrides SHORTFALL — an unreliable instrument cannot accuse", () => {
+    // The same rule that makes a suspect window suppress a shortfall
+    // server-side. A shortfall measured by an instrument two providers cannot
+    // agree on is not evidence about money.
+    const view = payoutView({
+      status: "shortfall", detail: "short", confirmedCount: 15, confirmedUsdc: 2.4,
+      settledCount: 18, windowBlocks: 40909, crossCheck: disagree,
+    });
+    expect(view.status).toBe("ENDPOINTS DISAGREE");
+    expect(view.status).not.toContain("SHORTFALL");
+  });
+
+  test("it is amber and unemphasised — an instrument fault is not a money alarm", () => {
+    const view = payoutView({
+      status: "confirmed", detail: "ok", confirmedCount: 18, confirmedUsdc: 3.1,
+      settledCount: 18, windowBlocks: 40909, crossCheck: disagree,
+    });
+    expect(view.tone).toBe("degraded");
+    expect(view.emphasised).toBe(false);
+  });
+
+  test("agreement leaves the verdict entirely alone", () => {
+    const view = payoutView({
+      status: "shortfall", detail: "short", confirmedCount: 15, confirmedUsdc: 2.4,
+      settledCount: 18, windowBlocks: 40909,
+      crossCheck: { status: "agree", detail: "A and B agree on 15", overdue: false, lastAgreedAtMs: NOW },
+    });
+    expect(view.status).toBe("SHORTFALL −3");
+    expect(view.tone).toBe("red");
+  });
+
+  test("the permanent key names all four states", () => {
+    // The key exists so the operator never has to remember which colour meant
+    // which. A fourth state that is not in it is a colour with no legend.
+    expect(EVIDENCE_KEY).toHaveLength(4);
+    expect(EVIDENCE_KEY.map((e) => e.text).join(" ")).toContain("ENDPOINTS DISAGREE");
+  });
+});
+
+describe("volumeMixNote — self-generated volume must not read as demand", () => {
+  const lifecycle = (self: number, external: number) => ({
+    selfPosted: { count: self, medianSeconds: 20, slowestSeconds: 79 },
+    external: { count: external, medianSeconds: 176, slowestSeconds: 176 },
+    externalPct: self + external === 0 ? null : Math.round((external / (self + external)) * 100),
+    unmeasurable: 0,
+  });
+
+  test("names Averray as the poster, in words a stranger cannot misread", () => {
+    // "18 self-posted" needs context the reader may not have. Someone glancing
+    // at this — or at a screenshot of it months later — must not read Averray's
+    // own pipeline volume as third-party demand.
+    const v = volumeMixNote({ lifecycle: lifecycle(18, 0), settledCount: 18 })!;
+    expect(v.text).toBe("18 settled — 18 posted by Averray · 0 external");
+  });
+
+  test("zero external is stated, never omitted", () => {
+    // Dropping an empty bucket is how "no external demand yet" becomes
+    // invisible, which is the one fact the line exists to keep visible.
+    const v = volumeMixNote({ lifecycle: lifecycle(9, 0), settledCount: 9 })!;
+    expect(v.text).toContain("0 external");
+  });
+
+  test("the parts sum to the ledger count", () => {
+    const v = volumeMixNote({ lifecycle: lifecycle(17, 1), settledCount: 18 })!;
+    const nums = [...v.text.matchAll(/(\d+) (?:posted by Averray|external|unclassified)/g)].map((m) => Number(m[1]));
+    expect(nums.reduce((a, b) => a + b, 0)).toBe(18);
+  });
+
+  test("a job the chain never saw is UNCLASSIFIED, never folded into a bucket", () => {
+    // The split comes from the chain, the total from the product's ledger.
+    // They can disagree — and "external" is the one number on this board that
+    // nobody should be able to inflate by accident.
+    const v = volumeMixNote({ lifecycle: lifecycle(17, 1), settledCount: 21 })!;
+    expect(v.text).toContain("3 unclassified");
+    expect(v.text).toContain("1 external");
+    expect(v.tone).toBe("degraded");
+  });
+
+  test("more chain settlements than ledger reads as a window edge", () => {
+    const v = volumeMixNote({ lifecycle: lifecycle(19, 1), settledCount: 18 })!;
+    expect(v.text).toContain("2 beyond the ledger window");
+    expect(v.text).not.toContain("unclassified");
+  });
+
+  test("a clean reconciliation stays quiet", () => {
+    expect(volumeMixNote({ lifecycle: lifecycle(18, 0), settledCount: 18 })!.tone).toBe("awaiting");
+  });
+
+  test("no lifecycle, no line — rather than a line claiming zero of everything", () => {
+    expect(volumeMixNote({ lifecycle: undefined, settledCount: 18 })).toBeNull();
   });
 });
 

--- a/packages/monitor-ui/src/lib/monitor/ops-spec.ts
+++ b/packages/monitor-ui/src/lib/monitor/ops-spec.ts
@@ -584,6 +584,30 @@ export function payoutView(payout: PayoutEvidence | undefined): EvidenceView {
       : `${payout.settledCount} marked settled by the monitor`;
   const fit = windowFitLine(payout);
 
+  // ── A DISAGREEMENT OUTRANKS BOTH VERDICTS ────────────────────────────────
+  //
+  // If two providers read the same pinned range and return different counts,
+  // the instrument is unreliable — and an unreliable instrument cannot assert
+  // a shortfall any more than it can assert a confirmation. Suspending the
+  // comparison is the honest outcome in BOTH directions.
+  //
+  // This is the same rule that already makes a `suspect` window suppress a
+  // shortfall server-side, applied one layer out.
+  if (payout.crossCheck?.status === "disagree") {
+    return {
+      status: "ENDPOINTS DISAGREE",
+      tone: "degraded",
+      line1: chainLine,
+      line2: ledgerLine,
+      delta: payout.crossCheck.detail,
+      fit,
+      // Not the alarming frame: nothing here says money is missing, and
+      // dressing an instrument fault as one is the false red this board keeps
+      // having to remove.
+      emphasised: false,
+    };
+  }
+
   if (payout.status === "shortfall") {
     const gap = payoutGap(payout);
     return {
@@ -737,7 +761,56 @@ export const EVIDENCE_KEY: readonly { tone: OpsTone; text: string }[] = [
   { tone: "ok", text: "CONFIRMED — proof matches the ledger" },
   { tone: "red", text: "SHORTFALL — proof missing: money broken" },
   { tone: "awaiting", text: "UNVERIFIED — chain unreadable: instrument broken, not money" },
+  // A fourth fact, not a fourth severity. Two providers reading the same
+  // pinned range and returning different counts means the proof cannot be
+  // trusted in EITHER direction — it suspends the comparison rather than
+  // resolving it, which is why it is not coral.
+  { tone: "degraded", text: "ENDPOINTS DISAGREE — two providers, two answers: proof suspended" },
 ];
+
+/**
+ * The provenance line: which endpoint served this proof, at what height.
+ *
+ * "Independent on-chain proof" has meant "whatever RPC the monitor happened to
+ * be pointed at", and one week produced three separate endpoint-lens surprises
+ * — WSS 1006s on the default host, native accounts invisible to the EVM lens,
+ * an Erc20 ledger split. Proof without provenance is one endpoint's opinion.
+ *
+ * Absent on an older payload: silence rather than a claim about a source we
+ * were not told.
+ */
+export function payoutProvenanceLine(payout: PayoutEvidence | undefined): string | null {
+  const e = payout?.endpoint;
+  if (!e || !e.host) return null;
+  const at = e.block == null ? "" : ` · block ${e.block.toLocaleString()}`;
+  return `proved via ${e.host}${at}`;
+}
+
+/**
+ * Whether a second provider agrees — always rendered, never a silent tick.
+ *
+ * "cross-checked ✓" with no date is indistinguishable from a check that
+ * stopped running months ago, so every state carries its own age and an
+ * agreement past its budget reports overdue. A check being broken is a
+ * finding, not an absence.
+ */
+export function crossCheckLine(
+  payout: PayoutEvidence | undefined,
+  nowMs: number,
+): { text: string; tone: OpsTone } | null {
+  const c = payout?.crossCheck;
+  if (!c) return null; // older payload — do not invent a fault
+  if (c.status === "agree") {
+    const age = c.lastAgreedAtMs == null ? "" : ` · ${formatAgo(c.lastAgreedAtMs, nowMs)}`;
+    return { text: `cross-checked ✓ ${c.detail}${age}`, tone: "awaiting" };
+  }
+  if (c.status === "disagree") return { text: c.detail, tone: "degraded" };
+  if (c.status === "not-configured") return { text: c.detail, tone: "awaiting" };
+  // unavailable / never-run: overdue is the part that decides the tone, because
+  // a check that has been failing for a fortnight is a different fact from one
+  // that failed this morning.
+  return { text: `${c.detail}${c.overdue ? " · CROSS-CHECK OVERDUE" : ""}`, tone: c.overdue ? "degraded" : "awaiting" };
+}
 
 // ── facts that sit BESIDE their subject ─────────────────────────────────────
 //
@@ -921,6 +994,9 @@ export const MONEY_LINE_RENDERERS = [
   "gasPoolNote",
   "economicsLine",
   "settledByHourView",
+  "volumeMixNote",
+  "payoutProvenanceLine",
+  "crossCheckLine",
 ] as const;
 
 /**
@@ -959,6 +1035,74 @@ export function lifecycleNote(
   if (lifecycle.unmeasurable > 0) parts.push(`${lifecycle.unmeasurable} not timeable`);
 
   return { text: parts.join(" · "), tone: "awaiting" };
+}
+
+/**
+ * WHO POSTED THE WORK — the composition of the settled count, reconciled.
+ *
+ * ── WHY THIS IS A LINE OF ITS OWN ─────────────────────────────────────────
+ *
+ * "18 settled" is honest and unexplained, and unexplained is how a number
+ * gets misread later. Three months from now — or in a screenshot tomorrow —
+ * volume Averray posted to itself reads as demand. The board should not need
+ * a footnote in someone's memory to be read correctly, so the composition
+ * sits beside the count rather than being inferrable from a latency line.
+ *
+ * ── IT RECONCILES, OR IT SAYS IT DOESN'T ──────────────────────────────────
+ *
+ * The parts must sum to the ledger's settled count. They come from different
+ * instruments — the split is read from the CHAIN (a fee-bearing settlement is
+ * an external bounty; a fee-waived one is Averray's own), the total from the
+ * product's own ledger — so they can disagree, and the difference is real
+ * information rather than a rounding nuisance.
+ *
+ * A job the chain read did not see is `unclassified`. It is never folded into
+ * either bucket: "external" is the one number on this board that nobody
+ * should be able to inflate by accident.
+ *
+ * ── WHAT THIS CANNOT SAY ──────────────────────────────────────────────────
+ *
+ * Not canary-vs-ingestion. The chain knows only whether a settlement paid a
+ * protocol fee, and both canary walks and ingestion jobs are fee-waived
+ * Averray postings — they are identical on-chain. The product's /health
+ * settlement block carries counts and no origin, so that split needs a
+ * product contract change, not a board change. Guessing it from job ids or
+ * titles would be a pattern match that silently reassigns volume the first
+ * time something is renamed.
+ */
+export function volumeMixNote(input: {
+  lifecycle: LifecycleView | undefined;
+  /** The product's own settled count — the total the parts must reconcile to. */
+  settledCount: number | null | undefined;
+}): { text: string; tone: OpsTone } | null {
+  const { lifecycle } = input;
+  if (!lifecycle) return null;
+  const self = lifecycle.selfPosted.count;
+  const external = lifecycle.external.count;
+  const classified = self + external;
+  if (classified === 0 && !input.settledCount) return null;
+
+  const total = input.settledCount ?? classified;
+  const parts = [
+    // Spelled out rather than "self-posted": the whole point of the line is
+    // that a reader who knows nothing about the system cannot mistake it.
+    `${self} posted by Averray`,
+    `${external} external`,
+  ];
+
+  const gap = total - classified;
+  let tone: OpsTone = "awaiting";
+  if (gap > 0) {
+    // Settled per the ledger, not seen by the chain read. Named, never absorbed.
+    parts.push(`${gap} unclassified`);
+    tone = "degraded";
+  } else if (gap < 0) {
+    // The chain read reached slightly further back than the ledger's 24h — a
+    // window edge, not a discrepancy, and it must not read as one.
+    parts.push(`${-gap} beyond the ledger window`);
+  }
+
+  return { text: `${total} settled — ${parts.join(" · ")}`, tone };
 }
 
 /** "19s" · "2h 14m" · "5d" — read without converting. */

--- a/packages/monitor-ui/src/lib/monitor/product-health.ts
+++ b/packages/monitor-ui/src/lib/monitor/product-health.ts
@@ -213,6 +213,26 @@ export interface PayoutEvidence {
    * instrument could not slice look exactly like a day nothing paid out.
    */
   byHour?: PayoutHistogram | { reason: string };
+  /**
+   * WHICH endpoint served this proof, and at what height.
+   *
+   * "Independent on-chain proof" has meant "whatever RPC the monitor was
+   * pointed at". Host only — provider URLs carry API keys, and a board is a
+   * thing people screenshot.
+   */
+  endpoint?: { host: string | null; block: number | null };
+  /** Whether a SECOND provider agrees over the same pinned range. */
+  crossCheck?: CrossCheckView;
+}
+
+/** Does a second provider see the same payouts? */
+export interface CrossCheckView {
+  status: "agree" | "disagree" | "unavailable" | "not-configured" | "never-run";
+  /** Names both endpoints and both counts when they differ. */
+  detail: string;
+  /** The last agreement is older than the budget — or never happened. */
+  overdue: boolean;
+  lastAgreedAtMs: number | null;
 }
 
 /** One hour of chain, counting back from the head at read time. */

--- a/packages/monitor-ui/src/styles/hermes4-ops.css
+++ b/packages/monitor-ui/src/styles/hermes4-ops.css
@@ -590,6 +590,16 @@ body,
    The dispute clock is the one line here where doing nothing costs
    money, so it is boxed and toned; the lifecycle line is context for
    the funnel beneath it and stays quiet. */
+/* Who posted the work. Slightly louder than the latency line beneath it —
+   the composition is the fact a stranger most needs and is least likely to
+   infer, and "0 external" should be readable without hunting for it. */
+.ops-volume-mix {
+  margin: calc(7 * var(--ops-u)) 0 0;
+  font-family: var(--h4-font-mono);
+  font-size: calc(12 * var(--ops-u));
+  line-height: 1.45;
+  color: var(--tone, var(--h4-ink));
+}
 .ops-lifecycle {
   margin: calc(6 * var(--ops-u)) 0 0;
   font-family: var(--h4-font-mono);
@@ -760,6 +770,23 @@ body,
   font-size: calc(12 * var(--ops-u));
   color: var(--tone, var(--h4-muted));
 }
+/* Provenance. Deliberately the quietest thing in the panel: it answers
+   "whose proof is this", which matters when a number is disputed and at no
+   other time. It must be present and it must not compete. */
+.ops-evidence-provenance {
+  display: flex;
+  align-items: baseline;
+  gap: calc(14 * var(--ops-u));
+  flex-wrap: wrap;
+  padding: calc(5 * var(--ops-u)) calc(14 * var(--ops-u));
+  border-top: 1px dashed var(--ops-rule);
+  font-family: var(--h4-font-mono);
+  font-size: calc(9.5 * var(--ops-u));
+  color: var(--tone, var(--h4-tel));
+}
+.ops-evidence-source { color: var(--h4-tel); }
+.ops-evidence-provenance > span[data-tone] { color: var(--tone, var(--h4-tel)); }
+
 .ops-evidence-key {
   display: flex;
   gap: calc(18 * var(--ops-u));

--- a/services/slack-operator/src/payout-crosscheck-cache.ts
+++ b/services/slack-operator/src/payout-crosscheck-cache.ts
@@ -1,0 +1,102 @@
+// The cross-check on its own cadence, so the heartbeat never waits for it.
+//
+// A comparison is three RPC calls — one head read plus a getLogs against each
+// provider — which is cheap, but it is also weekly-useful information: two
+// endpoints that agreed an hour ago are not going to disagree by lunchtime.
+// Running it every heartbeat would spend a second provider's rate limit to
+// re-learn the same fact hundreds of times a day.
+//
+// Same contract as the gas cache, for the same reasons:
+//
+//   · the heartbeat always gets an ANSWER IMMEDIATELY — the last verdict
+//   · a failure keeps the previous verdict and says why it stopped moving
+//   · before the first run there is a "never run" verdict, NOT silence and
+//     NOT a pass
+//
+// The last-agreement timestamp survives failures deliberately. It is what
+// makes "cross-check overdue" possible: an agreement is only reassuring for as
+// long as it is recent, and the clock has to keep running while the check is
+// broken — otherwise a check that stopped working reads the same as one that
+// keeps passing.
+
+import {
+  crossCheckNeverRun,
+  decideCrossCheck,
+  type CrossCheckView,
+  type EndpointReading,
+} from "./payout-crosscheck.js";
+
+export interface CrossCheckCache {
+  /** The current verdict. Never null — "never run" is itself a verdict. */
+  read(): CrossCheckView;
+  /** Re-compare if the verdict has aged past the interval. Returns at once. */
+  maybeRefresh(nowMs: number): void;
+}
+
+/** Weekly. Two providers that agree today will agree this afternoon. */
+export const DEFAULT_CROSSCHECK_INTERVAL_MS = 7 * 24 * 60 * 60 * 1000;
+
+export interface CrossCheckRun {
+  primary: EndpointReading | null;
+  secondary: EndpointReading | null;
+  secondaryReason?: string | null;
+  range?: { fromBlock: number; toBlock: number } | null;
+}
+
+export function createCrossCheckCache(deps: {
+  /** False when no second endpoint is configured. */
+  configured: boolean;
+  /** Performs both pinned reads. Injected so this is testable without a chain. */
+  run: () => Promise<CrossCheckRun>;
+  intervalMs?: number;
+  onError?: (message: string) => void;
+}): CrossCheckCache {
+  const intervalMs = deps.intervalMs ?? DEFAULT_CROSSCHECK_INTERVAL_MS;
+  let verdict: CrossCheckView = crossCheckNeverRun(deps.configured);
+  // Survives failures on purpose — see the header.
+  let lastAgreedAtMs: number | null = null;
+  let lastRunAtMs: number | null = null;
+  let running = false;
+
+  return {
+    read: () => verdict,
+
+    maybeRefresh(nowMs) {
+      if (!deps.configured) return;
+      if (running) return;
+      if (lastRunAtMs !== null && nowMs - lastRunAtMs < intervalMs) return;
+      running = true;
+      void (async () => {
+        try {
+          const run = await deps.run();
+          verdict = decideCrossCheck({
+            configured: true,
+            primary: run.primary,
+            secondary: run.secondary,
+            ...(run.secondaryReason ? { secondaryReason: run.secondaryReason } : {}),
+            ...(run.range ? { range: run.range } : {}),
+            lastAgreedAtMs,
+            nowMs,
+          });
+          if (verdict.status === "agree") lastAgreedAtMs = nowMs;
+        } catch (error) {
+          const message = error instanceof Error ? error.message : String(error);
+          verdict = decideCrossCheck({
+            configured: true,
+            primary: null,
+            secondary: null,
+            secondaryReason: message,
+            lastAgreedAtMs,
+            nowMs,
+          });
+          deps.onError?.(message);
+        } finally {
+          // Set even on failure: a provider that is down must not be retried
+          // every heartbeat until it comes back.
+          lastRunAtMs = nowMs;
+          running = false;
+        }
+      })();
+    },
+  };
+}

--- a/services/slack-operator/src/payout-crosscheck.ts
+++ b/services/slack-operator/src/payout-crosscheck.ts
@@ -1,0 +1,204 @@
+// Is the payout proof one endpoint's opinion?
+//
+// The evidence panel is the board's strongest claim: an INDEPENDENT on-chain
+// read that can contradict the product's own ledger. But "independent" has
+// meant "whatever RPC the monitor happened to be pointed at", and one week
+// produced three separate endpoint-lens surprises — WSS 1006s on the default
+// host, native accounts invisible to the EVM lens, an Erc20 ledger split.
+//
+// Proof without provenance is one endpoint's opinion. This compares the same
+// window against a second, different provider.
+//
+// ── DISAGREEMENT IS A THIRD KIND OF FAULT ──────────────────────────────────
+//
+// The panel already separates two: SHORTFALL (we can see, and money is
+// missing) and UNVERIFIED (we cannot see — the instrument is broken, the
+// money may be fine). Endpoints disagreeing is neither. It means the
+// instrument is unreliable, which SUSPENDS the comparison rather than
+// resolving it either way — including suspending a shortfall, because a
+// shortfall measured by an instrument two providers cannot agree on is not
+// evidence about money.
+//
+// ── COMPARE BEHIND THE HEAD, OR MANUFACTURE FALSE ALARMS ───────────────────
+//
+// Two honest endpoints legitimately disagree at the tip: they see different
+// pending blocks, and one may be a block or two behind. Comparing "the last
+// N blocks" on each would produce a disagreement most times it ran, and an
+// alarm that is usually wrong is one the operator learns to ignore — the
+// exact failure this board keeps having to fix.
+//
+// So the comparison runs over a range PINNED on both sides and ending well
+// behind the head. `SAFE_HEAD_LAG_BLOCKS` is that margin.
+//
+// ── A TICK MUST NEVER AGE SILENTLY ─────────────────────────────────────────
+//
+// "cross-checked ✓" with no date is indistinguishable from a check that
+// stopped running months ago. Every state carries its age, and an agreement
+// older than the budget reports `overdue` — the check being broken is itself
+// a finding, not an absence.
+
+/** How far behind the head the compared range ends. ~7 min at 2.1s/block. */
+export const SAFE_HEAD_LAG_BLOCKS = 200;
+
+/** Past this, the last agreement is too old to still be reassuring. */
+export const CROSSCHECK_OVERDUE_MS = 10 * 24 * 60 * 60 * 1000;
+
+export type CrossCheckStatus =
+  /** Both endpoints read the same range and got the same count. */
+  | "agree"
+  /** Both read it and got different counts — the instrument is unreliable. */
+  | "disagree"
+  /** The second endpoint could not be read. Not evidence either way. */
+  | "unavailable"
+  /** No second endpoint is configured. Nobody asked for this; not a fault. */
+  | "not-configured"
+  /** Configured, but no comparison has completed yet. */
+  | "never-run";
+
+export interface CrossCheckView {
+  status: CrossCheckStatus;
+  /** One sentence, naming both endpoints and both counts when they differ. */
+  detail: string;
+  /** True when the last AGREEMENT is older than the budget, or never happened. */
+  overdue: boolean;
+  /** Epoch ms of the last agreement, for rendering its age. */
+  lastAgreedAtMs: number | null;
+}
+
+export interface EndpointReading {
+  host: string;
+  /** Payouts counted over the pinned range. Null means the read failed. */
+  count: number | null;
+}
+
+export function decideCrossCheck(input: {
+  /** A second RPC URL was configured. */
+  configured: boolean;
+  primary: EndpointReading | null;
+  secondary: EndpointReading | null;
+  /** Why the secondary read failed, when it did. */
+  secondaryReason?: string | null;
+  /** The pinned range both endpoints were asked about. */
+  range?: { fromBlock: number; toBlock: number } | null;
+  lastAgreedAtMs: number | null;
+  nowMs: number;
+  overdueAfterMs?: number;
+}): CrossCheckView {
+  const budget = input.overdueAfterMs ?? CROSSCHECK_OVERDUE_MS;
+  const agedOut =
+    input.lastAgreedAtMs === null || input.nowMs - input.lastAgreedAtMs > budget;
+
+  if (!input.configured) {
+    // Deliberately NOT overdue. A check nobody enabled is not a check that
+    // broke, and rendering it as one puts a permanent amber on the panel.
+    return {
+      status: "not-configured",
+      detail:
+        "no second endpoint configured — this proof rests on one provider (set PRODUCT_HEALTH_PAYOUT_CROSSCHECK_RPC_URL)",
+      overdue: false,
+      lastAgreedAtMs: null,
+    };
+  }
+
+  const range = input.range
+    ? ` over blocks ${input.range.fromBlock.toLocaleString()}–${input.range.toBlock.toLocaleString()}`
+    : "";
+
+  if (input.secondaryReason || input.secondary?.count == null) {
+    const why = input.secondaryReason ?? "second endpoint returned no count";
+    return {
+      status: "unavailable",
+      detail: `cross-check could not run — ${why}`,
+      // An unreadable second endpoint does not reset the clock: if the last
+      // real agreement has aged out, the panel is overdue whatever the reason.
+      overdue: agedOut,
+      lastAgreedAtMs: input.lastAgreedAtMs,
+    };
+  }
+
+  if (input.primary?.count == null) {
+    return {
+      status: "unavailable",
+      detail: "cross-check could not run — the primary read produced no count to compare",
+      overdue: agedOut,
+      lastAgreedAtMs: input.lastAgreedAtMs,
+    };
+  }
+
+  if (input.primary.count !== input.secondary.count) {
+    // Name both, or the alarm has no next step.
+    return {
+      status: "disagree",
+      detail:
+        `${input.primary.host} reads ${input.primary.count} · ` +
+        `${input.secondary.host} reads ${input.secondary.count}${range} — ` +
+        "same range, two answers: the payout instrument is not reliable until this is resolved",
+      overdue: false,
+      lastAgreedAtMs: input.lastAgreedAtMs,
+    };
+  }
+
+  return {
+    status: "agree",
+    detail: `${input.primary.host} and ${input.secondary.host} agree on ${input.primary.count}${range}`,
+    overdue: false,
+    lastAgreedAtMs: input.nowMs,
+  };
+}
+
+/**
+ * Configured but never completed — distinct from a passing check.
+ *
+ * Split out because the caller reaches this before any comparison has run,
+ * and "no result yet" must not borrow the wording of an agreement.
+ */
+export function crossCheckNeverRun(configured: boolean): CrossCheckView {
+  if (!configured) {
+    return decideCrossCheck({
+      configured: false, primary: null, secondary: null, lastAgreedAtMs: null, nowMs: 0,
+    });
+  }
+  return {
+    status: "never-run",
+    detail: "cross-check configured but has not completed a comparison yet",
+    overdue: false,
+    lastAgreedAtMs: null,
+  };
+}
+
+/**
+ * The range both endpoints are asked about.
+ *
+ * Ends `SAFE_HEAD_LAG_BLOCKS` behind the head so tip disagreement — which is
+ * normal and says nothing about the instrument — cannot register as a finding.
+ * Returns null when the head is too shallow to leave that margin.
+ */
+export function pinnedCompareRange(input: {
+  latestBlock: number;
+  lookbackBlocks: number;
+  headLag?: number;
+}): { fromBlock: number; toBlock: number } | null {
+  const lag = input.headLag ?? SAFE_HEAD_LAG_BLOCKS;
+  const toBlock = input.latestBlock - lag;
+  if (!(toBlock > 0)) return null;
+  const fromBlock = Math.max(0, toBlock - input.lookbackBlocks);
+  if (fromBlock >= toBlock) return null;
+  return { fromBlock, toBlock };
+}
+
+/**
+ * Host only — never the full URL.
+ *
+ * Provider URLs carry API keys in the path or query often enough that echoing
+ * one onto a screen (or into a screenshot, or a Buzz message) is a credential
+ * leak. The host is the whole of what the provenance line needs to say.
+ */
+export function endpointHost(url: string | null | undefined): string | null {
+  const raw = (url ?? "").trim();
+  if (!raw) return null;
+  try {
+    return new URL(raw).host || null;
+  } catch {
+    return null;
+  }
+}

--- a/services/slack-operator/src/product-health.ts
+++ b/services/slack-operator/src/product-health.ts
@@ -37,6 +37,8 @@ import { readGasSpend } from "./gas-spend-read.js";
 import { readJobLifecycle } from "./job-lifecycle-read.js";
 import { summarizeLifecycle, type LifecycleSummary } from "./job-lifecycle.js";
 import { bucketPayoutsByHour, isHistogramUnavailable, type PayoutHistogram } from "./payout-histogram.js";
+import { endpointHost, pinnedCompareRange, type CrossCheckView } from "./payout-crosscheck.js";
+import { createCrossCheckCache, type CrossCheckCache } from "./payout-crosscheck-cache.js";
 import { createGasSpendCache, type GasSpendCache, type GasSpendSnapshot, type GasUnreadable } from "./gas-spend-cache.js";
 import { alertProvenance, decideMoneyAlert } from "./money-alert.js";
 import { decideSelfFreshness, fetchSelfCompare } from "./self-freshness.js";
@@ -560,6 +562,8 @@ export interface ProductHealthConfig {
   gasRefreshMs: number;
   /** Settled-minus-confirmed gap tolerated as a window-boundary artifact. */
   payoutTolerance: number;
+  /** A SECOND provider, so the proof is not one endpoint's opinion. */
+  payoutCrossCheckRpcUrl: string;
   /** Filesystem the monitor writes to. Container `/` sees real host capacity. */
   diskPath: string;
   /** Free-space floor in GiB — below this the disk probe goes red. */
@@ -674,6 +678,7 @@ export function loadProductHealthConfig(env: NodeJS.ProcessEnv = process.env): P
     // mainnet only escaped by overriding to 43200 (still 25.3h, 5% long).
     payoutLookbackBlocks: num(env.PRODUCT_HEALTH_PAYOUT_LOOKBACK_BLOCKS, 60000),
     payoutTolerance: num(env.PRODUCT_HEALTH_PAYOUT_TOLERANCE, 1),
+    payoutCrossCheckRpcUrl: (env.PRODUCT_HEALTH_PAYOUT_CROSSCHECK_RPC_URL ?? "").trim(),
     // Off by default. A pass is ~174 RPC calls against an endpoint that
     // rate-limits by answering 404, so the operator opts in knowingly.
     gasAttributionEnabled: truthy(env.PRODUCT_HEALTH_GAS_ATTRIBUTION_ENABLED),
@@ -1460,6 +1465,15 @@ export async function readPayoutTransfers(input: {
    * must not claim the payout count is fee-free.
    */
   feeRecipientAddress?: string;
+  /**
+   * Read this EXACT block range instead of "the last N blocks up to latest".
+   *
+   * The cross-check asks two providers the same question, and "the last N
+   * blocks" is not the same question twice: each resolves `latest` against its
+   * own view of the tip. Pinning both sides is what makes a difference in the
+   * answers mean something.
+   */
+  range?: { fromBlock: number; toBlock: number };
   fetchImpl: typeof fetch;
 }): Promise<{
   count: number | null;
@@ -1498,14 +1512,18 @@ export async function readPayoutTransfers(input: {
         );
       }
     }
-    const latest = Number(BigInt(await ethRpc(input.rpcUrl, "eth_blockNumber", [], input.fetchImpl)));
-    const fromBlock = Math.max(0, latest - input.lookbackBlocks);
+    // A pinned range skips the head read entirely — asking each provider for
+    // its own `latest` is precisely what the pin exists to avoid.
+    const latest = input.range
+      ? input.range.toBlock
+      : Number(BigInt(await ethRpc(input.rpcUrl, "eth_blockNumber", [], input.fetchImpl)));
+    const fromBlock = input.range ? input.range.fromBlock : Math.max(0, latest - input.lookbackBlocks);
     const logs = await ethRpcRaw(
       input.rpcUrl,
       "eth_getLogs",
       [{
         fromBlock: `0x${fromBlock.toString(16)}`,
-        toBlock: "latest",
+        toBlock: input.range ? `0x${input.range.toBlock.toString(16)}` : "latest",
         // The CONTRACT THAT EMITS the payout event, not the token.
         address: input.sourceAddress,
         topics: [RESERVATION_SETTLED_TOPIC],
@@ -1677,6 +1695,68 @@ function gasAttribution(input: {
 
   gasCache.maybeRefresh(input.nowMs);
   return gasCache.read(input.nowMs);
+}
+
+let crossCheckCache: CrossCheckCache | null = null;
+
+/**
+ * Ask a SECOND provider the same pinned question, weekly.
+ *
+ * Both reads use one range, computed once from the primary's head and ending
+ * `SAFE_HEAD_LAG_BLOCKS` behind it. Letting each provider resolve its own
+ * `latest` would compare two different questions and disagree most times it
+ * ran — see payout-crosscheck.ts.
+ */
+function payoutCrossCheck(input: {
+  config: ProductHealthConfig;
+  sourceAddress?: string;
+  chainId?: number;
+  fetchImpl: typeof fetch;
+  nowMs: number;
+}): CrossCheckView {
+  const { config } = input;
+  const configured = Boolean(
+    config.payoutCrossCheckRpcUrl && config.rpcUrl && input.sourceAddress && config.usdcAddress,
+  );
+  crossCheckCache ??= createCrossCheckCache({
+    configured,
+    run: async () => {
+      // Re-checked inside the closure rather than trusted from `configured`:
+      // this cache is a module singleton and outlives any one call's type
+      // narrowing, so this is the guard that actually holds at run time.
+      const primaryUrl = config.rpcUrl;
+      const secondUrl = config.payoutCrossCheckRpcUrl;
+      const source = input.sourceAddress;
+      if (!primaryUrl || !secondUrl || !source) {
+        return { primary: null, secondary: null, secondaryReason: "cross-check lost its configuration between runs" };
+      }
+      const latest = Number(BigInt(await ethRpc(primaryUrl, "eth_blockNumber", [], input.fetchImpl)));
+      const range = pinnedCompareRange({ latestBlock: latest, lookbackBlocks: config.payoutLookbackBlocks });
+      if (!range) return { primary: null, secondary: null, secondaryReason: "chain too short to compare behind the head" };
+      const shared = {
+        sourceAddress: source,
+        usdcAddress: config.usdcAddress,
+        usdcDecimals: config.usdcDecimals,
+        lookbackBlocks: config.payoutLookbackBlocks,
+        ...(input.chainId !== undefined ? { expectedChainId: input.chainId } : {}),
+        range,
+        fetchImpl: input.fetchImpl,
+      };
+      const [primary, secondary] = await Promise.all([
+        readPayoutTransfers({ ...shared, rpcUrl: primaryUrl }),
+        readPayoutTransfers({ ...shared, rpcUrl: secondUrl }),
+      ]);
+      return {
+        primary: { host: endpointHost(primaryUrl) ?? "primary", count: primary.count },
+        secondary: { host: endpointHost(secondUrl) ?? "secondary", count: secondary.count },
+        ...(secondary.reason ? { secondaryReason: secondary.reason } : {}),
+        range,
+      };
+    },
+    onError: () => {},
+  });
+  crossCheckCache.maybeRefresh(input.nowMs);
+  return crossCheckCache.read();
 }
 
 /** Test seam: forget the singleton so each test starts from no snapshot. */
@@ -2122,6 +2202,17 @@ export interface PayoutEvidence {
    */
   byHour?: PayoutHistogram | { reason: string };
   /**
+   * WHICH endpoint served this proof, and at what height.
+   *
+   * "Independent on-chain proof" has meant "whatever RPC the monitor was
+   * pointed at". One week produced three separate endpoint-lens surprises, so
+   * the panel names its source rather than implying the chain speaks with one
+   * voice. Host only — provider URLs carry API keys.
+   */
+  endpoint?: { host: string | null; block: number | null };
+  /** Whether a SECOND provider agrees. Never absent — see payout-crosscheck. */
+  crossCheck?: CrossCheckView;
+  /**
    * Protocol-fee credits in the SAME window — settlements whose recipient was
    * the fee treasury, and the reason `confirmedCount` is not simply every
    * settlement found on chain.
@@ -2162,6 +2253,7 @@ export function withFeeSplit(
     fromBlock?: number | null;
   },
   blockSeconds?: number | null,
+  provenance?: { host: string | null; crossCheck: CrossCheckView },
 ): PayoutEvidence {
   return {
     ...evidence,
@@ -2169,6 +2261,12 @@ export function withFeeSplit(
     feeUsdc: read.feeUsdc,
     feesSeparated: read.feesSeparated,
     byHour: sliceIntoHours(read, blockSeconds ?? null),
+    ...(provenance
+      ? {
+          endpoint: { host: provenance.host, block: read.latestBlock ?? null },
+          crossCheck: provenance.crossCheck,
+        }
+      : {}),
   };
 }
 
@@ -2429,12 +2527,15 @@ export async function collectProductHealthProbes(
     maxBlocks: config.payoutLookbackBlocks,
     targetHours: PAYOUT_COMPARISON_HOURS,
   });
+  // Named once: the cross-check must read the SAME contract, and a second
+  // inline copy of this expression is how the two silently drift apart.
+  const payoutSource = config.payoutSourceAddress || h.body?.addresses?.agentAccountCore;
   const payoutRead = config.payoutEvidenceEnabled
     ? await readPayoutTransfers({
         rpcUrl: config.rpcUrl,
         // USDC leaves AgentAccountCore, not the signer EOA — the reward bank is
         // an in-contract position and the signer only sends the tx (#558).
-        sourceAddress: config.payoutSourceAddress || h.body?.addresses?.agentAccountCore,
+        sourceAddress: payoutSource,
         usdcAddress: config.usdcAddress,
         usdcDecimals: config.usdcDecimals,
         lookbackBlocks: lookback.blocks,
@@ -2468,6 +2569,16 @@ export async function collectProductHealthProbes(
     }),
     payoutRead,
     blockSeconds,
+    {
+      host: endpointHost(config.rpcUrl),
+      crossCheck: payoutCrossCheck({
+        config,
+        ...(payoutSource ? { sourceAddress: payoutSource } : {}),
+        ...(chainId !== undefined ? { chainId } : {}),
+        fetchImpl,
+        nowMs: chainCtx.nowMs,
+      }),
+    },
   );
   // The monitor's own version. Degraded-safe: any failure is "unknown", which
   // must never render as up to date.

--- a/services/slack-operator/test/unit/payout-crosscheck.test.ts
+++ b/services/slack-operator/test/unit/payout-crosscheck.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, test } from "vitest";
+
+import {
+  CROSSCHECK_OVERDUE_MS,
+  SAFE_HEAD_LAG_BLOCKS,
+  crossCheckNeverRun,
+  decideCrossCheck,
+  endpointHost,
+  pinnedCompareRange,
+} from "../../src/payout-crosscheck.js";
+
+const NOW = 1_785_700_000_000;
+const A = { host: "services.polkadothub-rpc.com", count: 18 };
+const B = { host: "eth-rpc.polkadot.io", count: 18 };
+const base = { configured: true, lastAgreedAtMs: NOW - 1000, nowMs: NOW };
+
+describe("agreement and disagreement", () => {
+  test("same count is a quiet agreement that names both endpoints", () => {
+    const v = decideCrossCheck({ ...base, primary: A, secondary: B });
+    expect(v.status).toBe("agree");
+    expect(v.detail).toContain("services.polkadothub-rpc.com");
+    expect(v.detail).toContain("eth-rpc.polkadot.io");
+    expect(v.overdue).toBe(false);
+    expect(v.lastAgreedAtMs).toBe(NOW);
+  });
+
+  test("a disagreement names BOTH counts, or the alarm has no next step", () => {
+    const v = decideCrossCheck({
+      ...base,
+      primary: A,
+      secondary: { ...B, count: 15 },
+      range: { fromBlock: 18_959_091, toBlock: 19_000_000 },
+    });
+    expect(v.status).toBe("disagree");
+    expect(v.detail).toContain("reads 18");
+    expect(v.detail).toContain("reads 15");
+    expect(v.detail).toContain("18,959,091");
+    expect(v.detail).toContain("not reliable");
+  });
+
+  test("a disagreement does not silently refresh the agreement clock", () => {
+    const v = decideCrossCheck({ ...base, primary: A, secondary: { ...B, count: 15 } });
+    expect(v.lastAgreedAtMs).toBe(base.lastAgreedAtMs);
+  });
+});
+
+describe("a tick must never age silently", () => {
+  test("an agreement older than the budget reports overdue when the check fails", () => {
+    const v = decideCrossCheck({
+      configured: true,
+      primary: A,
+      secondary: null,
+      secondaryReason: "second endpoint unreachable (ETIMEDOUT)",
+      lastAgreedAtMs: NOW - CROSSCHECK_OVERDUE_MS - 1,
+      nowMs: NOW,
+    });
+    expect(v.status).toBe("unavailable");
+    expect(v.overdue).toBe(true);
+    expect(v.detail).toContain("ETIMEDOUT");
+  });
+
+  test("a recent agreement is not overdue merely because one run failed", () => {
+    const v = decideCrossCheck({
+      configured: true,
+      primary: A,
+      secondary: null,
+      secondaryReason: "429 rate limited",
+      lastAgreedAtMs: NOW - 60_000,
+      nowMs: NOW,
+    });
+    expect(v.overdue).toBe(false);
+  });
+
+  test("never having agreed is overdue the moment a run fails", () => {
+    // Otherwise a check that has NEVER succeeded renders identically to one
+    // that succeeded yesterday.
+    const v = decideCrossCheck({
+      configured: true, primary: A, secondary: null,
+      secondaryReason: "unreachable", lastAgreedAtMs: null, nowMs: NOW,
+    });
+    expect(v.overdue).toBe(true);
+  });
+});
+
+describe("absence is not a fault, and never-run is not a pass", () => {
+  test("no second endpoint configured is not overdue and says what is missing", () => {
+    // A check nobody enabled is not a check that broke. Rendering it as one
+    // puts a permanent amber on the panel, which trains the operator past it.
+    const v = decideCrossCheck({
+      configured: false, primary: A, secondary: null, lastAgreedAtMs: null, nowMs: NOW,
+    });
+    expect(v.status).toBe("not-configured");
+    expect(v.overdue).toBe(false);
+    expect(v.detail).toContain("one provider");
+    expect(v.detail).toContain("PRODUCT_HEALTH_PAYOUT_CROSSCHECK_RPC_URL");
+  });
+
+  test("configured but not yet run borrows none of an agreement's wording", () => {
+    const v = crossCheckNeverRun(true);
+    expect(v.status).toBe("never-run");
+    expect(v.detail).not.toContain("agree");
+    expect(v.lastAgreedAtMs).toBeNull();
+  });
+
+  test("a null count on either side is unavailable, never a disagreement", () => {
+    // "could not read" and "read something different" are different findings
+    // and only one of them impugns the instrument.
+    expect(
+      decideCrossCheck({ ...base, primary: A, secondary: { host: B.host, count: null } }).status,
+    ).toBe("unavailable");
+    expect(
+      decideCrossCheck({ ...base, primary: { host: A.host, count: null }, secondary: B }).status,
+    ).toBe("unavailable");
+  });
+});
+
+describe("pinnedCompareRange — compare behind the head", () => {
+  test("the compared range ends well behind the tip", () => {
+    // Two honest endpoints legitimately disagree at the tip. Comparing there
+    // would fire most times it ran, and an alarm that is usually wrong is the
+    // failure mode this whole exercise exists to avoid.
+    const r = pinnedCompareRange({ latestBlock: 19_000_000, lookbackBlocks: 40_909 })!;
+    expect(r.toBlock).toBe(19_000_000 - SAFE_HEAD_LAG_BLOCKS);
+    expect(r.fromBlock).toBe(r.toBlock - 40_909);
+  });
+
+  test("both sides are pinned, so the same question is asked twice", () => {
+    const r = pinnedCompareRange({ latestBlock: 19_000_000, lookbackBlocks: 100 })!;
+    expect(Number.isInteger(r.fromBlock)).toBe(true);
+    expect(Number.isInteger(r.toBlock)).toBe(true);
+    expect(r.toBlock).toBeGreaterThan(r.fromBlock);
+  });
+
+  test("a chain too shallow for the margin yields no range rather than a bad one", () => {
+    expect(pinnedCompareRange({ latestBlock: 50, lookbackBlocks: 40_000 })).toBeNull();
+  });
+});
+
+describe("endpointHost — the URL never reaches the screen", () => {
+  test("host only, because provider URLs carry API keys", () => {
+    // Echoing a full URL onto a board (or into a screenshot, or a Buzz
+    // message) is a credential leak, and the host is all the line needs.
+    expect(endpointHost("https://rpc.example.com/v1/SECRET-KEY?apikey=abc123")).toBe("rpc.example.com");
+    expect(endpointHost("https://services.polkadothub-rpc.com/mainnet/")).toBe("services.polkadothub-rpc.com");
+  });
+
+  test("an unparseable value yields null, never the raw string", () => {
+    // Returning the raw string here would defeat the redaction above the
+    // moment someone configured a URL the parser did not like.
+    expect(endpointHost("not a url with ?apikey=leak")).toBeNull();
+    expect(endpointHost("")).toBeNull();
+    expect(endpointHost(undefined)).toBeNull();
+  });
+});


### PR DESCRIPTION
Improvements **#3** and **#4** from the review. Stacked on #690 — it needs the block range that PR returns from the payout read.

---

## #3 — who posted the work

*"18 settled"* is honest and unexplained, and unexplained is how a number gets misread later. Volume Averray posts to itself reads as demand to anyone without the context — including a future reader of a screenshot.

The FLOW panel now carries the composition beside the count, on **both** surfaces:

```
21 settled — 17 posted by Averray · 1 external · 3 unclassified
```

It **reconciles against the ledger's settled count.** The split is read from the *chain* (fee-bearing ⇒ external bounty, fee-waived ⇒ Averray's own) and the total from the *product's* ledger, so they can disagree — and that gap is information. A job the chain read never saw is `unclassified`, never folded into either bucket: `external` is the one number on this board nobody should be able to inflate by accident.

### What it deliberately does not say

**Canary-vs-ingestion isn't buildable from this repo, and I'd rather say so than approximate it.** The chain knows only whether a settlement paid a protocol fee, and canary walks and ingestion jobs are *both* fee-waived Averray postings — identical on-chain. The product's `/health` settlement block carries counts and no origin field. That split needs a product contract change.

Per the spec's own "no silent absorption" rule, guessing it from job ids or titles would be a pattern match that silently reassigns volume the first time something gets renamed.

---

## #4 — proof without provenance is one endpoint's opinion

### Provenance, always shown

```
proved via services.polkadothub-rpc.com · block 19,000,081
```

**Host only, never the URL** — provider URLs carry API keys in the path or query, and a board is a thing people screenshot. An unparseable value yields `null`, not the raw string, so the redaction can't be defeated by a URL the parser dislikes.

### Cross-check, weekly

- **Both sides read a pinned range ending `SAFE_HEAD_LAG_BLOCKS` behind the head.** Letting each provider resolve its own `latest` compares two different questions — honest endpoints disagree at the tip, and it would have fired most times it ran. An alarm that is usually wrong is the failure mode this whole exercise exists to prevent.
- **A disagreement is a fourth *state*, not a fourth severity**, and it's in the permanent key. It overrides `CONFIRMED` **and** `SHORTFALL`: an instrument two providers can't agree on cannot accuse the money any more than it can vouch for it. Amber and unemphasised — an instrument fault is not a money alarm. Same rule that already makes a `suspect` window suppress a shortfall, one layer out.
- **Every state carries its age.** An agreement past its budget reports `CROSS-CHECK OVERDUE`; "cross-checked ✓" with no date is indistinguishable from a check that stopped running months ago.
- **Not configured is stated, never alarmed.** A check nobody enabled is not a check that broke — that would put a permanent amber on the panel.

---

## Found while building

- **The compose-env guard caught the new knob before it shipped.** Config that never reaches the container is a feature that silently does nothing. Exactly the class of bug that guard exists for, and it worked.
- The wiring guard now records a **written argument** for every desk-only renderer, so an exemption is a decision rather than an omission.

## Verification

- **2537 tests pass repo-wide** — 14 new backend (agreement, disagreement, overdue, redaction, head-lag), 12 new view-model, plus guard entries
- typecheck clean on both packages

## Not built

`#1` (runway dual-window) — its proposed data source, signer balance delta over 7 days, is wrong: **top-ups land in the same balance**, so it under-reports burn and can report it negative. Needs the gas-receipt sum instead. `#2` (Bank lane) rides the ceremony packet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)