### PR TITLE
docs(protocol): name the commit author, and state the SHA before review

### DIFF
--- a/docs/CODEX_HANDOFF_PROTOCOL.md
+++ b/docs/CODEX_HANDOFF_PROTOCOL.md
@@ -36,6 +36,41 @@ Every Codex-authored PR should include:
 
 Codex should not rely on green CI alone. The Hermes handoff is a separate release signal.
 
+## Commit attribution and the head SHA
+
+Two rules, both cheap, both about making the record say who did what.
+
+**1. Every Codex commit carries its own trailer.**
+
+```
+Co-Authored-By: Codex <codex@openai.com>
+```
+
+Squash-merge rewrites the author of every commit on `main` to the account that
+merged it, so the author field carries no information about who wrote the change.
+The trailer is the only part that survives. Without one, Codex's work is recorded
+as an *absence* of a trailer — which is indistinguishable from a hand-written
+commit, or from a trailer dropped in a rebase. An absence is not evidence.
+
+**2. The handback states the head commit SHA, in full, before review begins.**
+
+When the implementer cannot publish — a missing or expired token, a sandbox
+without network — someone else pushes the branch on their behalf. That is fine,
+and it should stay checkable: if the SHA was stated up front, the published head
+either matches it or it does not, and anyone can verify that without trusting
+either party.
+
+State the full 40-character SHA. A short prefix is not enough; a too-short match
+pattern has silently missed the real value here before.
+
+### Why this matters more than push access
+
+The separation this protocol depends on is that implementer and reviewer are
+independently verifiable. Push identity never provided that — squash-merge
+flattens it. What provides it is a SHA committed to in advance, plus a reviewer
+who reproduces the load-bearing claim rather than reading the diff and agreeing.
+Both hold even when the implementer has no working credentials at all.
+
 ## What Hermes Checks
 
 Hermes PR review is read-only and recommendation-only. It checks:


### PR DESCRIPTION
Came out of asking why the implementer's broken `gh` token mattered. It turns out it didn't — and the thing that *does* matter was unwritten.

## What the record actually shows

Squash-merge rewrites the author of every commit on `main` to the merging account. So on `main`:

```
f7b56e1  depre-dev   Co-Authored-By: Claude Opus 5   ← mine
5cdf57d  depre-dev   (none)                          ← Codex's
```

Same author, both. The trailer is the only surviving signal, and Codex sets none — so its work is recorded as an **absence**. That reads identically to a commit written by hand, or to a trailer dropped in a rebase. An absence is not evidence of anything.

This is the same failure class this repo keeps removing: a signal whose miss is indistinguishable from its negative.

## The two rules

1. **Codex carries its own `Co-Authored-By` trailer** — so authorship is asserted, not inferred from silence.
2. **The handback states the full 40-char head SHA before review begins** — so when someone publishes on the implementer's behalf, the match is checkable by a third party.

On the second: full SHA, not a prefix. A too-short match pattern has already silently missed the real value in this repo once, while gating the fix for that exact mistake.

## Why not just fix the token

Push access was never the separation the protocol relies on. #694 was gated correctly with the implementer's credentials completely broken — because the SHA was stated in advance (published head matched `5cdf57d9…` exactly) and because the load-bearing claim was reproduced rather than read. Both properties survive zero credentials.

Fixing the token is still worth doing for iteration speed. It just doesn't buy the provenance property, and it would have been easy to believe it did.

Docs-only; CI is the gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)