### PR TITLE
board: a gap of one is the steady state, not a standing alarm

### DIFF
--- a/packages/monitor-ui/src/lib/monitor/ops-spec.test.ts
+++ b/packages/monitor-ui/src/lib/monitor/ops-spec.test.ts
@@ -356,6 +356,23 @@ describe("volumeMixNote — self-generated volume must not read as demand", () =
     expect(v.tone).toBe("degraded");
   });
 
+  test("a gap of ONE is named but not alarmed — it is the steady state", () => {
+    // Seen live on three separate reads: 14/15, 15/16, 17/18, always exactly
+    // one. It is the most recently settled job, confirmed by the ledger before
+    // its log is inside the block window. Structural and benign — and a line
+    // that is amber on every read forever is a line nobody reads, which would
+    // cost precisely the case it exists for.
+    const v = volumeMixNote({ lifecycle: lifecycle(14, 0), settledCount: 15 })!;
+    expect(v.text).toContain("1 unclassified");
+    expect(v.tone).toBe("awaiting");
+  });
+
+  test("past the tolerance it DOES alarm — the count is never suppressed", () => {
+    const v = volumeMixNote({ lifecycle: lifecycle(14, 0), settledCount: 17 })!;
+    expect(v.text).toContain("3 unclassified");
+    expect(v.tone).toBe("degraded");
+  });
+
   test("more chain settlements than ledger reads as a window edge", () => {
     const v = volumeMixNote({ lifecycle: lifecycle(19, 1), settledCount: 18 })!;
     expect(v.text).toContain("2 beyond the ledger window");

--- a/packages/monitor-ui/src/lib/monitor/ops-spec.ts
+++ b/packages/monitor-ui/src/lib/monitor/ops-spec.ts
@@ -1074,6 +1074,19 @@ export function volumeMixNote(input: {
   lifecycle: LifecycleView | undefined;
   /** The product's own settled count — the total the parts must reconcile to. */
   settledCount: number | null | undefined;
+  /**
+   * Gap treated as the expected window-edge artifact rather than a fault.
+   *
+   * Observed live on three separate reads — 14/15, 15/16, 17/18 — always
+   * exactly one: the most recently settled job, confirmed by the ledger before
+   * its log is inside the block window. It is structural, it is benign, and
+   * lighting it amber on every read forever is how an operator learns to scroll
+   * past the line — which would cost exactly the case the line exists for.
+   *
+   * Same boundary and same reasoning as PRODUCT_HEALTH_PAYOUT_TOLERANCE. The
+   * gap is still COUNTED and still NAMED at any size; only the alarm waits.
+   */
+  edgeTolerance?: number;
 }): { text: string; tone: OpsTone } | null {
   const { lifecycle } = input;
   if (!lifecycle) return null;
@@ -1091,11 +1104,14 @@ export function volumeMixNote(input: {
   ];
 
   const gap = total - classified;
+  const tolerance = input.edgeTolerance ?? 1;
   let tone: OpsTone = "awaiting";
   if (gap > 0) {
-    // Settled per the ledger, not seen by the chain read. Named, never absorbed.
+    // Settled per the ledger, not seen by the chain read. Named, never absorbed
+    // — but only ALARMING past the window-edge tolerance, because one is the
+    // steady state and a permanent amber is a line nobody reads.
     parts.push(`${gap} unclassified`);
-    tone = "degraded";
+    if (gap > tolerance) tone = "degraded";
   } else if (gap < 0) {
     // The chain read reached slightly further back than the ledger's 24h — a
     // window edge, not a discrepancy, and it must not read as one.


### PR DESCRIPTION
Follow-up to #691 — the fix was pushed while that PR was merging, so it missed the merge by seconds. **Without this, the line #691 just added lights amber on every read, forever.**

## What the live board showed

```
settled (ledger) : 15
chain split      : 14 Averray + 0 external
```

A gap of exactly **one** — and that is now three sightings: 14/15, 15/16, 17/18.

It is structural. The most recently settled job is confirmed by the product's ledger *before* its settlement log falls inside the block window, so the two instruments disagree by one essentially all the time.

## The defect

As merged, `volumeMixNote` tones **any** positive gap `degraded`. On this board that means a permanent amber on a line that is behaving exactly as designed.

That is the crying-wolf failure this board keeps having to remove — the stale banner that was lit most of the time, the shortfall that fired on a window artifact — and I shipped it into the same PR whose description argues against it. It is also precisely the objection I raised to proposal #1 an hour earlier: *"a projection that overstates urgency 40× gets ignored, and then it's useless the day it's right."*

## The fix

The gap is still **counted** and still **named** at every size. Only the alarm waits until it exceeds the window-edge tolerance:

```
15 settled — 14 posted by Averray · 0 external · 1 unclassified     ← grey
17 settled — 14 posted by Averray · 0 external · 3 unclassified     ← amber
```

Same boundary and the same reasoning as `PRODUCT_HEALTH_PAYOUT_TOLERANCE`, which exists for this exact artifact one panel down.

## Verification

- 2 new tests: a gap of one is named and quiet; past the tolerance it alarms and the count is never suppressed
- 2539 tests pass repo-wide, typecheck clean

Caught by reading a live board, not by a test — same as every other real defect in this run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)