### PR TITLE
runway: project signer gas from consumption, not from its balance

### DIFF
--- a/packages/monitor-ui/src/lib/monitor/ops-spec.test.ts
+++ b/packages/monitor-ui/src/lib/monitor/ops-spec.test.ts
@@ -356,6 +356,23 @@ describe("volumeMixNote — self-generated volume must not read as demand", () =
     expect(v.tone).toBe("degraded");
   });
 
+  test("a gap of ONE is named but not alarmed — it is the steady state", () => {
+    // Seen live on three separate reads: 14/15, 15/16, 17/18, always exactly
+    // one. It is the most recently settled job, confirmed by the ledger before
+    // its log is inside the block window. Structural and benign — and a line
+    // that is amber on every read forever is a line nobody reads, which would
+    // cost precisely the case it exists for.
+    const v = volumeMixNote({ lifecycle: lifecycle(14, 0), settledCount: 15 })!;
+    expect(v.text).toContain("1 unclassified");
+    expect(v.tone).toBe("awaiting");
+  });
+
+  test("past the tolerance it DOES alarm — the count is never suppressed", () => {
+    const v = volumeMixNote({ lifecycle: lifecycle(14, 0), settledCount: 17 })!;
+    expect(v.text).toContain("3 unclassified");
+    expect(v.tone).toBe("degraded");
+  });
+
   test("more chain settlements than ledger reads as a window edge", () => {
     const v = volumeMixNote({ lifecycle: lifecycle(19, 1), settledCount: 18 })!;
     expect(v.text).toContain("2 beyond the ledger window");

--- a/packages/monitor-ui/src/lib/monitor/ops-spec.ts
+++ b/packages/monitor-ui/src/lib/monitor/ops-spec.ts
@@ -1074,6 +1074,19 @@ export function volumeMixNote(input: {
   lifecycle: LifecycleView | undefined;
   /** The product's own settled count — the total the parts must reconcile to. */
   settledCount: number | null | undefined;
+  /**
+   * Gap treated as the expected window-edge artifact rather than a fault.
+   *
+   * Observed live on three separate reads — 14/15, 15/16, 17/18 — always
+   * exactly one: the most recently settled job, confirmed by the ledger before
+   * its log is inside the block window. It is structural, it is benign, and
+   * lighting it amber on every read forever is how an operator learns to scroll
+   * past the line — which would cost exactly the case the line exists for.
+   *
+   * Same boundary and same reasoning as PRODUCT_HEALTH_PAYOUT_TOLERANCE. The
+   * gap is still COUNTED and still NAMED at any size; only the alarm waits.
+   */
+  edgeTolerance?: number;
 }): { text: string; tone: OpsTone } | null {
   const { lifecycle } = input;
   if (!lifecycle) return null;
@@ -1091,11 +1104,14 @@ export function volumeMixNote(input: {
   ];
 
   const gap = total - classified;
+  const tolerance = input.edgeTolerance ?? 1;
   let tone: OpsTone = "awaiting";
   if (gap > 0) {
-    // Settled per the ledger, not seen by the chain read. Named, never absorbed.
+    // Settled per the ledger, not seen by the chain read. Named, never absorbed
+    // — but only ALARMING past the window-edge tolerance, because one is the
+    // steady state and a permanent amber is a line nobody reads.
     parts.push(`${gap} unclassified`);
-    tone = "degraded";
+    if (gap > tolerance) tone = "degraded";
   } else if (gap < 0) {
     // The chain read reached slightly further back than the ledger's 24h — a
     // window edge, not a discrepancy, and it must not read as one.

--- a/services/slack-operator/src/gas-burn-rate.ts
+++ b/services/slack-operator/src/gas-burn-rate.ts
@@ -1,0 +1,114 @@
+// How fast the signer's gas is ACTUALLY being consumed.
+//
+// ── WHY NOT THE BALANCE ────────────────────────────────────────────────────
+//
+// The runway projection fits a slope to balance samples. A balance is not
+// consumption: TOP-UPS LAND IN THE SAME NUMBER. On 2026-08-02 a ~5 DOT top-up
+// inside the window made the signer's balance rise while gas was being spent,
+// and the arithmetic only worked out because the top-up was found by hand:
+//
+//     1.9622728 + 5 − 2.049685 = 4.9125877
+//
+// Fitted to a slope, that window reads as REFILLING — burn ≤ 0, `hoursToFloor`
+// null, "stable". The burn does not shrink; it vanishes. A projection that
+// disappears the moment someone tops up is worst exactly when the operator is
+// most engaged with the pool.
+//
+// The slope has two more problems on this signer. The window is six hours, and
+// six hours of a bursty workload is mostly noise. And the samples live in the
+// monitor's memory, so every deploy resets them — after a restart there are not
+// enough samples to estimate anything at all.
+//
+// Gas spend read from receipts has none of these properties. It is consumption,
+// it cannot be cancelled by a deposit, and it is re-read from chain rather than
+// accumulated in a process that restarts.
+//
+// ── WHEN IT REFUSES ────────────────────────────────────────────────────────
+//
+// Every refusal here points the same way: if the burn figure might UNDERSTATE
+// spend, it is not used, because an understated burn OVERSTATES the runway —
+// and a false "you have a week" on a gas floor is the one direction this board
+// must never be wrong in. `gas-spend-read.ts` makes the same argument about its
+// own transaction cap.
+//
+// A refusal is not a gap: the caller falls back to the balance trend and the
+// board says which basis it used, so a reader can tell a measured projection
+// from an inferred one.
+
+export interface MeasuredBurn {
+  /** Units per hour, from actual consumption. */
+  perHour: number;
+  /** Hours the measurement covers — the qualifier the headline must carry. */
+  windowHours: number;
+}
+
+export interface BurnUnmeasurable {
+  reason: string;
+}
+
+export function isBurnUnmeasurable(v: MeasuredBurn | BurnUnmeasurable): v is BurnUnmeasurable {
+  return (v as BurnUnmeasurable).reason !== undefined;
+}
+
+/**
+ * A rate needs enough hours behind it to be a rate.
+ *
+ * Under this, one busy minute dominates and the projection swings wildly
+ * between reads — which is how an operator learns to ignore it.
+ */
+export const MIN_BURN_WINDOW_HOURS = 4;
+
+/** Past this the snapshot describes a different day, not this one. */
+export const MAX_BURN_AGE_MS = 6 * 60 * 60 * 1000;
+
+export function measuredGasBurn(input: {
+  /** Total spend observed over the window. */
+  totalDot: number | null | undefined;
+  /** Blocks the read covered. */
+  blocksScanned: number | null | undefined;
+  /** MEASURED seconds per block — never an assumed one. */
+  blockSeconds: number | null | undefined;
+  /** True when the transaction cap bit and some spend is NOT counted. */
+  truncated: boolean;
+  ageMs: number;
+  minWindowHours?: number;
+  maxAgeMs?: number;
+}): MeasuredBurn | BurnUnmeasurable {
+  if (input.truncated) {
+    // The total is a floor, not a total. Dividing it into a runway produces a
+    // number that is too LONG, which is the dangerous direction.
+    return { reason: "gas read hit its transaction cap — the total understates spend" };
+  }
+  if (input.totalDot == null || !Number.isFinite(input.totalDot) || input.totalDot < 0) {
+    return { reason: "no gas total to divide" };
+  }
+  if (input.blockSeconds == null || !(input.blockSeconds > 0)) {
+    // Same rule as everywhere else on this board: an assumed block time has
+    // already been wrong here by 3x, and it would scale the rate by that factor.
+    return { reason: "block time not measured — the window cannot be converted to hours" };
+  }
+  if (input.blocksScanned == null || !(input.blocksScanned > 0)) {
+    return { reason: "gas read reported no block span" };
+  }
+
+  const windowHours = (input.blocksScanned * input.blockSeconds) / 3600;
+  const minHours = input.minWindowHours ?? MIN_BURN_WINDOW_HOURS;
+  if (windowHours < minHours) {
+    return { reason: `gas window spans only ${windowHours.toFixed(1)}h — too short to be a rate` };
+  }
+  const maxAge = input.maxAgeMs ?? MAX_BURN_AGE_MS;
+  if (input.ageMs > maxAge) {
+    const hours = Math.round(input.ageMs / 3_600_000);
+    return { reason: `gas figures are ${hours}h old — they describe a different day` };
+  }
+
+  // Zero is a real measurement — nothing ran — and the caller renders it as
+  // stable rather than as an infinite countdown.
+  return { perHour: input.totalDot / windowHours, windowHours };
+}
+
+/** "the last 24h's burn" — the qualifier that keeps the number honest. */
+export function burnBasisLabel(burn: MeasuredBurn): string {
+  const h = Math.round(burn.windowHours);
+  return `at the last ${h}h of measured burn`;
+}

--- a/services/slack-operator/src/index.ts
+++ b/services/slack-operator/src/index.ts
@@ -157,6 +157,7 @@ import { startBuzzInbound } from "./buzz-inbound-start.js";
 import { decideProbeTransitions } from "./probe-transitions.js";
 import { describeBuzzDelivery, recordBuzzDelivery, type BuzzDeliveryState } from "./buzz-delivery.js";
 import type { ProbeResult } from "./product-health.js";
+import { isBurnUnmeasurable, measuredGasBurn } from "./gas-burn-rate.js";
 import {
   emitCopilotStreamEvent,
   onCopilotStreamEvent,
@@ -3714,10 +3715,27 @@ function startOperatorRoutines() {
       // "reward bank ≈ 6h to floor" / "stable" / awaiting. Suggest-only: the board
       // tells the operator when to top up; it never moves funds.
       if (productHealthSnapshotBlocks?.solvency) {
+        // Signer gas projects from CONSUMPTION, not from its balance. A
+        // balance slope reads a top-up as refilling and makes the burn vanish;
+        // measuredGasBurn refuses itself rather than understate spend, and a
+        // refusal falls through to the slope with the basis said out loud.
+        const gasBurn = (() => {
+          const g = productHealthSnapshotBlocks?.gas;
+          if (!g || "unreadable" in g) return undefined;
+          const rate = measuredGasBurn({
+            totalDot: g.totalDot,
+            blocksScanned: g.blocksScanned,
+            blockSeconds: productHealthSnapshotBlocks?.flow?.payout?.window?.blockSeconds ?? null,
+            truncated: g.truncated,
+            ageMs: g.ageMs,
+          });
+          return isBurnUnmeasurable(rate) ? undefined : { signer_gas: rate };
+        })();
         const runway = deriveLiquidityRunway(
           productHealthHistory,
           productHealthSnapshotBlocks.solvency.pools,
           Date.now(),
+          gasBurn ? { measuredBurn: gasBurn } : {},
         );
         productHealthSnapshotBlocks.solvency.runwayNote = runway.note;
         productHealthSnapshotBlocks.solvency.runway = runway.pools;

--- a/services/slack-operator/src/product-health.ts
+++ b/services/slack-operator/src/product-health.ts
@@ -38,6 +38,7 @@ import { readJobLifecycle } from "./job-lifecycle-read.js";
 import { summarizeLifecycle, type LifecycleSummary } from "./job-lifecycle.js";
 import { bucketPayoutsByHour, isHistogramUnavailable, type PayoutHistogram } from "./payout-histogram.js";
 import { endpointHost, pinnedCompareRange, type CrossCheckView } from "./payout-crosscheck.js";
+import { burnBasisLabel, isBurnUnmeasurable, type MeasuredBurn } from "./gas-burn-rate.js";
 import { createCrossCheckCache, type CrossCheckCache } from "./payout-crosscheck-cache.js";
 import { createGasSpendCache, type GasSpendCache, type GasSpendSnapshot, type GasUnreadable } from "./gas-spend-cache.js";
 import { alertProvenance, decideMoneyAlert } from "./money-alert.js";
@@ -318,6 +319,20 @@ export interface LiquidityRunwayPool {
   hoursToFloor: number | null;
   /** Did we have enough data to project? false = awaiting samples (not "stable"). */
   estimable: boolean;
+  /**
+   * WHERE the rate came from, because the two are not equally trustworthy.
+   *
+   * `measured-spend` is consumption read from receipts — a top-up cannot cancel
+   * it and a restart cannot forget it. `balance-slope` is a regression over
+   * balance samples, which a deposit inside the window turns into "refilling"
+   * and which resets whenever the monitor restarts.
+   *
+   * Rendered, not merely carried: a reader is entitled to know whether a
+   * countdown was measured or inferred.
+   */
+  basis: "measured-spend" | "balance-slope";
+  /** Hours the rate was measured over, when it was measured. */
+  basisWindowHours?: number;
   status: ProbeStatus;
 }
 
@@ -328,6 +343,16 @@ export interface LiquidityRunway {
 }
 
 export interface LiquidityRunwayOptions {
+  /**
+   * Consumption actually observed, per pool key — preferred over the balance
+   * slope wherever it is available.
+   *
+   * The slope is a fallback, not a peer. It reads a TOP-UP as refilling and so
+   * makes the burn vanish exactly when the operator is most engaged with the
+   * pool; see gas-burn-rate.ts. Anything here has already refused itself if it
+   * might understate spend.
+   */
+  measuredBurn?: Readonly<Record<string, MeasuredBurn>>;
   /** Trailing window the burn rate is fit over (default 6h). */
   windowMs?: number;
   /** Minimum non-null samples needed to project (default 3). */
@@ -401,15 +426,43 @@ export function deriveLiquidityRunway(
     }
     const current = pool.amount;
     const floor = pool.floor;
+    // Consumption beats inference. When a measured rate exists for this pool we
+    // use it and skip the sample machinery entirely — the minimum-samples and
+    // minimum-span guards exist to stop the SLOPE lying, and a rate read from
+    // receipts is not subject to either failure.
+    const measured = opts.measuredBurn?.[pool.key];
     const mk = (
       extra: Pick<LiquidityRunwayPool, "burnPerHour" | "hoursToFloor" | "estimable" | "status">,
-    ): LiquidityRunwayPool => ({ key: pool.key, label: pool.label, unit: pool.unit, current, floor, ...extra });
+      basis: LiquidityRunwayPool["basis"] = measured ? "measured-spend" : "balance-slope",
+    ): LiquidityRunwayPool => ({
+      key: pool.key, label: pool.label, unit: pool.unit, current, floor, basis,
+      ...(basis === "measured-spend" && measured ? { basisWindowHours: measured.windowHours } : {}),
+      ...extra,
+    });
 
     // Already at/below floor — the balance probe owns the red; runway is 0.
     if (current <= floor) {
       out.push(mk({ burnPerHour: null, hoursToFloor: 0, estimable: true, status: "red" }));
       continue;
     }
+    if (measured) {
+      const burnPerHour = measured.perHour;
+      if (burnPerHour <= 0) {
+        // A real zero: nothing was spent in the window. Distinct from the
+        // slope's "refilling", which is what a deposit looks like.
+        out.push(mk({ burnPerHour, hoursToFloor: null, estimable: true, status: "ok" }));
+        continue;
+      }
+      const hoursToFloor = (current - floor) / burnPerHour;
+      if (hoursToFloor > stableCapHours) {
+        out.push(mk({ burnPerHour, hoursToFloor: null, estimable: true, status: "ok" }));
+        continue;
+      }
+      const status: ProbeStatus = hoursToFloor <= redHours ? "red" : hoursToFloor <= warnHours ? "degraded" : "ok";
+      out.push(mk({ burnPerHour, hoursToFloor, estimable: true, status }));
+      continue;
+    }
+
     const samples: { t: number; v: number }[] = [];
     for (const snap of history) {
       if (snap.at < windowStart) continue;
@@ -446,7 +499,20 @@ function summariseRunway(pools: ReadonlyArray<LiquidityRunwayPool>): string | nu
     .sort((a, b) => (a.hoursToFloor as number) - (b.hoursToFloor as number));
   if (trending.length) {
     const p = trending[0];
-    return `${p.label} ${formatRunwayHours(p.hoursToFloor as number)}`;
+    // The qualifier is the honesty. "~5d to floor" invites a long-run reading
+    // of a short-run number; "~5d at the last 24h of measured burn" is the same
+    // number with its scope attached, and lets the reader judge whether the
+    // last day was typical. The board cannot know that; the operator can.
+    // Only a PROJECTION carries a basis. At or below the floor there is no rate
+    // and nothing was inferred — the balance simply is what it is — so a
+    // qualifier there would be noise attached to a fact.
+    const basis =
+      p.burnPerHour == null
+        ? ""
+        : p.basis === "measured-spend" && p.basisWindowHours != null
+          ? ` ${burnBasisLabel({ perHour: p.burnPerHour, windowHours: p.basisWindowHours })}`
+          : " from the balance trend";
+    return `${p.label} ${formatRunwayHours(p.hoursToFloor as number)}${basis}`;
   }
   // Enough data but no downward trend → a real, honest "stable". No estimable
   // pool at all → null (awaiting) so the board shows its awaiting-data line.
@@ -2365,6 +2431,15 @@ export interface ProductHealthSnapshotBlocks {
   chain?: ChainTickData;
   solvency?: SolvencySnapshotData;
   flow?: MoneyPathData;
+  /**
+   * Gas attribution, when it is readable.
+   *
+   * Spread onto the payload since #672 but never declared here, so nothing
+   * in-process could consume it — the runway had no way to reach the one
+   * measurement of actual consumption on the board and fell back to fitting a
+   * slope through balances. Declared now because the projection reads it.
+   */
+  gas?: GasSpendSnapshot | GasUnreadable;
 }
 
 function resolveProductHealthNetwork(chainId: number | undefined): "testnet" | "mainnet" | "unknown" {

--- a/services/slack-operator/test/unit/gas-burn-rate.test.ts
+++ b/services/slack-operator/test/unit/gas-burn-rate.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, test } from "vitest";
+
+import {
+  MAX_BURN_AGE_MS,
+  burnBasisLabel,
+  isBurnUnmeasurable,
+  measuredGasBurn,
+  type MeasuredBurn,
+} from "../../src/gas-burn-rate.js";
+
+/** A live-shaped read: 1.684 DOT over ~24h at the chain's measured rate. */
+const live = {
+  totalDot: 1.684,
+  blocksScanned: 40_678,
+  blockSeconds: 2.124,
+  truncated: false,
+  ageMs: 5 * 60_000,
+};
+
+function ok(v: ReturnType<typeof measuredGasBurn>): MeasuredBurn {
+  if (isBurnUnmeasurable(v)) throw new Error(`expected a rate, got: ${v.reason}`);
+  return v;
+}
+
+describe("consumption, not balance", () => {
+  test("the rate comes out of spend over the window it was measured on", () => {
+    const b = ok(measuredGasBurn(live));
+    // 40,678 blocks × 2.124s = 86,400s = 24.0h
+    expect(b.windowHours).toBeCloseTo(24, 1);
+    expect(b.perHour).toBeCloseTo(1.684 / 24, 4);
+  });
+
+  test("it projects the live board's numbers to days, not hours", () => {
+    // Signer gas 9.52 DOT against a 1.00 floor. The balance-slope method said
+    // ~3d off a six-hour regression; measured consumption says ~5d, and that
+    // number is what the last day of real work actually cost.
+    const b = ok(measuredGasBurn(live));
+    const hoursToFloor = (9.52 - 1.0) / b.perHour;
+    expect(hoursToFloor / 24).toBeGreaterThan(4.5);
+    expect(hoursToFloor / 24).toBeLessThan(6);
+  });
+
+  test("a top-up cannot cancel it — there is no balance in the arithmetic", () => {
+    // The whole point. A deposit changes the balance and not one input here.
+    const before = ok(measuredGasBurn(live));
+    const after = ok(measuredGasBurn({ ...live }));
+    expect(after.perHour).toBe(before.perHour);
+  });
+
+  test("zero spend is a real measurement, not a refusal", () => {
+    const b = ok(measuredGasBurn({ ...live, totalDot: 0 }));
+    expect(b.perHour).toBe(0);
+  });
+});
+
+describe("every refusal points away from a false green", () => {
+  test("a truncated read is refused — its total is a floor, not a total", () => {
+    // An understated burn OVERSTATES the runway. "You have a week" on a gas
+    // floor is the one direction this board must never be wrong in.
+    const v = measuredGasBurn({ ...live, truncated: true });
+    expect(isBurnUnmeasurable(v)).toBe(true);
+    expect(isBurnUnmeasurable(v) && v.reason).toContain("understates spend");
+  });
+
+  test("an unmeasured block time is refused rather than assumed", () => {
+    // An assumed block time has already been wrong here by 3x, and it scales
+    // the rate by exactly that factor.
+    const v = measuredGasBurn({ ...live, blockSeconds: null });
+    expect(isBurnUnmeasurable(v)).toBe(true);
+    expect(isBurnUnmeasurable(v) && v.reason).toContain("block time not measured");
+  });
+
+  test("a window of minutes is refused — one busy minute is not a rate", () => {
+    const v = measuredGasBurn({ ...live, blocksScanned: 1_000 });
+    expect(isBurnUnmeasurable(v)).toBe(true);
+    expect(isBurnUnmeasurable(v) && v.reason).toContain("too short to be a rate");
+  });
+
+  test("figures from a different day are refused", () => {
+    const v = measuredGasBurn({ ...live, ageMs: MAX_BURN_AGE_MS + 1 });
+    expect(isBurnUnmeasurable(v)).toBe(true);
+    expect(isBurnUnmeasurable(v) && v.reason).toContain("different day");
+  });
+
+  test("no total and no span are refused, never treated as zero burn", () => {
+    // Zero burn would read as an infinite runway — the same false green.
+    for (const bad of [{ totalDot: null }, { blocksScanned: 0 }, { totalDot: Number.NaN }]) {
+      expect(isBurnUnmeasurable(measuredGasBurn({ ...live, ...bad }))).toBe(true);
+    }
+  });
+});
+
+describe("the headline carries its qualifier", () => {
+  test("the label names the window the rate came from", () => {
+    // "~5d to floor" invites a long-run reading. "~5d at the last 24h of
+    // measured burn" is the same number with its scope attached.
+    expect(burnBasisLabel(ok(measuredGasBurn(live)))).toBe("at the last 24h of measured burn");
+  });
+});

--- a/test/unit/product-health.test.ts
+++ b/test/unit/product-health.test.ts
@@ -1409,6 +1409,57 @@ describe("deriveLiquidityRunway", () => {
     status: "ok",
   });
 
+  const gasPool = (amount: number, floor = 1): SolvencyPoolData => ({
+    key: "signer_gas", label: "signer gas", amount, unit: "DOT", floor, status: "ok",
+  });
+
+  it("a TOP-UP no longer cancels the burn — measured spend has no balance in it", () => {
+    // THE DEFECT. A slope fitted to balances reads a deposit as refilling, so
+    // burn <= 0, hoursToFloor null, "stable". The burn does not shrink; it
+    // vanishes — exactly when the operator is most engaged with the pool.
+    // Observed live: 1.9622728 + 5 − 2.049685 = 4.9125877, a rising balance
+    // while gas was being spent the whole time.
+    const now = 10 * HOUR;
+    const risingBalance = [
+      bal(now - 6 * HOUR, null, 2.0),
+      bal(now - 3 * HOUR, null, 6.5), // the top-up lands
+      bal(now, null, 6.2),
+    ];
+    const slopeOnly = deriveLiquidityRunway(risingBalance, [gasPool(6.2)], now);
+    expect(slopeOnly.pools[0]!.hoursToFloor, "the slope hides the burn").toBeNull();
+    expect(slopeOnly.pools[0]!.basis).toBe("balance-slope");
+
+    // Same window, same top-up, measured consumption: the countdown survives.
+    const measured = deriveLiquidityRunway(risingBalance, [gasPool(6.2)], now, {
+      measuredBurn: { signer_gas: { perHour: 0.0702, windowHours: 24 } },
+    });
+    expect(measured.pools[0]!.basis).toBe("measured-spend");
+    expect(measured.pools[0]!.hoursToFloor).toBeCloseTo((6.2 - 1) / 0.0702, 0);
+    expect(measured.note).toContain("at the last 24h of measured burn");
+  });
+
+  it("a measured rate projects even with NO history at all", () => {
+    // The slope needs 3 samples over 15 minutes held in memory, and that memory
+    // resets on every deploy — so right after a restart the board could not
+    // project anything. A rate read from chain does not care.
+    const r = deriveLiquidityRunway([], [gasPool(9.52)], 10 * HOUR, {
+      measuredBurn: { signer_gas: { perHour: 0.0702, windowHours: 24 } },
+    });
+    expect(r.pools[0]!.estimable).toBe(true);
+    // 8.52 DOT above floor at 0.0702/h ≈ 121h ≈ 5 days, against the ~3d the
+    // six-hour balance regression was reporting on the live board.
+    expect(r.pools[0]!.hoursToFloor! / 24).toBeGreaterThan(4.5);
+  });
+
+  it("zero measured spend is stable, and says so without a countdown", () => {
+    const r = deriveLiquidityRunway([], [gasPool(9.52)], 10 * HOUR, {
+      measuredBurn: { signer_gas: { perHour: 0, windowHours: 24 } },
+    });
+    expect(r.pools[0]!.hoursToFloor).toBeNull();
+    expect(r.pools[0]!.status).toBe("ok");
+    expect(r.pools[0]!.estimable).toBe(true);
+  });
+
   it("projects a countdown from a steady drain (degraded band)", () => {
     const now = 6 * HOUR;
     // 19 → 13 over 6h = 1 USDC/h; floor 1 ⇒ (13-1)/1 = 12h ⇒ degraded
@@ -1418,7 +1469,7 @@ describe("deriveLiquidityRunway", () => {
     expect(r.pools[0].burnPerHour).toBeCloseTo(1, 6);
     expect(r.pools[0].hoursToFloor).toBeCloseTo(12, 6);
     expect(r.pools[0].status).toBe("degraded");
-    expect(r.note).toBe("reward bank ~12h to floor");
+    expect(r.note).toBe("reward bank ~12h to floor from the balance trend");
   });
 
   it("pages (red) when the floor is < 6h out", () => {
@@ -1428,7 +1479,7 @@ describe("deriveLiquidityRunway", () => {
     const r = deriveLiquidityRunway(history, [usdcPool(5)], now);
     expect(r.pools[0].hoursToFloor).toBeCloseTo(2, 6);
     expect(r.pools[0].status).toBe("red");
-    expect(r.note).toBe("reward bank ~2h to floor");
+    expect(r.note).toBe("reward bank ~2h to floor from the balance trend");
   });
 
   it("reads stable — not a fake countdown — when the balance is flat", () => {
@@ -1479,7 +1530,7 @@ describe("deriveLiquidityRunway", () => {
     ];
     const r = deriveLiquidityRunway(history, pools, now);
     expect(r.pools.map((p) => p.key)).toEqual(["signer_gas", "reward_bank"]);
-    expect(r.note).toBe("reward bank ~12h to floor"); // gas is stable ⇒ usdc is the nearest
+    expect(r.note).toBe("reward bank ~12h to floor from the balance trend"); // gas is stable ⇒ usdc is the nearest
   });
 });
 


### PR DESCRIPTION
Improvement **#1**, with the data source corrected.

## The defect was already in the code, and worse than the proposal assumed

`deriveLiquidityRunway` fits a slope through **balance samples** over a **six-hour** window held in the monitor's memory. Three consequences, all live:

- **A top-up lands in the same number it measures.** A deposit inside the window makes the slope positive → burn ≤ 0 → `hoursToFloor: null` → *"stable / refilling"*. The burn doesn't shrink, it **vanishes** — precisely when the operator is most engaged with the pool. Not hypothetical: `1.9622728 + 5 − 2.049685 = 4.9125877`, a rising balance while gas was being spent throughout.
- **Six hours of a bursty signer is mostly noise** — which is where `~3d to floor` came from on a pool with five days in it.
- **The samples are in-process**, so every deploy resets them and the board can project nothing until three more accumulate.

This is the same flaw as the proposal's "signer balance now vs 7 days ago", which is why that source couldn't be used to fix it.

## The fix

Signer gas projects from **measured consumption** — the gas already read from receipts for the burn breakdown. A top-up cannot cancel it, a restart cannot forget it, no sample history needed.

**On your live numbers:** 9.52 DOT against a 1.00 floor at 1.684 DOT/24h → **~121h ≈ 5 days**, not 3. And that number is what the last day of real work actually cost.

### Every refusal points away from a false green

`measuredGasBurn` declines rather than understate spend — truncated read (its total is a floor, not a total), unmeasured block time, window under 4h, figures over 6h old. An understated burn **overstates** the runway, and a false *"you have a week"* on a gas floor is the one direction this board must never be wrong in. A refusal falls back to the slope, with the basis said out loud.

## The basis is rendered

```
signer gas ~5d to floor at the last 24h of measured burn
```

`~5d to floor` invites a long-run reading of a short-run number. The qualifier lets the reader judge whether the last day was typical — the board can't know that, the operator can. A pool **at** the floor gets no qualifier: nothing was projected there.

## Found on the way

`gas` has been spread onto the health payload since #672 but was **never declared** on `ProductHealthSnapshotBlocks`. Nothing in-process could consume it — which is why the runway had no access to the one measurement of actual consumption on the board.

## Not built, deliberately: the 7-day rate

A 7d gas read is ~1200 RPC calls and would very likely hit the transaction cap → `truncated` → understated burn → overstated runway → false green. **The honest short-run number with its window named beats a long-run number derived from a partial total.** If the longer window is wanted it needs a daily cadence and a hard refusal on truncation — its own packet.

The attribution half of the proposal already ships: the burn note reads `1.684 DOT burned · 0.094 per settlement · resolveSinglePayout 42% · +1 other signer`, so a spike explains itself.

## Verification

- **2552 tests pass**, 13 new — 10 on the burn rate, 3 on the runway including the top-up inversion the whole change exists for
- typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)