### PR TITLE
test(int2): prove the budget fix against a real run — eleventh case

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,7 +128,7 @@ jobs:
 
       - name: Prove the suite did not skip
         if: always()
-        run: test "$(tr -d '[:space:]' < '${{ runner.temp }}/int2-suite-evidence/executed-count.txt')" = "10"
+        run: test "$(tr -d '[:space:]' < '${{ runner.temp }}/int2-suite-evidence/executed-count.txt')" = "11"
 
       - name: Upload INT-2 evidence
         if: always()

--- a/docs/HARNESS_INT2_EVIDENCE_BUNDLE.md
+++ b/docs/HARNESS_INT2_EVIDENCE_BUNDLE.md
@@ -18,6 +18,13 @@
 The suite is the load-bearing part: it is the only evidence that re-proves
 itself on every change. The two ceremonies are point-in-time.
 
+> **Post-acceptance note (2026-08-03):** The automated suite grew from 10 to
+> 11 cases after acceptance. The added case proves through the real dispatcher,
+> pinned Harness, Postgres, and Docker path that a terminal, verified run which
+> exceeded its measured model-token budget still reaches `handoff_ready`, while
+> recording the named overrun and a warning. The original 10-case claim above
+> remains the accepted point-in-time record.
+
 ## 2. §21.1 gate — clause by clause
 
 ### "Concurrent/replayed dispatch creates exactly one Harness run"

--- a/scripts/ceremony/int2-evidence.mjs
+++ b/scripts/ceremony/int2-evidence.mjs
@@ -83,6 +83,43 @@ const CASE_EXPECTATIONS = Object.freeze({
     requireFence: true,
     expectedToolCommand: GREEN_TOOL_COMMAND,
   }),
+  "budget-overrun": Object.freeze({
+    lifecycle: "handoff_ready",
+    runCount: 1,
+    runOutcome: "completed",
+    runState: "learning_processed",
+    claimCount: 1,
+    outboxCount: 1,
+    decisions: {
+      dispatch_approval: 1,
+      handoff: 1,
+      dispatch_refusal: 0,
+    },
+    criterion: {
+      passed: true,
+      reason: "exit_0",
+      verdict: "completed",
+    },
+    requirePatch: true,
+    requireManifest: true,
+    requireFence: true,
+    expectedBudget: Object.freeze({
+      elapsedSeconds: 60,
+      modelTokens: 6,
+      toolCalls: 30,
+      estimatedUsdMicros: null,
+    }),
+    expectedBudgetStatus: "budget_status=exhausted",
+    expectedBudgetDimension:
+      "budget_exhaustion_dimension=model_tokens used=7 limit=6 over_by=1",
+    expectRunNotCancelled: true,
+    alert: Object.freeze({
+      severity: "warn",
+      code: "budget_exhausted",
+      message: "model_tokens used=7 limit=6 over_by=1",
+    }),
+    expectedToolCommand: GREEN_TOOL_COMMAND,
+  }),
   negative: Object.freeze({
     lifecycle: "failed",
     runCount: 1,
@@ -513,6 +550,7 @@ export async function collectInt2Evidence({
   expectedPath = INT2_EXPECTED_PATH,
   evidenceDir,
   profileLoadError,
+  alertsPath = process.env.HARNESS_DISPATCH_ALERTS_PATH,
 } = {}) {
   requireValue(workItemId, "workItemId");
   requireValue(intendedRunId, "intendedRunId");
@@ -612,6 +650,9 @@ export async function collectInt2Evidence({
       })
     : null;
   const verification = verificationFromEvents(events);
+  const alerts = alertsPath
+    ? await readDispatchAlerts(alertsPath, workItemId)
+    : [];
   const evidence = {
     schemaVersion: 1,
     kind: "int2_automated_evidence",
@@ -624,6 +665,7 @@ export async function collectInt2Evidence({
     dispatchClaims: raw.dispatchClaims,
     outbox: raw.outbox,
     decisions: raw.decisions,
+    alerts,
     runs: raw.runs,
     status: parseKeyValueLines(statusText),
     events,
@@ -720,6 +762,13 @@ export function verifyInt2Evidence(
         run?.state === expectations.runState,
         "run_terminal_state",
         `expected ${expectations.runState}, got ${run?.state}`,
+      );
+    }
+    if (expectations.expectRunNotCancelled) {
+      check(
+        run?.state !== "cancelled" && run?.outcome !== "cancelled",
+        "run_not_cancelled",
+        `run state=${run?.state} outcome=${run?.outcome}`,
       );
     }
     if (expectations.effectiveCapabilities) {
@@ -820,6 +869,64 @@ export function verifyInt2Evidence(
       `missing ${expectations.decisionReason}`,
     );
   }
+  const handoff = decisions.find(
+    (decision) => decision?.decisionType === "handoff",
+  );
+  if (expectations.expectedBudgetStatus) {
+    check(
+      handoff?.proposal?.why?.includes(expectations.expectedBudgetStatus),
+      "handoff_budget_status",
+      `missing ${expectations.expectedBudgetStatus}`,
+    );
+  }
+  if (expectations.expectedBudgetDimension) {
+    check(
+      handoff?.proposal?.why?.includes(expectations.expectedBudgetDimension),
+      "handoff_budget_dimension",
+      `missing ${expectations.expectedBudgetDimension}`,
+    );
+  }
+  if (expectations.expectRunNotCancelled) {
+    check(
+      decisions.every((decision) =>
+        !decision?.effects?.mutations?.some(
+          (mutation) =>
+            mutation?.system === "agent-harness"
+            && mutation?.action === "cancel",
+        )),
+      "no_cancel_mutation",
+      "a decision records Harness cancellation",
+    );
+  }
+  if (expectations.alert) {
+    const alerts = Array.isArray(evidence?.alerts) ? evidence.alerts : [];
+    check(
+      alerts.length === 1,
+      "one_budget_alert",
+      `expected 1 work-item alert, got ${alerts.length}`,
+    );
+    const alert = alerts[0];
+    check(
+      alert?.severity === expectations.alert.severity,
+      "budget_alert_severity",
+      `expected ${expectations.alert.severity}, got ${alert?.severity}`,
+    );
+    check(
+      alert?.code === expectations.alert.code,
+      "budget_alert_code",
+      `expected ${expectations.alert.code}, got ${alert?.code}`,
+    );
+    check(
+      alert?.harnessRunId === evidence?.intendedRunId,
+      "budget_alert_run_identity",
+      `expected ${evidence?.intendedRunId}, got ${alert?.harnessRunId}`,
+    );
+    check(
+      alert?.message?.includes(expectations.alert.message),
+      "budget_alert_dimension",
+      `missing ${expectations.alert.message}`,
+    );
+  }
   if (expectations.profileLoadErrorReason) {
     check(
       evidence?.profileLoadError?.name === "ProfileManifestError"
@@ -841,6 +948,7 @@ export function verifyInt2Evidence(
       evidence.task,
       check,
       expectations.expectedAcceptanceCommand,
+      expectations.expectedBudget,
     );
   }
   if (expectations.requireManifest) {
@@ -1271,6 +1379,12 @@ function verifyFence(
   task,
   check,
   expectedAcceptanceCommand = "git diff --check",
+  expectedBudget = {
+    elapsedSeconds: 60,
+    modelTokens: 8000,
+    toolCalls: 30,
+    estimatedUsdMicros: null,
+  },
 ) {
   check(
     task?.repository?.nameWithOwner ===
@@ -1321,15 +1435,25 @@ function verifyFence(
     `unexpected acceptance ${JSON.stringify(task?.acceptance?.criteria)}`,
   );
   check(
-    equal(task?.budget, {
-      elapsedSeconds: 60,
-      modelTokens: 8000,
-      toolCalls: 30,
-      estimatedUsdMicros: null,
-    }),
+    equal(task?.budget, expectedBudget),
     "fence_budget",
     `unexpected budget ${JSON.stringify(task?.budget)}`,
   );
+}
+
+async function readDispatchAlerts(target, workItemId) {
+  let bytes;
+  try {
+    bytes = await readFile(target, "utf8");
+  } catch (error) {
+    if (error?.code === "ENOENT") return [];
+    throw error;
+  }
+  return bytes
+    .split(/\r?\n/u)
+    .filter(Boolean)
+    .map((line) => JSON.parse(line))
+    .filter((alert) => alert?.workItemId === workItemId);
 }
 
 function fixtureFence(fixture) {

--- a/scripts/ceremony/run-int2-automated-suite.sh
+++ b/scripts/ceremony/run-int2-automated-suite.sh
@@ -286,7 +286,7 @@ printf '%s\n' "INT2_WORKSPACE_SNAPSHOT spared=$(
   grep -c . "$_int2_workspaces_before" 2>/dev/null || echo 0
 )" >> "$_int2_bootstrap_log"
 
-printf '%s\n' "INT2_CASES_STARTED expected=10" >> "$_int2_bootstrap_log"
+printf '%s\n' "INT2_CASES_STARTED expected=11" >> "$_int2_bootstrap_log"
 (
   cd "$_int2_repo"
   npm run build
@@ -295,9 +295,9 @@ printf '%s\n' "INT2_CASES_STARTED expected=10" >> "$_int2_bootstrap_log"
 )
 
 _int2_executed="$(tr -d '[:space:]' < "$_int2_marker")"
-test "$_int2_executed" = "10" \
+test "$_int2_executed" = "11" \
   || {
-    echo "INT-2 suite executed $_int2_executed cases; expected 10" >&2
+    echo "INT-2 suite executed $_int2_executed cases; expected 11" >&2
     exit 1
   }
 _int2_elapsed="$(( $(date +%s) - _int2_started ))"

--- a/scripts/ops/harness-pilot.mjs
+++ b/scripts/ops/harness-pilot.mjs
@@ -11,6 +11,7 @@ const FIXTURES = new Set([
   "lint-format",
   "lint-format-paid",
   "lint-format-green",
+  "lint-format-budget-overrun",
   "lint-format-red",
 ]);
 const POLICY_VERSION = "dispatch-policy-v1";
@@ -613,7 +614,7 @@ function helpText() {
   return `Usage: node scripts/ops/harness-pilot.mjs <subcommand> [options]
 
 Human-operated supervised-pilot commands:
-  propose --fixture <docs-fix|add-unit-test|small-refactor|lint-format|lint-format-green|lint-format-red>
+  propose --fixture <docs-fix|add-unit-test|small-refactor|lint-format|lint-format-green|lint-format-budget-overrun|lint-format-red>
           [--work-item <id>] [--deadline <iso>]
   approve --work-item <id> --version <n> --operator <id> --confirm
   cancel  --work-item <id> --version <n> --operator <id> --confirm

--- a/test/fixtures/agent-integration/ceremony/lint-format-budget-overrun.json
+++ b/test/fixtures/agent-integration/ceremony/lint-format-budget-overrun.json
@@ -1,0 +1,44 @@
+{
+  "workItemId": "ceremony-lint-format-budget-overrun-001",
+  "correlationId": "ceremony-lint-format-budget-overrun-001",
+  "taskKind": "lint_format",
+  "title": "Create one bounded formatting proof with a measured token overrun",
+  "objective": "Create the deterministic green-path proof document within the pilot path allowlist.",
+  "whyNow": "The supervised-dispatch suite must prove that a verified terminal outcome survives a measured model-token budget overrun.",
+  "requestedBy": {
+    "type": "operator",
+    "id": "pilot-operator"
+  },
+  "repository": {
+    "nameWithOwner": "depre-dev/averray-reference-agent",
+    "baseRevision": "8b94278578913b7cd7aa1acb276db48613090c7b",
+    "allowedPaths": [
+      "docs/**",
+      "test/**"
+    ],
+    "forbiddenPaths": [
+      "contracts/**",
+      "ops/**",
+      "scripts/ops/**",
+      ".github/**"
+    ]
+  },
+  "profile": "coding-change-pilot",
+  "acceptanceCriteria": [
+    {
+      "id": "format-command",
+      "type": "command",
+      "command": "git diff --check",
+      "required": true
+    }
+  ],
+  "budget": {
+    "elapsedSeconds": 60,
+    "modelTokens": 6,
+    "toolCalls": 30,
+    "estimatedUsdMicros": null
+  },
+  "deadline": "2027-12-31T23:59:59.000Z",
+  "riskTier": "low",
+  "selectionReason": "The reused green script records seven model tokens, so a six-token cap deterministically proves terminal overrun preservation."
+}

--- a/test/integration/int2-automated-suite.test.ts
+++ b/test/integration/int2-automated-suite.test.ts
@@ -75,7 +75,7 @@ const FIXTURE_ROOT = path.join(
   REPOSITORY_ROOT,
   "test/fixtures/agent-integration/ceremony",
 );
-const EXPECTED_CASE_COUNT = 10;
+const EXPECTED_CASE_COUNT = 11;
 const TEST_TIMEOUT_MS = 240_000;
 const TERMINAL_WAIT_MS = 180_000;
 const HARNESS_STATE_WAIT_MS = 90_000;
@@ -338,6 +338,26 @@ describe.skipIf(!ready)("INT-2 automated supervised-dispatch suite", () => {
     );
   }, TEST_TIMEOUT_MS);
 
+  it("preserves a verified terminal handoff after a measured token overrun", async () => {
+    executedCases += 1;
+    const evidence = await runScriptedTerminalCase({
+      caseName: "budget-overrun",
+      fixture: "lint-format-budget-overrun",
+      script: "lint-format-green.jsonl",
+      lifecycle: "handoff_ready",
+      reconcileAfterHarnessTerminal: true,
+    });
+    assertD3Mutation(
+      "budget-overrun",
+      evidence,
+      (mutated) => {
+        mutated.task.lifecycle = "failed";
+      },
+      "terminal_lifecycle",
+      "change the over-budget terminal lifecycle from handoff_ready to failed",
+    );
+  }, TEST_TIMEOUT_MS);
+
   it("restarts between submit and reconcile without duplicating the run", async () => {
     executedCases += 1;
     await writePilotProfile(INT2_PILOT_CAPABILITIES);
@@ -530,15 +550,21 @@ describe.skipIf(!ready)("INT-2 automated supervised-dispatch suite", () => {
     script,
     lifecycle,
     preserveProfile = false,
+    reconcileAfterHarnessTerminal = false,
   }: {
-    caseName: "green" | "idle" | "negative" | "narrow";
-    fixture: "lint-format" | "lint-format-green" | "lint-format-red";
+    caseName: "budget-overrun" | "green" | "idle" | "negative" | "narrow";
+    fixture:
+      | "lint-format"
+      | "lint-format-budget-overrun"
+      | "lint-format-green"
+      | "lint-format-red";
     script:
       | "lint-format-green.jsonl"
       | "lint-format-idle.jsonl"
       | "lint-format-red.jsonl";
     lifecycle: "handoff_ready" | "failed";
     preserveProfile?: boolean;
+    reconcileAfterHarnessTerminal?: boolean;
   }): Promise<any> {
     if (!preserveProfile) {
       await writePilotProfile(INT2_PILOT_CAPABILITIES);
@@ -549,6 +575,16 @@ describe.skipIf(!ready)("INT-2 automated supervised-dispatch suite", () => {
     const worker = await startWorker();
     const dispatcher = createDispatcher();
     try {
+      if (reconcileAfterHarnessTerminal) {
+        await expect(dispatcher.tick()).resolves.toMatchObject({
+          outcome: "dispatched",
+          intendedRunId: approval.intendedRunId,
+        });
+        await waitForHarnessState(
+          approval.intendedRunId,
+          "learning_processed",
+        );
+      }
       await waitForLifecycle(
         dispatcher,
         workItemId,

--- a/test/unit/agent-task-proposal.test.ts
+++ b/test/unit/agent-task-proposal.test.ts
@@ -57,6 +57,7 @@ const CEREMONY_FIXTURES = [
   "small-refactor",
   "lint-format",
   "lint-format-green",
+  "lint-format-budget-overrun",
   "lint-format-red",
 ] as const;
 const temporaryRoots: string[] = [];

--- a/test/unit/harness-pilot-cli.test.ts
+++ b/test/unit/harness-pilot-cli.test.ts
@@ -306,6 +306,17 @@ describe("Harness pilot CLI", () => {
       fixture: "lint-format-green",
     });
   });
+
+  it("accepts the dedicated terminal budget-overrun fixture", () => {
+    expect(parsePilotArgs([
+      "propose",
+      "--fixture",
+      "lint-format-budget-overrun",
+    ])).toEqual({
+      command: "propose",
+      fixture: "lint-format-budget-overrun",
+    });
+  });
 });
 
 function pilotServices(overrides: Record<string, unknown> = {}) {

--- a/test/unit/int2-ceremony-scripts.test.ts
+++ b/test/unit/int2-ceremony-scripts.test.ts
@@ -228,10 +228,10 @@ describe("committed INT-2 ceremony mechanics", () => {
       expectNoCapabilityEvents: true,
     });
 
-    expect(integrationSuite).toContain("const EXPECTED_CASE_COUNT = 10;");
-    expect(shellSuite).toContain("INT2_CASES_STARTED expected=10");
-    expect(shellSuite).toContain('test "$_int2_executed" = "10"');
-    expect(workflow).toContain("executed-count.txt')\" = \"10\"");
+    expect(integrationSuite).toContain("const EXPECTED_CASE_COUNT = 11;");
+    expect(shellSuite).toContain("INT2_CASES_STARTED expected=11");
+    expect(shellSuite).toContain('test "$_int2_executed" = "11"');
+    expect(workflow).toContain("executed-count.txt')\" = \"11\"");
   });
 
   // verifyScriptedPairPreflight runs two full `git clone --local


### PR DESCRIPTION
Closes the gap flagged on #653: the dispatcher fix was unit-proven but had never been exercised through a real dispatcher, a real Harness run, and a real container.

**Published on the implementer's behalf** — their `gh` token for this org is still invalid. Commit `5cdf57d` is theirs, unmodified.

## The case

A scripted run that **succeeds** (`git diff --check` → `exit_0`) under a budget of **6 model tokens**, below the green script's measured **7**. So succeeding necessarily overruns.

```
lifecycle          handoff_ready
run                completed / learning_processed, attempt 1
budget             model_tokens used=7 limit=6 over_by=1
decisions          exactly one handoff
alert              one warn — not critical, not cancelled
```

That combination — over budget **and** a valid handoff — did not exist before kernel [#32](https://github.com/averray-agent/agent-harness/pull/32) and the pin move in #676. It is the whole reason this packet was unsatisfiable a day ago.

## D4(b) — the point of the packet

With **only** `reconcile-run.ts` reverted to pre-#653 (`7d73be1`), the real suite gave **10 passed / 1 failed**, and the new case alone went red: Harness outcome still `completed`, task lifecycle `failed`.

That is the defect reappearing on demand. A case that passed both ways would have proven nothing.

## D4(a)

Lifecycle mutation `handoff_ready → failed` rejected as `terminal_lifecycle`, recorded in `suite-summary.json`.

## Bookkeeping

All four count sites moved to 11 together, with the unit guard updated. The evidence bundle is **amended, not rewritten** — a dated post-acceptance note; the original "10 cases" claim survives as the accepted point-in-time record.

Existing fixture budgets and production reconciliation logic unchanged.

## Verification

Implementer: typecheck exit 0 · 2541 passed / 15 skipped · build exit 0 · real INT-2 suite **11/11** against pinned Harness `f010c993…`

🤖 Generated with [Claude Code](https://claude.com/claude-code)