### PR TITLE
docs(agents): typecheck before test in a fresh worktree

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,6 +54,13 @@ npm test          # vitest run — must pass
 npm run build     # tsc -b emit (only needed to validate emit / run dist)
 ```
 
+**Run `typecheck` before `test`, in that order, in a fresh checkout or worktree.**
+`typecheck` is `tsc -b`, which emits the workspace packages' declarations. Without
+it `vitest` cannot resolve `@avg/*` imports and fails with module-not-found errors
+that read like broken code rather than a missing build. This catches out every new
+worktree — don't take a wall of `@avg/*` resolution failures as a real defect until
+you have built.
+
 Changes that can affect supervised Harness dispatch are additionally gated in
 CI by `scripts/ceremony/run-int2-automated-suite.sh`. It runs the deterministic
 INT-2 cases against the real dispatcher, disposable Postgres databases, the


### PR DESCRIPTION
Six lines in `AGENTS.md`, under the Quick reference block.

`@avg/*` resolves through each package's `exports` field to `dist/` — I checked, and there is no vitest alias pointing at source:

```
@avg/schemas  exports  →  ./dist/index.js, ./dist/index.d.ts
vitest.config.ts        no alias / paths for @avg
fresh worktree          packages/schemas/dist  does not exist
```

So `npm test` before `npm run typecheck` fails with module-not-found errors across every `@avg/*` import. The failure mode is the problem: it reads like broken code, not a missing build step.

This has cost real time more than once — including mid-ceremony, where it briefly looked like a defect in the thing under test. The command order was already implicit in the block; this makes it explicit and says why.

Docs-only; CI is the gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)