### PR TITLE
feat(harness): add INT-3d operator packet builder

### DIFF
--- a/scripts/ops/int3c-send.mjs
+++ b/scripts/ops/int3c-send.mjs
@@ -202,7 +202,7 @@ function parseArguments(argv) {
   };
 }
 
-async function loadAndValidatePacket(packetPath) {
+export async function loadAndValidatePacket(packetPath) {
   let input;
   try {
     input = JSON.parse(await readFile(packetPath, "utf8"));

--- a/scripts/ops/int3d-build-packet.mjs
+++ b/scripts/ops/int3d-build-packet.mjs
@@ -1,0 +1,549 @@
+#!/usr/bin/env node
+
+import { randomUUID } from "node:crypto";
+import {
+  access,
+  link,
+  mkdir,
+  readFile,
+  unlink,
+  writeFile,
+} from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import {
+  getRunBinding,
+} from "../../packages/averray-mcp/dist/run-binding-outbox.js";
+import {
+  listAgentTasks,
+} from "../../packages/averray-mcp/dist/agent-task-store.js";
+import {
+  createHarnessCliReadPort,
+} from "../../packages/averray-mcp/dist/harness-read-port.js";
+import {
+  projectHarnessRun,
+} from "../../packages/averray-mcp/dist/harness-run-projection.js";
+import {
+  agentTaskV1Schema,
+  artifactRefSchema,
+  assertVerifiedHandoffMatchesTaskAndRun,
+} from "../../packages/schemas/dist/index.js";
+import {
+  createFilePrPayloadArtifactPort,
+  createLocalGitPrPayloadRepositoryPort,
+} from "../../services/harness-dispatcher/dist/pr-payload-local-ports.js";
+import {
+  actuatePullRequestPayload,
+} from "../../services/harness-dispatcher/dist/pr-payload-actuator.js";
+import {
+  buildVerifiedHandoff,
+} from "../../services/harness-dispatcher/dist/reconcile-run.js";
+
+const DEFAULT_HALT_FILE = "/data/HALT";
+const DEFAULT_READ_TIMEOUT_MS = 15_000;
+const TOKEN_ENVIRONMENT_KEY = "GITHUB_INSTALLATION_TOKEN";
+
+export const INT3D_EXIT = Object.freeze({
+  ok: 0,
+  usage: 64,
+  tokenEnvironment: 65,
+  authorizationInvalid: 66,
+  authorizationContainsToken: 67,
+  outputExists: 68,
+  taskUnavailable: 69,
+  bindingUnavailable: 70,
+  runNotTerminal: 71,
+  handoffIneligible: 72,
+  haltGlobal: 73,
+  haltRepository: 74,
+  operationRefused: 75,
+});
+
+class Int3dBuilderError extends Error {
+  constructor(name, exitCode, message) {
+    super(message);
+    this.name = "Int3dBuilderError";
+    this.codeName = name;
+    this.exitCode = exitCode;
+  }
+}
+
+export async function runInt3dBuilder({
+  argv,
+  env = process.env,
+  stdout = process.stdout,
+  stderr = process.stderr,
+  dependencies = {},
+}) {
+  try {
+    // Check key presence without reading its value. The database-reading
+    // builder must never share the sender's credential-bearing environment.
+    if (Object.prototype.hasOwnProperty.call(env, TOKEN_ENVIRONMENT_KEY)) {
+      fail(
+        "INT3D_TOKEN_ENVIRONMENT_REFUSED",
+        INT3D_EXIT.tokenEnvironment,
+        `${TOKEN_ENVIRONMENT_KEY} must be absent from the builder environment`,
+      );
+    }
+
+    const options = parseArguments(argv);
+    await assertOutputAbsent(options.outputPath);
+    const issuedAuthorization = await readTokenFreeAuthorization(
+      options.authorizationPath,
+    );
+
+    const readHaltState = dependencies.readHaltState
+      ?? (() => readOperatorHaltState(env));
+    const initialHalt = await readHaltState();
+    if (initialHalt.global) {
+      fail(
+        "INT3D_HALT_GLOBAL",
+        INT3D_EXIT.haltGlobal,
+        "global HALT is active",
+      );
+    }
+
+    const listTasks = dependencies.listTasks ?? listAgentTasks;
+    const task = await loadCurrentTask(options.workItemId, listTasks);
+    if (initialHalt.repositories.some((candidate) =>
+      candidate.toLowerCase() === task.repository.nameWithOwner.toLowerCase())) {
+      fail(
+        "INT3D_HALT_REPOSITORY",
+        INT3D_EXIT.haltRepository,
+        `repository HALT is active for ${task.repository.nameWithOwner}`,
+      );
+    }
+    if (task.lifecycle !== "handoff_ready") {
+      fail(
+        "INT3D_HANDOFF_INELIGIBLE",
+        INT3D_EXIT.handoffIneligible,
+        `AgentTask lifecycle is ${task.lifecycle}, not handoff_ready`,
+      );
+    }
+
+    const readBinding = dependencies.getRunBinding ?? getRunBinding;
+    const binding = await readBinding(task.workItemId);
+    if (!binding) {
+      fail(
+        "INT3D_BINDING_UNAVAILABLE",
+        INT3D_EXIT.bindingUnavailable,
+        "the work item has no durable Harness run binding",
+      );
+    }
+    if (
+      task.bindings?.harnessRunId
+      && task.bindings.harnessRunId !== binding.harnessRunId
+    ) {
+      fail(
+        "INT3D_BINDING_UNAVAILABLE",
+        INT3D_EXIT.bindingUnavailable,
+        "AgentTask and outbox Harness run bindings disagree",
+      );
+    }
+
+    const readPort = dependencies.readPort ?? createHarnessCliReadPort({
+      command: env.HARNESS_BIN?.trim() || "harness",
+      timeoutMs: readTimeoutMs(env.HARNESS_DISPATCH_READ_TIMEOUT_MS),
+    });
+    const read = await readPort.readRun({
+      harnessRunId: binding.harnessRunId,
+    });
+    if (read.status.runId !== binding.harnessRunId) {
+      fail(
+        "INT3D_BINDING_UNAVAILABLE",
+        INT3D_EXIT.bindingUnavailable,
+        "Harness snapshot identity does not match the durable run binding",
+      );
+    }
+    if (read.status.outcome === undefined) {
+      fail(
+        "INT3D_RUN_NOT_TERMINAL",
+        INT3D_EXIT.runNotTerminal,
+        "the bound Harness run is not terminal",
+      );
+    }
+
+    const now = dependencies.now?.() ?? new Date();
+    const projection = projectHarnessRun(
+      projectionBinding(task, binding, read),
+      read,
+      { now },
+    );
+    let handoff;
+    try {
+      handoff = buildVerifiedHandoff(task, projection, read, now);
+      await assertVerifiedHandoffMatchesTaskAndRun(task, projection, handoff);
+    } catch {
+      fail(
+        "INT3D_HANDOFF_INELIGIBLE",
+        INT3D_EXIT.handoffIneligible,
+        "the terminal run cannot produce a verified eligible handoff",
+      );
+    }
+    if (handoff.eligibleForPrOpen !== true) {
+      fail(
+        "INT3D_HANDOFF_INELIGIBLE",
+        INT3D_EXIT.handoffIneligible,
+        "VerifiedHandoff eligibleForPrOpen is not true",
+      );
+    }
+
+    const patchArtifacts = createFilePrPayloadArtifactPort(
+      options.patchArtifactRoot,
+    );
+    const payloadArtifacts = createFilePrPayloadArtifactPort(
+      options.payloadArtifactRoot,
+    );
+    let actuation;
+    try {
+      actuation = await actuatePullRequestPayload(
+        { task, run: projection, handoff },
+        {
+          artifacts: {
+            read: patchArtifacts.read,
+            write: payloadArtifacts.write,
+          },
+          repository: createLocalGitPrPayloadRepositoryPort({
+            repositoryRoot: options.repositoryRoot,
+            repository: task.repository.nameWithOwner,
+            baseRef: options.baseRef,
+          }),
+          readHaltState,
+        },
+      );
+    } catch (error) {
+      if (error?.reason === "halt_global") {
+        fail("INT3D_HALT_GLOBAL", INT3D_EXIT.haltGlobal, "global HALT is active");
+      }
+      if (error?.reason === "halt_repository") {
+        fail(
+          "INT3D_HALT_REPOSITORY",
+          INT3D_EXIT.haltRepository,
+          `repository HALT is active for ${task.repository.nameWithOwner}`,
+        );
+      }
+      throw error;
+    }
+
+    const packet = {
+      schemaVersion: 1,
+      kind: "int3c_operator_handoff",
+      handoff,
+      actuation,
+      issuedAuthorization,
+    };
+    await writeNewFileAtomically(
+      options.outputPath,
+      `${JSON.stringify(packet, null, 2)}\n`,
+    );
+    stdout.write(`INT3D_PACKET_BUILT out=${options.outputPath}\n`);
+    return INT3D_EXIT.ok;
+  } catch (error) {
+    if (error instanceof Int3dBuilderError) {
+      stderr.write(`${error.codeName}: ${error.message}\n`);
+      return error.exitCode;
+    }
+    stderr.write("INT3D_OPERATION_REFUSED: packet construction failed\n");
+    return INT3D_EXIT.operationRefused;
+  }
+}
+
+function parseArguments(argv) {
+  const names = new Map([
+    ["--work-item", "workItemId"],
+    ["--repository-root", "repositoryRoot"],
+    ["--base-ref", "baseRef"],
+    ["--patch-artifact-root", "patchArtifactRoot"],
+    ["--payload-artifact-root", "payloadArtifactRoot"],
+    ["--authorization", "authorizationPath"],
+    ["--out", "outputPath"],
+  ]);
+  const values = {};
+  for (let index = 0; index < argv.length; index += 2) {
+    const flag = argv[index];
+    const value = argv[index + 1];
+    const name = names.get(flag);
+    if (!name || typeof value !== "string" || !value.trim() || name in values) {
+      fail(
+        "INT3D_USAGE",
+        INT3D_EXIT.usage,
+        "all packet-builder arguments are required exactly once",
+      );
+    }
+    values[name] = value.trim();
+  }
+  if (Object.keys(values).length !== names.size) {
+    fail(
+      "INT3D_USAGE",
+      INT3D_EXIT.usage,
+      "all packet-builder arguments are required exactly once",
+    );
+  }
+  return {
+    workItemId: values.workItemId,
+    repositoryRoot: path.resolve(values.repositoryRoot),
+    baseRef: values.baseRef,
+    patchArtifactRoot: path.resolve(values.patchArtifactRoot),
+    payloadArtifactRoot: path.resolve(values.payloadArtifactRoot),
+    authorizationPath: path.resolve(values.authorizationPath),
+    outputPath: path.resolve(values.outputPath),
+  };
+}
+
+async function assertOutputAbsent(target) {
+  try {
+    await access(target);
+  } catch (error) {
+    if (error?.code === "ENOENT") return;
+    throw error;
+  }
+  fail(
+    "INT3D_OUTPUT_EXISTS",
+    INT3D_EXIT.outputExists,
+    "--out already exists and will not be overwritten",
+  );
+}
+
+async function readTokenFreeAuthorization(target) {
+  let parsed;
+  try {
+    parsed = JSON.parse(await readFile(target, "utf8"));
+  } catch {
+    fail(
+      "INT3D_AUTHORIZATION_INVALID",
+      INT3D_EXIT.authorizationInvalid,
+      "authorization metadata is unavailable or is not JSON",
+    );
+  }
+  if (containsTokenKey(parsed)) {
+    fail(
+      "INT3D_AUTHORIZATION_CONTAINS_TOKEN",
+      INT3D_EXIT.authorizationContainsToken,
+      "authorization metadata contains a token key",
+    );
+  }
+  if (!isRecord(parsed)) {
+    fail(
+      "INT3D_AUTHORIZATION_INVALID",
+      INT3D_EXIT.authorizationInvalid,
+      "authorization metadata must be an object",
+    );
+  }
+  return parsed;
+}
+
+function containsTokenKey(value) {
+  if (Array.isArray(value)) return value.some(containsTokenKey);
+  if (!isRecord(value)) return false;
+  return Object.entries(value).some(([key, nested]) =>
+    key.toLowerCase() === "token" || containsTokenKey(nested));
+}
+
+async function loadCurrentTask(workItemId, listTasks) {
+  let tasks;
+  try {
+    tasks = await listTasks({ workItemId, limit: 1_000 });
+  } catch {
+    fail(
+      "INT3D_TASK_UNAVAILABLE",
+      INT3D_EXIT.taskUnavailable,
+      "AgentTask could not be read from the dispatcher store",
+    );
+  }
+  const matching = tasks
+    .map((candidate) => agentTaskV1Schema.parse(candidate))
+    .filter((candidate) => candidate.workItemId === workItemId)
+    .sort((left, right) => right.taskVersion - left.taskVersion);
+  const task = matching[0];
+  if (!task) {
+    fail(
+      "INT3D_TASK_UNAVAILABLE",
+      INT3D_EXIT.taskUnavailable,
+      `no AgentTask exists for work item ${workItemId}`,
+    );
+  }
+  return task;
+}
+
+function projectionBinding(task, binding, read) {
+  const manifestRef = task.bindings?.runManifestRef
+    ?? binding.runManifestRef
+    ?? manifestRefFromRead(read);
+  const manifestHash = task.bindings?.runManifestHash
+    ?? binding.runManifestHash
+    ?? manifestRef?.sha256;
+  if (!manifestHash) {
+    fail(
+      "INT3D_BINDING_UNAVAILABLE",
+      INT3D_EXIT.bindingUnavailable,
+      "the terminal run has no immutable manifest binding",
+    );
+  }
+
+  const observedCapabilities = read.events.flatMap((event) => {
+    if (event.type !== "CapabilityDispatched") return [];
+    const capability = stringField(event.payload, "capability")
+      ?? stringField(event.payload, "capability_id");
+    return capability ? [capability] : [];
+  });
+  const modelBindings = new Map();
+  for (const event of read.events) {
+    if (event.type !== "ModelRequested") continue;
+    const role = stringField(event.payload, "role");
+    const modelRef = stringField(event.payload, "model_ref");
+    if (!role || !modelRef || modelBindings.has(role)) continue;
+    modelBindings.set(role, {
+      role,
+      adapter: "harness-observed",
+      provider: "harness-observed",
+      modelRef,
+      profileHash: task.approval.policyHash,
+    });
+  }
+
+  return {
+    workItemId: task.workItemId,
+    correlationId: task.correlationId,
+    harnessRunId: binding.harnessRunId,
+    taskVersion: task.taskVersion,
+    repository: task.repository.nameWithOwner,
+    title: task.proposal.title,
+    summary: task.proposal.objective,
+    registeredAt: task.timestamps.runBoundAt
+      ?? binding.boundAt
+      ?? task.timestamps.dispatchClaimedAt
+      ?? task.timestamps.updatedAt,
+    staleAfterSeconds: 300,
+    manifest: {
+      ...(manifestRef ? { ref: manifestRef } : {}),
+      hash: manifestHash,
+      profile: task.intent.profile,
+      riskClass: riskClassForTask(task),
+      effectiveCapabilities: [...new Set([
+        ...task.requestedAuthority.grants.map((grant) => grant.capabilityId),
+        ...observedCapabilities,
+      ])],
+      network: read.status.egressPolicy ?? task.requestedAuthority.network,
+      policyHash: task.approval.policyHash,
+      verifierHash: task.acceptance.verifierPlanHash,
+      modelBindings: [...modelBindings.values()],
+      skillVersions: [],
+    },
+    budget: {
+      elapsedSecondsLimit: task.budget.elapsedSeconds,
+      modelTokensLimit: task.budget.modelTokens,
+      toolCallsLimit: task.budget.toolCalls,
+      estimatedUsdMicrosLimit: task.budget.estimatedUsdMicros,
+    },
+    ...(task.bindings?.averrayJobId
+      ? { averrayJobId: task.bindings.averrayJobId }
+      : {}),
+    ...(task.bindings?.averraySessionId
+      ? { averraySessionId: task.bindings.averraySessionId }
+      : {}),
+    ...(task.bindings?.pullRequest
+      ? { pullRequest: task.bindings.pullRequest }
+      : {}),
+  };
+}
+
+function manifestRefFromRead(read) {
+  for (const event of [...read.events].reverse()) {
+    if (event.type !== "EnvironmentPrepared") continue;
+    const hash = stringField(event.payload, "manifest_hash");
+    const digest = /^sha256:([a-f0-9]{64})$/u.exec(hash ?? "")?.[1];
+    if (!digest) continue;
+    return artifactRefSchema.parse({
+      uri: `artifact://sha256/${digest}`,
+      sha256: `sha256:${digest}`,
+      mediaType: "application/json",
+    });
+  }
+  return undefined;
+}
+
+function riskClassForTask(task) {
+  if (task.risk.tier === "low") return "low";
+  if (task.risk.tier === "medium") return "standard";
+  return "elevated";
+}
+
+function stringField(record, key) {
+  const value = record?.[key];
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+async function readOperatorHaltState(env) {
+  const globalPath = env.HALT_FILE?.trim() || DEFAULT_HALT_FILE;
+  const global = await fileExists(globalPath);
+  const repositoryPath = env.HARNESS_REPOSITORY_HALT_FILE?.trim();
+  let repositories = [];
+  if (repositoryPath && await fileExists(repositoryPath)) {
+    repositories = (await readFile(repositoryPath, "utf8"))
+      .split(/\r?\n/u)
+      .map((value) => value.trim())
+      .filter((value) => value.length > 0 && !value.startsWith("#"));
+  }
+  return { global, repositories };
+}
+
+async function fileExists(target) {
+  try {
+    await access(target);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function readTimeoutMs(value) {
+  if (value === undefined || value.trim() === "") return DEFAULT_READ_TIMEOUT_MS;
+  const parsed = Number(value);
+  return Number.isSafeInteger(parsed) && parsed > 0
+    ? parsed
+    : DEFAULT_READ_TIMEOUT_MS;
+}
+
+async function writeNewFileAtomically(target, contents) {
+  await mkdir(path.dirname(target), { recursive: true });
+  const temporary = path.join(
+    path.dirname(target),
+    `.${path.basename(target)}.${process.pid}.${randomUUID()}.tmp`,
+  );
+  try {
+    await writeFile(temporary, contents, {
+      encoding: "utf8",
+      flag: "wx",
+      mode: 0o600,
+    });
+    await link(temporary, target);
+  } catch (error) {
+    if (error?.code === "EEXIST") {
+      fail(
+        "INT3D_OUTPUT_EXISTS",
+        INT3D_EXIT.outputExists,
+        "--out already exists and will not be overwritten",
+      );
+    }
+    throw error;
+  } finally {
+    await unlink(temporary).catch(() => undefined);
+  }
+}
+
+function isRecord(value) {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function fail(name, exitCode, message) {
+  throw new Int3dBuilderError(name, exitCode, message);
+}
+
+async function main() {
+  process.exitCode = await runInt3dBuilder({ argv: process.argv.slice(2) });
+}
+
+if (process.argv[1] && fileURLToPath(import.meta.url) === path.resolve(process.argv[1])) {
+  await main();
+}

--- a/services/harness-dispatcher/src/reconcile-run.ts
+++ b/services/harness-dispatcher/src/reconcile-run.ts
@@ -975,7 +975,7 @@ function taskWithProjectionFacts(
   };
 }
 
-function buildVerifiedHandoff(
+export function buildVerifiedHandoff(
   task: AgentTaskV1,
   projection: AgentRunProjectionV1,
   read: HarnessRunReadSnapshot,

--- a/test/integration/int3d-packet-builder.test.ts
+++ b/test/integration/int3d-packet-builder.test.ts
@@ -1,0 +1,482 @@
+import { execFile } from "node:child_process";
+import {
+  mkdir,
+  mkdtemp,
+  readFile,
+  rm,
+  writeFile,
+} from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { promisify } from "node:util";
+
+import {
+  agentTaskV1Schema,
+  hashAgentTaskApprovalPayload,
+  type AgentTaskV1,
+} from "@avg/schemas";
+import {
+  createFilePrPayloadArtifactPort,
+} from "../../services/harness-dispatcher/src/pr-payload-local-ports.js";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+
+// The committed operator entry points are JavaScript so they can be invoked
+// with plain Node after the required workspace build.
+// @ts-expect-error The .mjs entry point intentionally has no declaration file.
+import {
+  INT3D_EXIT,
+  runInt3dBuilder,
+} from "../../scripts/ops/int3d-build-packet.mjs";
+// @ts-expect-error The .mjs entry point intentionally has no declaration file.
+import {
+  loadAndValidatePacket,
+} from "../../scripts/ops/int3c-send.mjs";
+
+const execFileAsync = promisify(execFile);
+const PINNED_REPOSITORY = "depre-dev/averray-reference-agent";
+const WORK_ITEM_ID = "int3d-one-work-item";
+const RUN_ID = "7db95d47-2cca-5572-a198-434723821fba";
+const ZERO_HASH = `sha256:${"0".repeat(64)}` as const;
+const A_HASH = `sha256:${"a".repeat(64)}` as const;
+const C_HASH = `sha256:${"c".repeat(64)}` as const;
+const D_HASH = `sha256:${"d".repeat(64)}` as const;
+const E_HASH = `sha256:${"e".repeat(64)}` as const;
+const FIXED_NOW = new Date("2026-08-03T12:30:00.000Z");
+const TOKEN_SENTINEL = "INT3D_TEST_TOKEN_SENTINEL_DO_NOT_USE";
+
+describe.sequential("INT-3d operator packet builder", () => {
+  let root: string;
+  let repositoryRoot: string;
+  let patchArtifactRoot: string;
+  let payloadArtifactRoot: string;
+  let authorizationPath: string;
+  let outputPath: string;
+  let baseRevision: string;
+  let task: AgentTaskV1;
+  let read: ReturnType<typeof terminalRead>;
+  let listTasks: ReturnType<typeof vi.fn>;
+  let readBinding: ReturnType<typeof vi.fn>;
+
+  beforeEach(async () => {
+    root = await mkdtemp(path.join(tmpdir(), "int3d-builder-"));
+    repositoryRoot = path.join(root, "repository");
+    patchArtifactRoot = path.join(root, "patch-artifacts");
+    payloadArtifactRoot = path.join(root, "payload-artifacts");
+    authorizationPath = path.join(root, "authorization.json");
+    outputPath = path.join(root, "operator-handoff.json");
+    await Promise.all([
+      mkdir(path.join(repositoryRoot, "docs"), { recursive: true }),
+      mkdir(patchArtifactRoot, { recursive: true }),
+      mkdir(payloadArtifactRoot, { recursive: true }),
+    ]);
+    await git(["init", "--initial-branch=main"], repositoryRoot);
+    const documentPath = path.join(repositoryRoot, "docs/int3d.md");
+    await writeFile(documentPath, "base\n", "utf8");
+    await git(["add", "docs/int3d.md"], repositoryRoot);
+    await git([
+      "-c",
+      "user.name=INT-3d Suite",
+      "-c",
+      "user.email=int3d@example.invalid",
+      "commit",
+      "-m",
+      "fixture base",
+    ], repositoryRoot);
+    baseRevision = (await git(["rev-parse", "HEAD"], repositoryRoot)).trim();
+
+    await writeFile(documentPath, "base\npacket builder\n", "utf8");
+    const patch = await git(
+      ["diff", "--binary", "--no-ext-diff", "--", "docs/int3d.md"],
+      repositoryRoot,
+    );
+    await writeFile(documentPath, "base\n", "utf8");
+    const patchRef = await createFilePrPayloadArtifactPort(
+      patchArtifactRoot,
+    ).write(Buffer.from(patch, "utf8"), "text/x-diff");
+
+    task = await approvedTask(baseRevision);
+    read = terminalRead(patchRef);
+    listTasks = vi.fn(async () => [task]);
+    readBinding = vi.fn(async () => ({
+      workItemId: task.workItemId,
+      harnessRunId: RUN_ID,
+      runManifestRef: ref(D_HASH),
+      runManifestHash: D_HASH,
+      boundAt: "2026-08-03T12:06:00.000Z",
+    }));
+    await writeFile(
+      authorizationPath,
+      `${JSON.stringify(safeAuthorization(), null, 2)}\n`,
+      "utf8",
+    );
+  });
+
+  afterEach(async () => {
+    await rm(root, { recursive: true, force: true });
+  });
+
+  it("builds a packet that the real INT-3c validator accepts", async () => {
+    const output = captureOutput();
+    const exitCode = await build(output);
+    const validated = await loadAndValidatePacket(outputPath);
+
+    expect(exitCode).toBe(INT3D_EXIT.ok);
+    expect(output.stderr.text).toBe("");
+    expect(output.stdout.text).toContain("INT3D_PACKET_BUILT");
+    expect(validated.handoff.workItemId).toBe(WORK_ITEM_ID);
+    expect(validated.handoff.generatedAt).toBe(FIXED_NOW.toISOString());
+    expect(validated.actuation.canonicalBytes).toBe(
+      JSON.parse(await readFile(outputPath, "utf8")).actuation.canonicalBytes,
+    );
+  });
+
+  it("rejects a payload byte perturbed after canonicalization", async () => {
+    const output = captureOutput();
+    expect(await build(output)).toBe(INT3D_EXIT.ok);
+    const packet = JSON.parse(await readFile(outputPath, "utf8"));
+    const originalTitle = packet.actuation.payload.title as string;
+    packet.actuation.payload.title = `${originalTitle}!`;
+    expect(packet.actuation.payload.title).not.toBe(originalTitle);
+    const perturbedPath = path.join(root, "operator-handoff-perturbed.json");
+    await writeFile(
+      perturbedPath,
+      `${JSON.stringify(packet, null, 2)}\n`,
+      "utf8",
+    );
+
+    await expect(loadAndValidatePacket(perturbedPath)).rejects.toThrow(
+      "payload canonical bytes do not match the typed payload",
+    );
+  });
+
+  it("refuses a non-terminal bound run before packet construction", async () => {
+    read = {
+      status: {
+        ...read.status,
+        state: "running",
+        outcome: undefined,
+      },
+      events: read.events.filter((event) => event.type !== "VerificationCompleted"),
+      deliverables: [],
+    };
+    const output = captureOutput();
+
+    expect(await build(output)).toBe(INT3D_EXIT.runNotTerminal);
+    expect(output.stderr.text).toContain("INT3D_RUN_NOT_TERMINAL");
+    await expect(readFile(outputPath, "utf8")).rejects.toMatchObject({
+      code: "ENOENT",
+    });
+  });
+
+  it("refuses before argument parsing when the token environment key is set", async () => {
+    const output = captureOutput();
+    const exitCode = await runInt3dBuilder({
+      argv: [],
+      env: { GITHUB_INSTALLATION_TOKEN: TOKEN_SENTINEL },
+      stdout: output.stdout,
+      stderr: output.stderr,
+      dependencies: {
+        listTasks,
+        getRunBinding: readBinding,
+      },
+    });
+
+    expect(exitCode).toBe(INT3D_EXIT.tokenEnvironment);
+    expect(output.stderr.text).toContain("INT3D_TOKEN_ENVIRONMENT_REFUSED");
+    expect(output.stderr.text).not.toContain(TOKEN_SENTINEL);
+    expect(listTasks).not.toHaveBeenCalled();
+    await expect(readFile(outputPath, "utf8")).rejects.toMatchObject({
+      code: "ENOENT",
+    });
+  });
+
+  it("refuses an authorization token key nested at any depth", async () => {
+    await writeFile(
+      authorizationPath,
+      JSON.stringify({
+        ...safeAuthorization(),
+        issuance: { response: [{ metadata: { token: TOKEN_SENTINEL } }] },
+      }),
+      "utf8",
+    );
+    const output = captureOutput();
+
+    expect(await build(output)).toBe(INT3D_EXIT.authorizationContainsToken);
+    expect(output.stderr.text).toContain("INT3D_AUTHORIZATION_CONTAINS_TOKEN");
+    expect(output.stderr.text).not.toContain(TOKEN_SENTINEL);
+    expect(listTasks).not.toHaveBeenCalled();
+    await expect(readFile(outputPath, "utf8")).rejects.toMatchObject({
+      code: "ENOENT",
+    });
+  });
+
+  it.each([
+    {
+      label: "global HALT",
+      halt: { global: true, repositories: [] },
+      exit: () => INT3D_EXIT.haltGlobal,
+      reason: "INT3D_HALT_GLOBAL",
+    },
+    {
+      label: "repository HALT",
+      halt: { global: false, repositories: [PINNED_REPOSITORY] },
+      exit: () => INT3D_EXIT.haltRepository,
+      reason: "INT3D_HALT_REPOSITORY",
+    },
+  ])("refuses $label without writing a packet", async (testCase) => {
+    const output = captureOutput();
+
+    expect(await build(output, {
+      readHaltState: async () => testCase.halt,
+    })).toBe(testCase.exit());
+    expect(output.stderr.text).toContain(testCase.reason);
+    await expect(readFile(outputPath, "utf8")).rejects.toMatchObject({
+      code: "ENOENT",
+    });
+  });
+
+  it("refuses to overwrite an existing packet before reading the store", async () => {
+    await writeFile(outputPath, "operator-owned\n", "utf8");
+    const output = captureOutput();
+
+    expect(await build(output)).toBe(INT3D_EXIT.outputExists);
+    expect(output.stderr.text).toContain("INT3D_OUTPUT_EXISTS");
+    expect(await readFile(outputPath, "utf8")).toBe("operator-owned\n");
+    expect(listTasks).not.toHaveBeenCalled();
+  });
+
+  it("refuses a terminal run whose verification is not eligible", async () => {
+    const verification = read.events.find(
+      (event) => event.type === "VerificationCompleted",
+    );
+    expect(verification).toBeDefined();
+    if (verification) {
+      verification.payload = {
+        ...verification.payload,
+        passed: false,
+        verdict: "failed",
+      };
+    }
+    const output = captureOutput();
+
+    expect(await build(output)).toBe(INT3D_EXIT.handoffIneligible);
+    expect(output.stderr.text).toContain("INT3D_HANDOFF_INELIGIBLE");
+    await expect(readFile(outputPath, "utf8")).rejects.toMatchObject({
+      code: "ENOENT",
+    });
+  });
+
+  it("keeps the builder structurally outside every GitHub request path", async () => {
+    const source = await readFile(
+      new URL("../../scripts/ops/int3d-build-packet.mjs", import.meta.url),
+      "utf8",
+    );
+
+    expect(source).not.toContain("pr-payload-github-client");
+    expect(source).not.toContain("pr-payload-sender");
+    expect(source).not.toMatch(/\bfetch\s*\(/u);
+    expect(source).not.toContain("node:http");
+    expect(source).not.toContain("node:https");
+  });
+
+  async function build(
+    output: ReturnType<typeof captureOutput>,
+    dependencyOverrides: Record<string, unknown> = {},
+  ): Promise<number> {
+    return runInt3dBuilder({
+      argv: builderArguments(),
+      env: { HALT_FILE: path.join(root, "HALT") },
+      stdout: output.stdout,
+      stderr: output.stderr,
+      dependencies: {
+        listTasks,
+        getRunBinding: readBinding,
+        readPort: { readRun: vi.fn(async () => read) },
+        now: () => FIXED_NOW,
+        readHaltState: async () => ({ global: false, repositories: [] }),
+        ...dependencyOverrides,
+      },
+    });
+  }
+
+  function builderArguments(): string[] {
+    return [
+      "--work-item",
+      WORK_ITEM_ID,
+      "--repository-root",
+      repositoryRoot,
+      "--base-ref",
+      "main",
+      "--patch-artifact-root",
+      patchArtifactRoot,
+      "--payload-artifact-root",
+      payloadArtifactRoot,
+      "--authorization",
+      authorizationPath,
+      "--out",
+      outputPath,
+    ];
+  }
+});
+
+async function approvedTask(baseRevision: string): Promise<AgentTaskV1> {
+  const fixture = JSON.parse(await readFile(
+    new URL(
+      "../fixtures/agent-integration/agent-task-v1.json",
+      import.meta.url,
+    ),
+    "utf8",
+  )) as Record<string, unknown>;
+  const candidate = agentTaskV1Schema.parse({
+    ...fixture,
+    workItemId: WORK_ITEM_ID,
+    correlationId: "int3d-one-correlation",
+    lifecycle: "handoff_ready",
+    proposal: {
+      ...(fixture.proposal as object),
+      title: "Build the verified INT-3d operator packet",
+      objective: "Construct the credential-free packet for the verified documentation patch.",
+    },
+    repository: {
+      provider: "github",
+      nameWithOwner: PINNED_REPOSITORY,
+      baseRevision,
+      allowedPaths: ["docs/**"],
+      forbiddenPaths: ["src/**", "ops/**"],
+    },
+    deadline: "2026-08-03T13:00:00.000Z",
+    requestedAuthority: {
+      ...(fixture.requestedAuthority as object),
+      grants: [{
+        capabilityId: "fs.write_file",
+        resource: PINNED_REPOSITORY,
+        constraints: { allowedPaths: ["docs/**"] },
+      }],
+    },
+    approval: {
+      required: "operator",
+      status: "approved",
+      actor: { type: "operator", id: "int3d-operator" },
+      decidedAt: "2026-08-03T12:05:00.000Z",
+      policyVersion: "dispatch-policy-v1",
+      policyHash: C_HASH,
+      approvedTaskHash: ZERO_HASH,
+    },
+    timestamps: {
+      proposedAt: "2026-08-03T12:00:00.000Z",
+      approvedAt: "2026-08-03T12:05:00.000Z",
+      runBoundAt: "2026-08-03T12:06:00.000Z",
+      terminalAt: "2026-08-03T12:29:59.000Z",
+      updatedAt: "2026-08-03T12:30:00.000Z",
+    },
+    bindings: {
+      harnessRunId: RUN_ID,
+      runManifestRef: ref(D_HASH),
+      runManifestHash: D_HASH,
+    },
+  });
+  const approvedTaskHash = await hashAgentTaskApprovalPayload(candidate);
+  return agentTaskV1Schema.parse({
+    ...candidate,
+    approval: { ...candidate.approval, approvedTaskHash },
+  });
+}
+
+function terminalRead(patchRef: ReturnType<typeof ref>) {
+  return {
+    status: {
+      runId: RUN_ID,
+      state: "completed" as const,
+      attempt: 1,
+      outcome: "completed" as const,
+      egressPolicy: "deny" as const,
+      createdAt: "2026-08-03T12:06:00.000Z",
+      updatedAt: "2026-08-03T12:29:59.000Z",
+    },
+    events: [
+      {
+        seq: 1,
+        type: "ContractCompiled",
+        payload: { risk_class: "low" },
+      },
+      {
+        seq: 2,
+        type: "EnvironmentPrepared",
+        payload: { manifest_hash: D_HASH },
+      },
+      {
+        seq: 3,
+        type: "VerificationCompleted",
+        payload: {
+          passed: true,
+          verdict: "completed",
+          report_ref: ref(E_HASH).uri,
+        },
+      },
+    ],
+    deliverables: [
+      { deliverableType: "workspace_patch", artifact: patchRef },
+      { deliverableType: "change_summary", artifact: ref(A_HASH) },
+      { deliverableType: "verification_report", artifact: ref(E_HASH) },
+    ],
+  };
+}
+
+function safeAuthorization() {
+  return {
+    identity: "ceremony-app#installation-1001",
+    repositorySelection: "selected",
+    repositories: [PINNED_REPOSITORY],
+    permissions: {
+      contents: "write",
+      pullRequests: "write",
+      extraWriteScopes: [],
+    },
+    expiresAt: "2026-08-03T13:00:00.000Z",
+  };
+}
+
+function ref(hash: `sha256:${string}`) {
+  return {
+    uri: `artifact://sha256/${hash.slice("sha256:".length)}`,
+    sha256: hash,
+  } as const;
+}
+
+function captureOutput() {
+  const stdout = {
+    text: "",
+    write(value: string) {
+      this.text += value;
+      return true;
+    },
+  };
+  const stderr = {
+    text: "",
+    write(value: string) {
+      this.text += value;
+      return true;
+    },
+  };
+  return { stdout, stderr };
+}
+
+async function git(args: string[], cwd: string): Promise<string> {
+  const { stdout } = await execFileAsync("git", args, {
+    cwd,
+    encoding: "utf8",
+    env: {
+      GIT_CONFIG_GLOBAL: "/dev/null",
+      GIT_CONFIG_NOSYSTEM: "1",
+      PATH: process.env.PATH,
+    },
+  });
+  return stdout;
+}


### PR DESCRIPTION
## What changed

- add the credential-free `int3d-build-packet.mjs` operator packet builder
- reconstruct terminal run projection and verified handoff from durable task/run inputs using the dispatcher shared functions
- actuate through the existing local artifact and repository ports and emit the `int3c_operator_handoff` envelope atomically without overwrite
- refuse token-bearing environments/authorization files, non-terminal or ineligible runs, HALT, and existing output
- export the existing INT-3c validator and dispatcher handoff builder without changing their behavior
- add real builder-to-validator, byte-perturbation, credential-boundary, terminal-run, HALT, overwrite, and no-GitHub-path tests

## Checks

- `npm run typecheck` — exit 0
- `npm test` — exit 0; 2,601 passed, 15 skipped
- `npm run build` — exit 0
- real container-backed INT-2 suite — exit 0; 11/11 cases executed
- D4 mutation — deliberately required the perturbed packet to validate; test failed with `INT3C_INPUT_INVALID` and `payload canonical bytes do not match the typed payload`

## Surfaces

Operator script, dispatcher export surface, integration tests. No backend runtime wiring, frontend, indexer, Caddy, contracts, public site, Compose, production database, GitHub credential, or real send. No environment or VPS secret change is required.