### PR TITLE
feat(harness): add INT-3c operator send driver

### DIFF
--- a/scripts/ops/int3c-preflight.mjs
+++ b/scripts/ops/int3c-preflight.mjs
@@ -1,0 +1,11 @@
+import {
+  preflightPullRequestPayload,
+} from "../../services/harness-dispatcher/dist/pr-payload-sender.js";
+
+/**
+ * INT-3c preflight imports only the sender's read-only operation. The live
+ * entry point loads this module only for the explicit `preflight` verb.
+ */
+export async function runInt3cPreflight(actuation, deps) {
+  return preflightPullRequestPayload(actuation, deps);
+}

--- a/scripts/ops/int3c-send-command.mjs
+++ b/scripts/ops/int3c-send-command.mjs
@@ -1,0 +1,8 @@
+import {
+  sendPullRequestPayload,
+} from "../../services/harness-dispatcher/dist/pr-payload-sender.js";
+
+/** The outward-facing operation is reachable only through the `send` verb. */
+export async function runInt3cSend(actuation, deps) {
+  return sendPullRequestPayload(actuation, deps);
+}

--- a/scripts/ops/int3c-send.mjs
+++ b/scripts/ops/int3c-send.mjs
@@ -1,0 +1,488 @@
+#!/usr/bin/env node
+
+import { createHash } from "node:crypto";
+import {
+  access,
+  mkdir,
+  readFile,
+  writeFile,
+} from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import {
+  artifactRefSchema,
+  canonicalContractJson,
+  pullRequestPayloadV1Schema,
+  verifiedHandoffV1Schema,
+} from "../../packages/schemas/dist/index.js";
+import {
+  createGitHubPrClient,
+} from "../../services/harness-dispatcher/dist/pr-payload-github-client.js";
+
+const REPOSITORY = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/u;
+const DEFAULT_HALT_FILE = "/data/HALT";
+
+export const INT3C_EXIT = Object.freeze({
+  ok: 0,
+  usage: 64,
+  inputInvalid: 65,
+  tokenUnavailable: 66,
+  confirmationRequired: 67,
+  handoffIneligible: 68,
+  haltGlobal: 69,
+  haltRepository: 70,
+  operationRefused: 71,
+  evidenceFailed: 72,
+});
+
+class Int3cDriverError extends Error {
+  constructor(name, exitCode, message) {
+    super(message);
+    this.name = "Int3cDriverError";
+    this.codeName = name;
+    this.exitCode = exitCode;
+  }
+}
+
+export async function runInt3cDriver({
+  argv,
+  env = process.env,
+  stdout = process.stdout,
+  stderr = process.stderr,
+  dependencies = {},
+}) {
+  try {
+    const options = parseArguments(argv);
+    const installationToken = env.GITHUB_INSTALLATION_TOKEN?.trim();
+    if (!installationToken) {
+      fail(
+        "INT3C_TOKEN_UNAVAILABLE",
+        INT3C_EXIT.tokenUnavailable,
+        "GITHUB_INSTALLATION_TOKEN is absent or empty",
+      );
+    }
+    if (
+      options.verb === "send"
+      && options.confirm !== options.repository
+    ) {
+      fail(
+        "INT3C_CONFIRMATION_REQUIRED",
+        INT3C_EXIT.confirmationRequired,
+        "--confirm must exactly repeat --repo for send",
+      );
+    }
+
+    const packet = await loadAndValidatePacket(options.handoffPath);
+    if (packet.actuation.payload.repository !== options.repository) {
+      fail(
+        "INT3C_INPUT_INVALID",
+        INT3C_EXIT.inputInvalid,
+        "--repo does not match the pinned payload repository",
+      );
+    }
+    if (packet.handoff.eligibleForPrOpen !== true) {
+      fail(
+        "INT3C_HANDOFF_INELIGIBLE",
+        INT3C_EXIT.handoffIneligible,
+        "VerifiedHandoff eligibleForPrOpen is not true",
+      );
+    }
+
+    const readHaltState = dependencies.readHaltState
+      ?? (() => readOperatorHaltState(env));
+    const halt = await readHaltState();
+    assertHaltClear(halt, options.repository);
+
+    const safeAuthorization = safeIssuedAuthorization(
+      packet.issuedAuthorization,
+    );
+    const createClient = dependencies.createGitHubClient
+      ?? ((config) => createGitHubPrClient(config));
+    const liveClient = createClient({
+      repository: options.repository,
+      installationToken,
+      issuedAuthorization: safeAuthorization,
+    });
+    const observed = createObservedGitHubClient(liveClient);
+    const senderDeps = {
+      github: observed.github,
+      readHaltState,
+    };
+    const operation = dependencies.operation
+      ?? await loadOperation(options.verb);
+    const result = await operation(packet.actuation, senderDeps);
+    const evidence = buildEvidence(
+      options.verb,
+      packet.actuation,
+      result,
+      observed.state,
+    );
+    await writeEvidence(options.evidencePath, evidence);
+    stdout.write(
+      `INT3C_${options.verb.toUpperCase()}_${String(result.outcome).toUpperCase()} evidence=${options.evidencePath}\n`,
+    );
+    return INT3C_EXIT.ok;
+  } catch (error) {
+    if (error instanceof Int3cDriverError) {
+      stderr.write(`${error.codeName}: ${error.message}\n`);
+      return error.exitCode;
+    }
+    const reason = typeof error === "object"
+      && error !== null
+      && "reason" in error
+      && typeof error.reason === "string"
+      ? error.reason
+      : "operation_failed";
+    stderr.write(
+      `INT3C_OPERATION_REFUSED: ${reason}\n`,
+    );
+    return INT3C_EXIT.operationRefused;
+  }
+}
+
+function parseArguments(argv) {
+  const [verb, ...tokens] = argv;
+  if (verb !== "preflight" && verb !== "send") {
+    fail(
+      "INT3C_USAGE",
+      INT3C_EXIT.usage,
+      "first argument must be preflight or send",
+    );
+  }
+  const values = new Map();
+  for (let index = 0; index < tokens.length; index += 2) {
+    const name = tokens[index];
+    const value = tokens[index + 1];
+    if (
+      !name?.startsWith("--")
+      || value === undefined
+      || value.startsWith("--")
+      || values.has(name)
+    ) {
+      fail(
+        "INT3C_USAGE",
+        INT3C_EXIT.usage,
+        "arguments must be unique --name value pairs",
+      );
+    }
+    values.set(name, value);
+  }
+  const allowed = new Set([
+    "--handoff",
+    "--repo",
+    "--evidence",
+    ...(verb === "send" ? ["--confirm"] : []),
+  ]);
+  const unknown = [...values.keys()].find((key) => !allowed.has(key));
+  if (unknown) {
+    fail("INT3C_USAGE", INT3C_EXIT.usage, `unsupported argument ${unknown}`);
+  }
+  const handoffPath = values.get("--handoff");
+  const repository = values.get("--repo");
+  const evidencePath = values.get("--evidence");
+  if (
+    !handoffPath
+    || !repository
+    || !evidencePath
+    || !REPOSITORY.test(repository)
+  ) {
+    fail(
+      "INT3C_USAGE",
+      INT3C_EXIT.usage,
+      "--handoff, --repo owner/name, and --evidence are required",
+    );
+  }
+  return {
+    verb,
+    handoffPath: path.resolve(handoffPath),
+    repository,
+    evidencePath: path.resolve(evidencePath),
+    confirm: values.get("--confirm"),
+  };
+}
+
+async function loadAndValidatePacket(packetPath) {
+  let input;
+  try {
+    input = JSON.parse(await readFile(packetPath, "utf8"));
+  } catch {
+    fail(
+      "INT3C_INPUT_INVALID",
+      INT3C_EXIT.inputInvalid,
+      "handoff packet is unavailable or is not JSON",
+    );
+  }
+  if (!isRecord(input)) {
+    fail(
+      "INT3C_INPUT_INVALID",
+      INT3C_EXIT.inputInvalid,
+      "handoff packet must be an object",
+    );
+  }
+  if (
+    input.schemaVersion !== 1
+    || input.kind !== "int3c_operator_handoff"
+    || !isRecord(input.actuation)
+    || !isRecord(input.issuedAuthorization)
+  ) {
+    fail(
+      "INT3C_INPUT_INVALID",
+      INT3C_EXIT.inputInvalid,
+      "handoff packet contract is invalid",
+    );
+  }
+  let handoff;
+  let artifact;
+  let payload;
+  try {
+    handoff = verifiedHandoffV1Schema.parse(input.handoff);
+    artifact = artifactRefSchema.parse(input.actuation.artifact);
+    payload = pullRequestPayloadV1Schema.parse(input.actuation.payload);
+  } catch {
+    fail(
+      "INT3C_INPUT_INVALID",
+      INT3C_EXIT.inputInvalid,
+      "handoff packet typed contracts are invalid",
+    );
+  }
+  const canonicalBytes = canonicalContractJson(payload);
+  if (input.actuation.canonicalBytes !== canonicalBytes) {
+    fail(
+      "INT3C_INPUT_INVALID",
+      INT3C_EXIT.inputInvalid,
+      "payload canonical bytes do not match the typed payload",
+    );
+  }
+  const digest = `sha256:${createHash("sha256")
+    .update(canonicalBytes, "utf8")
+    .digest("hex")}`;
+  if (
+    artifact.sha256 !== digest
+    || artifact.uri !== `artifact://sha256/${digest.slice("sha256:".length)}`
+    || (artifact.sizeBytes !== undefined
+      && artifact.sizeBytes !== Buffer.byteLength(canonicalBytes, "utf8"))
+  ) {
+    fail(
+      "INT3C_INPUT_INVALID",
+      INT3C_EXIT.inputInvalid,
+      "payload artifact content identity does not match",
+    );
+  }
+  assertHandoffPayloadBinding(handoff, payload);
+  return {
+    handoff,
+    actuation: { artifact, payload, canonicalBytes },
+    issuedAuthorization: input.issuedAuthorization,
+  };
+}
+
+function assertHandoffPayloadBinding(handoff, payload) {
+  const patchRef = handoff.deliverables.patchRef;
+  if (
+    payload.source.workItemId !== handoff.workItemId
+    || payload.source.taskVersion !== handoff.taskVersion
+    || payload.source.approvedTaskHash !== handoff.taskHash
+    || payload.source.harnessRunId !== handoff.harnessRunId
+    || payload.source.verificationDecisionHash !== handoff.verification.decisionHash
+    || !patchRef
+    || payload.patch.ref.sha256 !== patchRef.sha256
+  ) {
+    fail(
+      "INT3C_INPUT_INVALID",
+      INT3C_EXIT.inputInvalid,
+      "handoff and payload identity bindings disagree",
+    );
+  }
+}
+
+function safeIssuedAuthorization(input) {
+  const permissions = isRecord(input.permissions) ? input.permissions : {};
+  const extraWriteScopes = Array.isArray(permissions.extraWriteScopes)
+    && permissions.extraWriteScopes.every((value) => typeof value === "string")
+    ? [...permissions.extraWriteScopes]
+    : undefined;
+  if (
+    typeof input.identity !== "string"
+    || input.identity.trim().length === 0
+    || (
+      input.repositorySelection !== "selected"
+      && input.repositorySelection !== "all"
+    )
+    || !["read", "write", "none"].includes(permissions.contents)
+    || !["read", "write", "none"].includes(permissions.pullRequests)
+    || extraWriteScopes === undefined
+  ) {
+    fail(
+      "INT3C_INPUT_INVALID",
+      INT3C_EXIT.inputInvalid,
+      "token-free issuance metadata is invalid",
+    );
+  }
+  return {
+    identity: input.identity,
+    repositorySelection: input.repositorySelection,
+    permissions: {
+      contents: permissions.contents,
+      pullRequests: permissions.pullRequests,
+      extraWriteScopes,
+    },
+  };
+}
+
+async function readOperatorHaltState(env) {
+  const globalPath = env.HALT_FILE?.trim() || DEFAULT_HALT_FILE;
+  const global = await fileExists(globalPath);
+  const repositoryPath = env.HARNESS_REPOSITORY_HALT_FILE?.trim();
+  let repositories = [];
+  if (repositoryPath && await fileExists(repositoryPath)) {
+    const contents = await readFile(repositoryPath, "utf8");
+    repositories = contents
+      .split(/\r?\n/u)
+      .map((line) => line.trim())
+      .filter((line) => line.length > 0 && !line.startsWith("#"));
+  }
+  return { global, repositories };
+}
+
+async function fileExists(filePath) {
+  try {
+    await access(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function assertHaltClear(halt, repository) {
+  if (halt.global) {
+    fail("INT3C_HALT_GLOBAL", INT3C_EXIT.haltGlobal, "Global HALT is active");
+  }
+  if (halt.repositories.some(
+    (candidate) => candidate.toLowerCase() === repository.toLowerCase(),
+  )) {
+    fail(
+      "INT3C_HALT_REPOSITORY",
+      INT3C_EXIT.haltRepository,
+      `Repository HALT is active for ${repository}`,
+    );
+  }
+}
+
+function createObservedGitHubClient(github) {
+  const state = {
+    liveBaseSha: undefined,
+    remoteHeads: [],
+  };
+  return {
+    state,
+    github: {
+      readWriteAuthorization: () => github.readWriteAuthorization(),
+      async readCurrentBase(repository, baseRef) {
+        const base = await github.readCurrentBase(repository, baseRef);
+        state.liveBaseSha = base.revision;
+        return base;
+      },
+      async listPullRequestsByHead(repository, headRef) {
+        const pullRequests = await github.listPullRequestsByHead(repository, headRef);
+        state.remoteHeads.push(...pullRequests.map(
+          (pullRequest) => structuredClone(pullRequest.head),
+        ));
+        return pullRequests;
+      },
+      materializeHead: (actuation) => github.materializeHead(actuation),
+      async openPullRequest(actuation) {
+        const pullRequest = await github.openPullRequest(actuation);
+        state.remoteHeads.push(structuredClone(pullRequest.head));
+        return pullRequest;
+      },
+    },
+  };
+}
+
+async function loadOperation(verb) {
+  if (verb === "preflight") {
+    const { runInt3cPreflight } = await import("./int3c-preflight.mjs");
+    return runInt3cPreflight;
+  }
+  const { runInt3cSend } = await import("./int3c-send-command.mjs");
+  return runInt3cSend;
+}
+
+function buildEvidence(verb, actuation, result, observed) {
+  if (!observed.liveBaseSha) {
+    fail(
+      "INT3C_EVIDENCE_FAILED",
+      INT3C_EXIT.evidenceFailed,
+      "live base SHA was not observed",
+    );
+  }
+  const authorization = result.authorization;
+  const evidence = {
+    githubAppInstallationIdentity: authorization.identity,
+    repository: authorization.repository,
+    repositorySelection: authorization.repositorySelection,
+    permissions: {
+      contents: authorization.permissions.contents,
+      pullRequests: authorization.permissions.pullRequests,
+    },
+    extraWriteScopes: [],
+    liveBaseSha: observed.liveBaseSha,
+    derivedHeadRef: actuation.payload.head.ref,
+    outcome: result.outcome,
+  };
+  if (verb === "send") {
+    const remoteHead = [...observed.remoteHeads].reverse().find(
+      (candidate) => candidate.ref === actuation.payload.head.ref
+        && candidate.revision === result.pullRequest.headSha,
+    );
+    if (!remoteHead || remoteHead.treeSha !== actuation.payload.head.treeSha) {
+      fail(
+        "INT3C_EVIDENCE_FAILED",
+        INT3C_EXIT.evidenceFailed,
+        "remote head tree did not confirm the verified payload tree",
+      );
+    }
+    return {
+      ...evidence,
+      pullRequestNumber: result.pullRequest.number,
+      headCommitSha: result.pullRequest.headSha,
+      payloadArtifactHash: result.payloadArtifact.sha256,
+      remoteHeadTreeMatchesPayload: true,
+    };
+  }
+  return evidence;
+}
+
+async function writeEvidence(target, evidence) {
+  try {
+    await mkdir(path.dirname(target), { recursive: true });
+    await writeFile(target, `${JSON.stringify(evidence, null, 2)}\n`, {
+      encoding: "utf8",
+      flag: "wx",
+      mode: 0o600,
+    });
+  } catch {
+    fail(
+      "INT3C_EVIDENCE_FAILED",
+      INT3C_EXIT.evidenceFailed,
+      "evidence path could not be written without overwriting",
+    );
+  }
+}
+
+function isRecord(value) {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function fail(name, exitCode, message) {
+  throw new Int3cDriverError(name, exitCode, message);
+}
+
+async function main() {
+  process.exitCode = await runInt3cDriver({ argv: process.argv.slice(2) });
+}
+
+if (process.argv[1] && fileURLToPath(import.meta.url) === path.resolve(process.argv[1])) {
+  await main();
+}

--- a/test/helpers/fake-github-client.ts
+++ b/test/helpers/fake-github-client.ts
@@ -1,0 +1,96 @@
+import type {
+  GitHubWriteAuthorization,
+  PrPayloadGitHubClient,
+  RemotePullRequest,
+} from "../../services/harness-dispatcher/src/pr-payload-sender.js";
+import type { PrPayloadActuationResult } from "../../services/harness-dispatcher/src/pr-payload-actuator.js";
+
+export const FAKE_GITHUB_REPOSITORY = "depre-dev/averray-reference-agent";
+
+export class FakeGitHubClient implements PrPayloadGitHubClient {
+  authorization: GitHubWriteAuthorization = {
+    identity: "ceremony-app#installation-1001",
+    repositorySelection: "selected",
+    writeRepositories: [FAKE_GITHUB_REPOSITORY],
+    permissions: {
+      contents: "write",
+      pullRequests: "write",
+      extraWriteScopes: [],
+    },
+  };
+  baseRevision: string;
+  remoteCalls = 0;
+  materializeCalls = 0;
+  createCalls = 0;
+  crashAfterCreate = false;
+  onMaterialize?: () => void;
+  readonly pullRequests: RemotePullRequest[] = [];
+
+  constructor(
+    baseRevision: string,
+    readonly repository = FAKE_GITHUB_REPOSITORY,
+  ) {
+    this.baseRevision = baseRevision;
+  }
+
+  async readWriteAuthorization(): Promise<GitHubWriteAuthorization> {
+    this.remoteCalls += 1;
+    return structuredClone(this.authorization);
+  }
+
+  async readCurrentBase(repository: string, baseRef: string) {
+    this.remoteCalls += 1;
+    if (repository !== this.repository) {
+      throw new Error(`Fake GitHub client refused repository ${repository}`);
+    }
+    return { ref: baseRef, revision: this.baseRevision };
+  }
+
+  async listPullRequestsByHead(repository: string, headRef: string) {
+    this.remoteCalls += 1;
+    return structuredClone(this.pullRequests.filter(
+      (pullRequest) => pullRequest.repository === repository
+        && pullRequest.head.ref === headRef,
+    ));
+  }
+
+  async materializeHead(): Promise<void> {
+    this.remoteCalls += 1;
+    this.materializeCalls += 1;
+    this.onMaterialize?.();
+  }
+
+  async openPullRequest(actuation: PrPayloadActuationResult) {
+    this.remoteCalls += 1;
+    this.createCalls += 1;
+    const opened = fakeRemotePullRequest(
+      actuation,
+      this.pullRequests.length + 1,
+    );
+    this.pullRequests.push(opened);
+    if (this.crashAfterCreate) {
+      this.crashAfterCreate = false;
+      throw new Error("simulated process loss after remote create");
+    }
+    return structuredClone(opened);
+  }
+}
+
+export function fakeRemotePullRequest(
+  actuation: PrPayloadActuationResult,
+  number: number,
+): RemotePullRequest {
+  return {
+    repository: actuation.payload.repository,
+    number,
+    state: "open",
+    title: actuation.payload.title,
+    body: actuation.payload.body,
+    base: structuredClone(actuation.payload.base),
+    head: {
+      ref: actuation.payload.head.ref,
+      revision: "e".repeat(40),
+      treeSha: actuation.payload.head.treeSha,
+    },
+  };
+}

--- a/test/integration/int3b-payload-sender.test.ts
+++ b/test/integration/int3b-payload-sender.test.ts
@@ -45,7 +45,6 @@ import {
   PrPayloadSendError,
   sendPullRequestPayload,
   preflightPullRequestPayload,
-  type GitHubWriteAuthorization,
   type PrPayloadGitHubClient,
   type PrPayloadSendRefusalReason,
   type PrPayloadSendResult,
@@ -57,6 +56,9 @@ import {
 import {
   createGitHubPrClient,
 } from "../../services/harness-dispatcher/src/pr-payload-github-client.js";
+import {
+  FakeGitHubClient,
+} from "../helpers/fake-github-client.js";
 
 const execFileAsync = promisify(execFile);
 const PINNED_REPOSITORY = "depre-dev/averray-reference-agent";
@@ -117,70 +119,6 @@ interface CeremonyEvidence {
 }
 
 class Int3bEvidenceError extends Error {}
-
-class FakeGitHubClient implements PrPayloadGitHubClient {
-  authorization: GitHubWriteAuthorization = {
-    identity: "ceremony-app#installation-1001",
-    repositorySelection: "selected",
-    writeRepositories: [PINNED_REPOSITORY],
-    permissions: {
-      contents: "write",
-      pullRequests: "write",
-      extraWriteScopes: [],
-    },
-  };
-  baseRevision: string;
-  remoteCalls = 0;
-  materializeCalls = 0;
-  createCalls = 0;
-  crashAfterCreate = false;
-  onMaterialize?: () => void;
-  readonly pullRequests: RemotePullRequest[] = [];
-
-  constructor(baseRevision: string) {
-    this.baseRevision = baseRevision;
-  }
-
-  async readWriteAuthorization(): Promise<GitHubWriteAuthorization> {
-    this.remoteCalls += 1;
-    return structuredClone(this.authorization);
-  }
-
-  async readCurrentBase(repository: string, baseRef: string) {
-    this.remoteCalls += 1;
-    expect(repository).toBe(PINNED_REPOSITORY);
-    return { ref: baseRef, revision: this.baseRevision };
-  }
-
-  async listPullRequestsByHead(repository: string, headRef: string) {
-    this.remoteCalls += 1;
-    return structuredClone(this.pullRequests.filter(
-      (pullRequest) => pullRequest.repository === repository
-        && pullRequest.head.ref === headRef,
-    ));
-  }
-
-  async materializeHead(): Promise<void> {
-    this.remoteCalls += 1;
-    this.materializeCalls += 1;
-    this.onMaterialize?.();
-  }
-
-  async openPullRequest(actuation: PrPayloadActuationResult) {
-    this.remoteCalls += 1;
-    this.createCalls += 1;
-    const opened = remotePullRequest(
-      actuation,
-      this.pullRequests.length + 1,
-    );
-    this.pullRequests.push(opened);
-    if (this.crashAfterCreate) {
-      this.crashAfterCreate = false;
-      throw new Error("simulated process loss after remote create");
-    }
-    return structuredClone(opened);
-  }
-}
 
 describe.sequential("INT-3b pull-request sending ceremony", () => {
   let root: string;

--- a/test/integration/int3c-operator-driver.test.ts
+++ b/test/integration/int3c-operator-driver.test.ts
@@ -1,0 +1,337 @@
+import { createHash } from "node:crypto";
+import {
+  mkdtemp,
+  readFile,
+  rm,
+  writeFile,
+} from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import {
+  canonicalContractJson,
+  pullRequestPayloadV1Schema,
+  verifiedHandoffV1Schema,
+} from "@avg/schemas";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+} from "vitest";
+
+import {
+  FakeGitHubClient,
+  FAKE_GITHUB_REPOSITORY,
+} from "../helpers/fake-github-client.js";
+
+// The committed operator entry point is JavaScript so it can be invoked with
+// plain Node after the required workspace build.
+// @ts-expect-error The .mjs entry point intentionally has no declaration file.
+import {
+  INT3C_EXIT,
+  runInt3cDriver,
+} from "../../scripts/ops/int3c-send.mjs";
+
+const TOKEN_SENTINEL = "INT3C_TEST_TOKEN_SENTINEL_DO_NOT_USE";
+const BASE_REVISION = "a".repeat(40);
+
+describe.sequential("INT-3c operator driver", () => {
+  let root: string;
+  let handoffPath: string;
+  let evidencePath: string;
+  let packet: Awaited<ReturnType<typeof operatorPacket>>;
+
+  beforeEach(async () => {
+    root = await mkdtemp(path.join(tmpdir(), "int3c-driver-"));
+    handoffPath = path.join(root, "handoff.json");
+    evidencePath = path.join(root, "evidence.json");
+    packet = await operatorPacket();
+    await writeFile(handoffPath, `${JSON.stringify(packet, null, 2)}\n`, "utf8");
+  });
+
+  afterEach(async () => {
+    await rm(root, { recursive: true, force: true });
+  });
+
+  it("runs send end-to-end through the shared fake without leaking the token", async () => {
+    const fakeGitHub = new FakeGitHubClient(BASE_REVISION);
+    const output = captureOutput();
+    let clientConfig: unknown;
+    const exitCode = await runInt3cDriver({
+      argv: sendArguments(),
+      env: driverEnvironment(),
+      stdout: output.stdout,
+      stderr: output.stderr,
+      dependencies: {
+        createGitHubClient(config: unknown) {
+          clientConfig = structuredClone(config);
+          return fakeGitHub;
+        },
+      },
+    });
+
+    const evidenceBytes = await readFile(evidencePath, "utf8");
+    expect(exitCode).toBe(INT3C_EXIT.ok);
+    expect(fakeGitHub.createCalls).toBe(1);
+    expect(clientConfig).toMatchObject({
+      repository: FAKE_GITHUB_REPOSITORY,
+      installationToken: TOKEN_SENTINEL,
+      issuedAuthorization: packet.issuedAuthorization,
+    });
+    expect(output.stdout.text).toContain("INT3C_SEND_OPENED");
+    expect(output.stderr.text).toBe("");
+    expect(output.stdout.text).not.toContain(TOKEN_SENTINEL);
+    expect(output.stderr.text).not.toContain(TOKEN_SENTINEL);
+    expect(evidenceBytes).not.toContain(TOKEN_SENTINEL);
+    expect(JSON.parse(evidenceBytes)).toEqual({
+      githubAppInstallationIdentity: "ceremony-app#installation-1001",
+      repository: FAKE_GITHUB_REPOSITORY,
+      repositorySelection: "selected",
+      permissions: {
+        contents: "write",
+        pullRequests: "write",
+      },
+      extraWriteScopes: [],
+      liveBaseSha: BASE_REVISION,
+      derivedHeadRef: packet.actuation.payload.head.ref,
+      outcome: "opened",
+      pullRequestNumber: 1,
+      headCommitSha: "e".repeat(40),
+      payloadArtifactHash: packet.actuation.artifact.sha256,
+      remoteHeadTreeMatchesPayload: true,
+    });
+  });
+
+  it("keeps preflight read-only and imports no send operation on its path", async () => {
+    const fakeGitHub = new FakeGitHubClient(BASE_REVISION);
+    const output = captureOutput();
+    const exitCode = await runInt3cDriver({
+      argv: preflightArguments(),
+      env: driverEnvironment(),
+      stdout: output.stdout,
+      stderr: output.stderr,
+      dependencies: {
+        createGitHubClient: () => fakeGitHub,
+      },
+    });
+
+    expect(exitCode).toBe(INT3C_EXIT.ok);
+    expect(fakeGitHub.materializeCalls).toBe(0);
+    expect(fakeGitHub.createCalls).toBe(0);
+    expect(fakeGitHub.pullRequests).toHaveLength(0);
+    expect(JSON.parse(await readFile(evidencePath, "utf8"))).toMatchObject({
+      outcome: "ready",
+      liveBaseSha: BASE_REVISION,
+    });
+    const preflightSource = await readFile(
+      new URL("../../scripts/ops/int3c-preflight.mjs", import.meta.url),
+      "utf8",
+    );
+    expect(preflightSource).not.toContain("sendPullRequestPayload");
+  });
+
+  it.each([
+    {
+      label: "missing token",
+      argv: () => preflightArguments(),
+      env: () => ({ HALT_FILE: path.join(root, "HALT") }),
+      expectedExit: () => INT3C_EXIT.tokenUnavailable,
+      expectedMessage: "INT3C_TOKEN_UNAVAILABLE",
+      mutate: () => undefined,
+      halt: undefined,
+    },
+    {
+      label: "missing confirmation",
+      argv: () => sendArguments().slice(0, -2),
+      env: () => driverEnvironment(),
+      expectedExit: () => INT3C_EXIT.confirmationRequired,
+      expectedMessage: "INT3C_CONFIRMATION_REQUIRED",
+      mutate: () => undefined,
+      halt: undefined,
+    },
+    {
+      label: "mismatched confirmation",
+      argv: () => sendArguments().map(
+        (value, index, values) => values[index - 1] === "--confirm"
+          ? "depre-dev/other"
+          : value,
+      ),
+      env: () => driverEnvironment(),
+      expectedExit: () => INT3C_EXIT.confirmationRequired,
+      expectedMessage: "INT3C_CONFIRMATION_REQUIRED",
+      mutate: () => undefined,
+      halt: undefined,
+    },
+    {
+      label: "ineligible handoff",
+      argv: () => preflightArguments(),
+      env: () => driverEnvironment(),
+      expectedExit: () => INT3C_EXIT.handoffIneligible,
+      expectedMessage: "INT3C_HANDOFF_INELIGIBLE",
+      mutate: () => {
+        packet.handoff.eligibleForPrOpen = false;
+      },
+      halt: undefined,
+    },
+    {
+      label: "global HALT",
+      argv: () => preflightArguments(),
+      env: () => driverEnvironment(),
+      expectedExit: () => INT3C_EXIT.haltGlobal,
+      expectedMessage: "INT3C_HALT_GLOBAL",
+      mutate: () => undefined,
+      halt: { global: true, repositories: [] },
+    },
+    {
+      label: "repository HALT",
+      argv: () => preflightArguments(),
+      env: () => driverEnvironment(),
+      expectedExit: () => INT3C_EXIT.haltRepository,
+      expectedMessage: "INT3C_HALT_REPOSITORY",
+      mutate: () => undefined,
+      halt: { global: false, repositories: [FAKE_GITHUB_REPOSITORY] },
+    },
+  ])("refuses $label before any GitHub call", async (testCase) => {
+    testCase.mutate();
+    await writeFile(handoffPath, `${JSON.stringify(packet, null, 2)}\n`, "utf8");
+    const fakeGitHub = new FakeGitHubClient(BASE_REVISION);
+    const output = captureOutput();
+    const exitCode = await runInt3cDriver({
+      argv: testCase.argv(),
+      env: testCase.env(),
+      stdout: output.stdout,
+      stderr: output.stderr,
+      dependencies: {
+        createGitHubClient: () => fakeGitHub,
+        ...(testCase.halt
+          ? { readHaltState: async () => testCase.halt }
+          : {}),
+      },
+    });
+
+    expect(exitCode).toBe(testCase.expectedExit());
+    expect(output.stderr.text).toContain(testCase.expectedMessage);
+    expect(fakeGitHub.remoteCalls).toBe(0);
+    await expect(readFile(evidencePath, "utf8")).rejects.toMatchObject({
+      code: "ENOENT",
+    });
+  });
+
+  function sendArguments() {
+    return [
+      "send",
+      "--handoff",
+      handoffPath,
+      "--repo",
+      FAKE_GITHUB_REPOSITORY,
+      "--evidence",
+      evidencePath,
+      "--confirm",
+      FAKE_GITHUB_REPOSITORY,
+    ];
+  }
+
+  function preflightArguments() {
+    return [
+      "preflight",
+      "--handoff",
+      handoffPath,
+      "--repo",
+      FAKE_GITHUB_REPOSITORY,
+      "--evidence",
+      evidencePath,
+    ];
+  }
+
+  function driverEnvironment() {
+    return {
+      GITHUB_INSTALLATION_TOKEN: TOKEN_SENTINEL,
+      HALT_FILE: path.join(root, "HALT"),
+    };
+  }
+});
+
+function captureOutput() {
+  const stdout = {
+    text: "",
+    write(value: string) {
+      this.text += value;
+      return true;
+    },
+  };
+  const stderr = {
+    text: "",
+    write(value: string) {
+      this.text += value;
+      return true;
+    },
+  };
+  return { stdout, stderr };
+}
+
+async function operatorPacket() {
+  const fixture = JSON.parse(await readFile(
+    new URL(
+      "../fixtures/agent-integration/verified-handoff-v1.json",
+      import.meta.url,
+    ),
+    "utf8",
+  ));
+  const handoff = verifiedHandoffV1Schema.parse(fixture);
+  const patchRef = handoff.deliverables.patchRef!;
+  const payload = pullRequestPayloadV1Schema.parse({
+    schemaVersion: 1,
+    kind: "pull_request_payload",
+    repository: FAKE_GITHUB_REPOSITORY,
+    base: {
+      ref: "main",
+      revision: BASE_REVISION,
+    },
+    head: {
+      ref: "harness/7db95d47-2cca-5572-a198-434723821fba",
+      treeSha: "b".repeat(40),
+    },
+    title: "INT-3c operator driver fixture",
+    body: "A verified, deterministic pull-request payload.",
+    patch: {
+      ref: patchRef,
+      sha256: patchRef.sha256,
+      bytes: "diff --git a/docs/example.md b/docs/example.md\n",
+    },
+    source: {
+      workItemId: handoff.workItemId,
+      taskVersion: handoff.taskVersion,
+      approvedTaskHash: handoff.taskHash,
+      harnessRunId: handoff.harnessRunId,
+      verificationDecisionHash: handoff.verification.decisionHash,
+    },
+  });
+  const canonicalBytes = canonicalContractJson(payload);
+  const digest = createHash("sha256").update(canonicalBytes, "utf8").digest("hex");
+  return {
+    schemaVersion: 1,
+    kind: "int3c_operator_handoff",
+    handoff,
+    actuation: {
+      artifact: {
+        uri: `artifact://sha256/${digest}`,
+        sha256: `sha256:${digest}`,
+        mediaType: "application/vnd.averray.pull-request-payload.v1+json",
+        sizeBytes: Buffer.byteLength(canonicalBytes, "utf8"),
+      },
+      payload,
+      canonicalBytes,
+    },
+    issuedAuthorization: {
+      identity: "ceremony-app#installation-1001",
+      repositorySelection: "selected",
+      permissions: {
+        contents: "write",
+        pullRequests: "write",
+        extraWriteScopes: [],
+      },
+    },
+  } as const;
+}


### PR DESCRIPTION
What changed
- Added separate INT-3c preflight and send operator paths, with explicit repository confirmation on send.
- Validates the typed handoff/INT-3a actuation packet and content identity before constructing the live client.
- Reads the installation token only from GITHUB_INSTALLATION_TOKEN and records only token-free authorization/evidence fields.
- Refuses missing token, missing or mismatched confirmation, ineligible handoff, and global/repository HALT before any GitHub call.
- Reuses the INT-3b FakeGitHubClient for end-to-end leak and refusal coverage; pr-payload-sender.ts and its ten cases are unchanged.

Checks
- npm run typecheck: exit 0
- npm test: exit 0; 2,591 passed, 15 skipped
- npm run build: exit 0
- INT-3c targeted suite: 8/8 passed
- D3 deliberate token-in-evidence mutation: leak assertion failed as required, then mutation restored

Affected surfaces
- Operator-side scripts and integration tests only.
- No agent profile, Compose, CI, production database, credential, real GitHub send, merge, or deployment change.

Environment
- Live operation requires an operator-provided GITHUB_INSTALLATION_TOKEN and token-free issuance metadata in the handoff packet.
- --evidence is required so the operator chooses the non-overwriting JSON evidence path.