### PR TITLE
board: render the Bank lane, and the two follow-ups it was waiting on

### DIFF
--- a/ops/compose.yml
+++ b/ops/compose.yml
@@ -586,6 +586,14 @@ services:
       # which the panel states plainly and does NOT treat as a fault. The
       # comparison is weekly and three RPC calls, so enabling it costs nothing.
       PRODUCT_HEALTH_PAYOUT_CROSSCHECK_RPC_URL: ${PRODUCT_HEALTH_PAYOUT_CROSSCHECK_RPC_URL:-}
+      # The Bank lane feed — the backend's read-only, credential-free observer
+      # snapshot, reachable only on the private Compose network. Hermes renders
+      # it; it never reads Hydration itself.
+      #
+      # Unset by default, and absent means the lane does not render AT ALL —
+      # not a row of "awaiting" tiles and not a complaint about its own
+      # absence. Only a configured feed that fails is worth a line on screen.
+      PRODUCT_HEALTH_BANK_FEED_URL: ${PRODUCT_HEALTH_BANK_FEED_URL:-}
       # Gas attribution — what the signer's burn went ON, by operation.
       #
       # OFF by default and deliberately opt-in: one pass is ~174 RPC calls (a

--- a/packages/monitor-ui/src/components/ops/BankLane.test.tsx
+++ b/packages/monitor-ui/src/components/ops/BankLane.test.tsx
@@ -1,0 +1,110 @@
+// @vitest-environment jsdom
+//
+// Queries are scoped to each render's own container rather than to `screen`.
+// Renders accumulate in the document across tests, and a document-wide query
+// finds the PREVIOUS test's markup — which passes for the wrong reason.
+
+import { cleanup, render } from "@testing-library/react";
+import { afterEach, describe, expect, test } from "vitest";
+
+// RTL's bound queries resolve against document.body, not the render's own
+// container — so without this, each test also sees every previous test's
+// markup and "found multiple elements" is the lucky outcome. The unlucky one
+// is an assertion passing against the wrong render.
+afterEach(cleanup);
+
+import { BankLane } from "./BankLane.js";
+import type { BankBlock } from "../../lib/monitor/product-health.js";
+
+const lane = (over: Partial<NonNullable<BankBlock["lane"]>> = {}): BankBlock => ({
+  lane: {
+    position: {
+      status: "unverified",
+      raw: null,
+      detail: "zero from aUSDC 0x2ec48840…acfa93, and this read path has never observed funds",
+    },
+    float: { text: "0.149412 USDC · 149,412 raw", tone: "ok" },
+    postage: { text: "1.51 DOT · committed postage, no withdraw path", tone: "ok" },
+    requests: { text: "no requests in flight", tone: "ok" },
+    overdueRequestId: null,
+    tone: "degraded",
+    ...over,
+  },
+});
+
+describe("a lane nobody wired occupies no board", () => {
+  test("no bank block renders NOTHING — not an empty lane, not a complaint", () => {
+    // Four "awaiting" tiles for an unconfigured feature is a permanently-lit
+    // panel nobody reads, and a line complaining about its own absence is
+    // noise about setup rather than about money.
+    const { container } = render(<BankLane bank={undefined} />);
+    expect(container.innerHTML).toBe("");
+  });
+
+  test("a CONFIGURED feed that failed does get a line", () => {
+    const { getByTestId } = render(<BankLane bank={{ unavailable: "bank feed unreachable — ECONNREFUSED" }} />);
+    expect(getByTestId("ops-bank-absent").textContent).toContain("ECONNREFUSED");
+  });
+});
+
+describe("the position tile states unverified rather than showing a zero", () => {
+  test("an uncalibrated zero reads UNVERIFIED and stays warm grey", () => {
+    const { getByTestId } = render(<BankLane bank={lane()} />);
+    const dd = getByTestId("ops-bank-position").querySelector("dd")!;
+    expect(dd.textContent).toContain("UNVERIFIED");
+    expect(dd.textContent).toContain("never observed funds");
+    // Never coral: it means the instrument cannot vouch for itself, not that
+    // the money is gone. Paging on a blind instrument is the false red this
+    // board has already removed twice.
+    expect(dd.getAttribute("data-tone")).toBe("awaiting");
+  });
+
+  test("a proven zero renders as a real reading", () => {
+    const { getByTestId } = render(
+      <BankLane
+        bank={lane({
+          position: { status: "empty", raw: "0", detail: "path proven against 100000 raw" },
+          tone: "ok",
+        })}
+      />,
+    );
+    const dd = getByTestId("ops-bank-position").querySelector("dd")!;
+    expect(dd.textContent).toContain("0 raw");
+    expect(dd.textContent).toContain("proven against 100000");
+    expect(dd.getAttribute("data-tone")).toBe("ok");
+  });
+});
+
+describe("the float is on screen with its raw units", () => {
+  test("both the decimal and the raw are shown", () => {
+    // Raw is the unit reconciliation happens in — every measured fee constant
+    // is in raw. The decimal alone is readable and useless for the job.
+    const { getByTestId } = render(<BankLane bank={lane()} />);
+    const text = getByTestId("ops-bank-float").textContent!;
+    expect(text).toContain("0.149412 USDC");
+    expect(text).toContain("149,412 raw");
+  });
+});
+
+describe("an overdue request is hoisted above the rows", () => {
+  test("the alarm names the request and reddens the lane", () => {
+    const { getByTestId } = render(
+      <BankLane
+        bank={lane({
+          requests: { text: "1 OVERDUE · req-9f02 leg2-dispatched for 1.5h", tone: "red" },
+          overdueRequestId: "req-9f02",
+          tone: "red",
+        })}
+      />,
+    );
+    // Legible before any row is read — the one state here where doing nothing
+    // costs money.
+    expect(getByTestId("ops-bank-alarm").textContent).toContain("req-9f02");
+    expect(getByTestId("ops-bank").getAttribute("data-tone")).toBe("red");
+  });
+
+  test("no overdue request means no alarm element at all", () => {
+    const { queryByTestId } = render(<BankLane bank={lane()} />);
+    expect(queryByTestId("ops-bank-alarm")).toBeNull();
+  });
+});

--- a/packages/monitor-ui/src/components/ops/BankLane.tsx
+++ b/packages/monitor-ui/src/components/ops/BankLane.tsx
@@ -1,0 +1,97 @@
+// BANK — the treasury's position at the venue, and the requests moving it.
+//
+// A second money path, next to the one the FLOW panel watches. That one pays
+// workers; this one parks the treasury's own USDC at Hydration and brings it
+// home. It has its own instruments and its own ways of lying, so it gets its
+// own strip rather than being folded into SOLVENCY.
+//
+// ── THE LINES ARE DECIDED SERVER-SIDE ─────────────────────────────────────
+//
+// Every string here arrives already rendered, beside the data that produced
+// it. This component chooses layout and tone and nothing else. A board that
+// re-derived these would be a second opinion on money, and two opinions is how
+// an operator learns to trust neither — the same rule that keeps the ops
+// verdict in one place.
+//
+// ── ABSENT IS NOT BROKEN, AND NOT AN EMPTY LANE ───────────────────────────
+//
+// No `bank` block at all means no feed was ever configured. That renders
+// NOTHING: a lane nobody wired must not occupy the board with four "awaiting"
+// tiles nor complain about its own absence. Only `unavailable` — a configured
+// feed that failed — is worth a line.
+
+import type { BankBlock } from "../../lib/monitor/product-health.js";
+
+export interface BankLaneProps {
+  bank: BankBlock | undefined;
+}
+
+export function BankLane({ bank }: BankLaneProps) {
+  if (!bank) return null; // never wired — say nothing at all
+  if (!bank.lane) {
+    return (
+      <p className="ops-bank-absent" data-tone="awaiting" data-testid="ops-bank-absent">
+        BANK — {bank.unavailable ?? "lane unavailable"}
+      </p>
+    );
+  }
+
+  const { lane } = bank;
+  return (
+    <section className="ops-bank" data-tone={lane.tone} aria-label="Bank — venue position" data-testid="ops-bank">
+      <div className="ops-bank-head">
+        <h2 className="ops-bank-title">BANK — HYDRATION USDC</h2>
+        {/* The alarm, hoisted so it is legible before any row is read. An
+            overdue request is the one state here where doing nothing costs
+            money, exactly like the dispute clock in FLOW. */}
+        {lane.overdueRequestId ? (
+          <span className="ops-bank-alarm" data-tone="red" data-testid="ops-bank-alarm">
+            ⏳ {lane.overdueRequestId} OVERDUE
+          </span>
+        ) : null}
+      </div>
+
+      <dl className="ops-bank-rows">
+        {/* POSITION carries a status word rather than only a number, because
+            "unverified" is a real state here: a zero from a read path that has
+            never seen funds is not evidence of an empty position. */}
+        <div className="ops-bank-row" data-testid="ops-bank-position">
+          <dt>POSITION</dt>
+          <dd data-tone={positionTone(lane.position?.status)}>
+            {lane.position
+              ? lane.position.status === "unverified"
+                ? `UNVERIFIED — ${lane.position.detail}`
+                : `${lane.position.raw} raw · ${lane.position.detail}`
+              : "not reported"}
+          </dd>
+        </div>
+        <Row label="FLOAT" line={lane.float} testId="ops-bank-float" />
+        <Row label="POSTAGE" line={lane.postage} testId="ops-bank-postage" />
+        <Row label="REQUESTS" line={lane.requests} testId="ops-bank-requests" />
+      </dl>
+    </section>
+  );
+}
+
+function Row({ label, line, testId }: { label: string; line: { text: string; tone: string }; testId: string }) {
+  return (
+    <div className="ops-bank-row" data-testid={testId}>
+      <dt>{label}</dt>
+      <dd data-tone={line.tone}>{line.text}</dd>
+    </div>
+  );
+}
+
+/**
+ * `unverified` is warm grey, never coral.
+ *
+ * It means the instrument cannot vouch for itself — not that the money is
+ * gone. Paging on a blind instrument is the false red that teaches an operator
+ * to ignore the real one, and this board has removed that mistake twice
+ * already.
+ */
+function positionTone(status: string | undefined): string {
+  if (status === "funded") return "ok";
+  if (status === "empty") return "ok";
+  return "awaiting";
+}

--- a/packages/monitor-ui/src/components/ops/OpsBoard.tsx
+++ b/packages/monitor-ui/src/components/ops/OpsBoard.tsx
@@ -23,6 +23,7 @@ import { opsVerdict, staleAfterMs, trustRows } from "../../lib/monitor/ops-spec.
 import { FlowPanel } from "./FlowPanel.js";
 import { PillarStrip } from "./PillarStrip.js";
 import { SolvencyPanel } from "./SolvencyPanel.js";
+import { BankLane } from "./BankLane.js";
 
 export interface OpsBoardProps {
   health: ProductHealth;
@@ -117,6 +118,10 @@ export function OpsBoard({
           <SolvencyPanel solvency={health.solvency} gas={health.gas} payout={health.flow?.payout} />
           <FlowPanel flow={health.flow} externalFunnel={health.externalFunnel} lifecycle={health.lifecycle} nowMs={nowMs} />
         </div>
+
+        {/* The treasury's own money path, under the one that pays workers.
+            Renders nothing at all when no feed is configured. */}
+        <BankLane bank={health.bank} />
 
         <PillarStrip probes={health.probes} history={health.history} />
 

--- a/packages/monitor-ui/src/components/ops/money-lines-wired.test.ts
+++ b/packages/monitor-ui/src/components/ops/money-lines-wired.test.ts
@@ -9,7 +9,7 @@ import { MONEY_LINE_RENDERERS } from "../../lib/monitor/ops-spec.js";
 const dir = path.dirname(fileURLToPath(import.meta.url));
 /** Every ops component, since each fact now lives beside its subject rather
  *  than in one strip — a renderer may legitimately be called from any of them. */
-const board = ["OpsBoard.tsx", "SolvencyPanel.tsx", "FlowPanel.tsx"]
+const board = ["OpsBoard.tsx", "SolvencyPanel.tsx", "FlowPanel.tsx", "BankLane.tsx"]
   .map((f) => fs.readFileSync(path.join(dir, f), "utf8"))
   .join("\n");
 /** The phone is a SEPARATE surface with its own components — a fact wired into
@@ -80,6 +80,23 @@ describe("every money line is actually rendered", () => {
     // the tested one — the same two-verdict-systems problem the board forbids.
     expect(board).toContain('from "../../lib/monitor/ops-spec.js"');
   });
+});
+
+/**
+ * A PANEL can be built-but-unwired too, not just a view model.
+ *
+ * The Bank lane's own tests pass by rendering the component directly, which
+ * says nothing about whether the board ever mounts it. I shipped exactly that
+ * and only caught it by opening the preview — the same failure the money-line
+ * guard above exists for, one level up.
+ */
+describe("every ops panel is mounted by the board", () => {
+  for (const panel of ["SolvencyPanel", "FlowPanel", "BankLane", "PillarStrip"] as const) {
+    it(`OpsBoard mounts <${panel}>`, () => {
+      const opsBoard = fs.readFileSync(path.join(dir, "OpsBoard.tsx"), "utf8");
+      expect(opsBoard, `${panel} exists and is tested but the board never renders it`).toContain(`<${panel}`);
+    });
+  }
 });
 
 /**

--- a/packages/monitor-ui/src/lib/monitor/ops-fixtures.ts
+++ b/packages/monitor-ui/src/lib/monitor/ops-fixtures.ts
@@ -288,6 +288,24 @@ const MAINNET_PROBES: ProductHealthProbe[] = [
 ];
 
 export const OPS_FIXTURE_NOMINAL: ProductHealth = {
+  // The lane as it stands TODAY: leg 1 executed, 149,412 raw of asset 22 live
+  // at the converted account, and the position still honestly unverified
+  // because leg 2 has not yet proven the aToken read path.
+  bank: {
+    lane: {
+      position: {
+        status: "unverified" as const,
+        raw: null,
+        detail:
+          "zero from erc20:0x2ec48840…acfa93.balanceOf(0x98f0033e…fcb68e), and this read path has never observed funds — not yet evidence of an empty position",
+      },
+      float: { text: "0.149412 USDC · 149,412 raw", tone: "ok" as const },
+      postage: { text: "1.51 DOT · 15,100,000,000 raw · committed postage, no withdraw path", tone: "ok" as const },
+      requests: { text: "no requests in flight", tone: "ok" as const },
+      overdueRequestId: null,
+      tone: "degraded" as const,
+    },
+  },
   enabled: true,
   at: FIXTURE_NOW - 2_000,
   status: "degraded",

--- a/packages/monitor-ui/src/lib/monitor/product-health.ts
+++ b/packages/monitor-ui/src/lib/monitor/product-health.ts
@@ -235,6 +235,34 @@ export interface CrossCheckView {
   lastAgreedAtMs: number | null;
 }
 
+/**
+ * The Bank lane, decided server-side.
+ *
+ * The lines arrive already rendered because the view is decided once, beside
+ * the data — the same rule as the ops verdict. A board that re-derived them
+ * would be a second opinion on money, and two opinions is how an operator
+ * learns to trust neither.
+ */
+export interface BankLine {
+  text: string;
+  tone: "ok" | "degraded" | "red" | "awaiting";
+}
+
+export interface BankLaneView {
+  position: { status: "funded" | "empty" | "unverified"; raw: string | null; detail: string } | null;
+  float: BankLine;
+  postage: BankLine;
+  requests: BankLine;
+  overdueRequestId: string | null;
+  tone: "ok" | "degraded" | "red" | "awaiting";
+}
+
+export interface BankBlock {
+  lane?: BankLaneView;
+  /** A CONFIGURED feed that failed. Absent block ⇒ never wired ⇒ no lane. */
+  unavailable?: string;
+}
+
 /** One hour of chain, counting back from the head at read time. */
 export interface HourSlice {
   /** 1 = the most recent hour, ascending into the past. */
@@ -365,6 +393,11 @@ export interface ProductHealth {
   solvency?: SolvencySnapshot;
   flow?: MoneyPathSnapshot;
   history?: HealthHistory;
+  /**
+   * The Bank lane. ABSENT means no feed was ever configured — the lane does
+   * not render at all, and says nothing. Only `unavailable` is a fault.
+   */
+  bank?: BankBlock;
   remediation?: RemediationStatus;
   /** #Ops delivery health — see BuzzDeliveryView. */
   buzz?: BuzzDeliveryView;

--- a/packages/monitor-ui/src/styles/hermes4-ops.css
+++ b/packages/monitor-ui/src/styles/hermes4-ops.css
@@ -890,6 +890,76 @@ body,
 }
 .ops-pillar-trend > span { min-width: 0; }
 
+/* ---- BANK lane -------------------------------------------------
+   A second money path beside the funnel's. Compact by design: four
+   facts, one line each, label column aligned so the eye can drop
+   straight to the value it came for.
+
+   Renders only when a feed exists. A lane nobody configured occupies
+   no space and makes no claim — the same treatment as the payout
+   cross-check's not-configured state. */
+.ops-bank {
+  display: flex;
+  flex-direction: column;
+  gap: calc(4 * var(--ops-u));
+  padding: calc(8 * var(--ops-u)) calc(14 * var(--ops-u));
+  border: 1px solid var(--ops-rule);
+}
+.ops-bank[data-tone="red"] { border-color: var(--h4-act); }
+.ops-bank-head {
+  display: flex;
+  align-items: baseline;
+  gap: calc(12 * var(--ops-u));
+}
+.ops-bank-title {
+  margin: 0;
+  font-family: var(--h4-font-display);
+  font-weight: 600;
+  font-size: calc(12.5 * var(--ops-u));
+  letter-spacing: 0.1em;
+  color: var(--h4-ink);
+}
+/* Hoisted so the one state that costs money while ignored is legible
+   before any row is read. */
+.ops-bank-alarm {
+  margin-left: auto;
+  font-family: var(--h4-font-mono);
+  font-size: calc(11 * var(--ops-u));
+  color: var(--tone, var(--h4-act));
+}
+.ops-bank-rows {
+  display: grid;
+  gap: calc(2 * var(--ops-u));
+  margin: 0;
+}
+.ops-bank-row {
+  display: grid;
+  grid-template-columns: calc(72 * var(--ops-u)) 1fr;
+  gap: calc(10 * var(--ops-u));
+  align-items: baseline;
+}
+.ops-bank-row dt {
+  font-family: var(--h4-font-mono);
+  font-size: calc(9 * var(--ops-u));
+  letter-spacing: 0.14em;
+  color: var(--h4-tel);
+}
+.ops-bank-row dd {
+  margin: 0;
+  min-width: 0;
+  font-family: var(--h4-font-mono);
+  font-size: calc(11 * var(--ops-u));
+  line-height: 1.45;
+  color: var(--tone, var(--h4-ink-2));
+}
+/* A configured feed that failed. Absent block renders nothing at all. */
+.ops-bank-absent {
+  margin: 0;
+  font-family: var(--h4-font-mono);
+  font-size: calc(10 * var(--ops-u));
+  color: var(--tone, var(--h4-tel));
+}
+
 /* ---- per-job economics -------------------------------------------
    What one job costs and earns, on one line between the probes and
    the footer. Also shipped unstyled; also monospace now, because it

--- a/services/slack-operator/src/bank-feed-fetch.ts
+++ b/services/slack-operator/src/bank-feed-fetch.ts
@@ -1,0 +1,166 @@
+// Reading the Bank lane feed off the backend's internal endpoint.
+//
+// This is the ONLY place the two services touch. Everything that arrives here
+// crossed a network from a different repo on a different release cadence, so
+// none of it is trusted: the shape is checked, and anything that does not
+// check out becomes a stated reason rather than a rendered number.
+//
+// ── WHY VALIDATE WHAT WE SPECIFIED ────────────────────────────────────────
+//
+// We wrote the contract, the producer implements it, and both sides have
+// tests. That makes drift unlikely, not impossible — the two ship
+// independently, and the failure mode of an unvalidated field is silent: a
+// `raw` that arrives as a NUMBER instead of a decimal string still renders,
+// just with the precision loss the string was there to prevent. A shape check
+// costs nothing and turns a silent wrong number into a visible refusal.
+//
+// ── ABSENT IS NOT BROKEN ──────────────────────────────────────────────────
+//
+// No URL configured means the lane is not wired, which is a fact about setup
+// and not a fault. It returns `undefined`, the lane renders nothing at all,
+// and the board stays quiet. Only a CONFIGURED feed that fails is a problem
+// worth a line on screen.
+
+import type { BankFeed, BankRequest, BankRequests, SourcedRead } from "./bank-feed.js";
+
+export interface BankFeedRead {
+  feed?: BankFeed;
+  /** Set when the feed is configured but could not be read or understood. */
+  reason?: string;
+}
+
+/** A read that takes longer than this is not going to help this heartbeat. */
+export const BANK_FEED_TIMEOUT_MS = 4000;
+
+export async function readBankFeed(input: {
+  /** Internal URL of the backend's read-only feed. Empty ⇒ not wired. */
+  url: string;
+  fetchImpl: typeof fetch;
+  timeoutMs?: number;
+}): Promise<BankFeedRead> {
+  if (!input.url) return {}; // not wired — not a fault, and not a lane
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), input.timeoutMs ?? BANK_FEED_TIMEOUT_MS);
+  try {
+    const res = await input.fetchImpl(input.url, { signal: controller.signal });
+    if (!res.ok) return { reason: `bank feed returned HTTP ${res.status}` };
+    const body: unknown = await res.json();
+    return normalizeBankFeed(body);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return { reason: `bank feed unreachable — ${message}` };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/**
+ * Shape-check the payload. Exported so the check is testable without a server.
+ *
+ * Every rejection names the field, because "malformed" on its own sends the
+ * reader to the wrong repo.
+ */
+export function normalizeBankFeed(body: unknown): BankFeedRead {
+  if (!body || typeof body !== "object") return { reason: "bank feed was not an object" };
+  const b = body as Record<string, unknown>;
+
+  const position = sourcedRead(b.position, "position");
+  if ("reason" in position) return position;
+  const float = sourcedRead(b.float, "float");
+  if ("reason" in float) return float;
+  const postage = sourcedRead(b.postage, "postage");
+  if ("reason" in postage) return postage;
+  const requests = requestsBlock(b.requests);
+  if ("reason" in requests) return requests;
+
+  const calibration = calibrationRecord(b.calibration);
+  return {
+    feed: {
+      position: position.read,
+      float: float.read,
+      postage: postage.read,
+      requests: requests.requests,
+      ...(calibration ? { calibration } : {}),
+    },
+  };
+}
+
+function sourcedRead(raw: unknown, field: string): { read: SourcedRead } | { reason: string } {
+  if (!raw || typeof raw !== "object") return { reason: `bank feed ${field} is missing` };
+  const r = raw as Record<string, unknown>;
+  if (typeof r.source !== "string" || !r.source) return { reason: `bank feed ${field} has no source` };
+  // A NUMBER here is the dangerous case: it would render, having already lost
+  // precision on the way. Refuse it rather than display it.
+  if (r.raw !== null && !(typeof r.raw === "string" && /^\d+$/.test(r.raw))) {
+    return { reason: `bank feed ${field}.raw must be a decimal string or null` };
+  }
+  if (r.readAtMs !== null && typeof r.readAtMs !== "number") {
+    return { reason: `bank feed ${field}.readAtMs must be a number or null` };
+  }
+  return {
+    read: {
+      raw: (r.raw as string | null) ?? null,
+      source: r.source,
+      readAtMs: (r.readAtMs as number | null) ?? null,
+      ...(typeof r.lastError === "string" ? { lastError: r.lastError } : {}),
+    },
+  };
+}
+
+function requestsBlock(raw: unknown): { requests: BankRequests } | { reason: string } {
+  if (!raw || typeof raw !== "object") return { reason: "bank feed requests is missing" };
+  const r = raw as Record<string, unknown>;
+  if (!Array.isArray(r.items)) return { reason: "bank feed requests.items is not an array" };
+  if (r.readAtMs !== null && typeof r.readAtMs !== "number") {
+    return { reason: "bank feed requests.readAtMs must be a number or null" };
+  }
+  const items: BankRequest[] = [];
+  for (const entry of r.items) {
+    if (!entry || typeof entry !== "object") return { reason: "bank feed request entry is not an object" };
+    const e = entry as Record<string, unknown>;
+    if (typeof e.id !== "string" || typeof e.phase !== "string") {
+      return { reason: "bank feed request entry needs a string id and phase" };
+    }
+    if (typeof e.ageSeconds !== "number" || typeof e.overdue !== "boolean") {
+      return { reason: `bank feed request ${e.id} needs numeric ageSeconds and boolean overdue` };
+    }
+    items.push({
+      id: e.id,
+      kind: typeof e.kind === "string" ? e.kind : "unknown",
+      // Passed through verbatim. The vocabulary belongs to the observer and
+      // the renderer flags anything it does not recognise.
+      phase: e.phase,
+      ageSeconds: e.ageSeconds,
+      overdue: e.overdue,
+    });
+  }
+  return {
+    requests: {
+      items,
+      readAtMs: (r.readAtMs as number | null) ?? null,
+      ...(typeof r.lastError === "string" ? { lastError: r.lastError } : {}),
+    },
+  };
+}
+
+/**
+ * A malformed calibration is dropped, never repaired.
+ *
+ * Dropping it costs a zero rendering as `unverified` — conservative, and it
+ * self-corrects on the next good read. Repairing it would mean inventing the
+ * proof that a read path works, which is the one thing this record exists to
+ * refuse.
+ */
+function calibrationRecord(raw: unknown): BankFeed["calibration"] {
+  if (!raw || typeof raw !== "object") return null;
+  const c = raw as Record<string, unknown>;
+  if (typeof c.provenSource !== "string" || !c.provenSource) return null;
+  if (typeof c.provenAtMs !== "number") return null;
+  if (typeof c.provenRaw !== "string" || !/^\d+$/.test(c.provenRaw)) return null;
+  try {
+    if (BigInt(c.provenRaw) <= 0n) return null; // a zero proves nothing
+  } catch {
+    return null;
+  }
+  return { provenAtMs: c.provenAtMs, provenRaw: c.provenRaw, provenSource: c.provenSource };
+}

--- a/services/slack-operator/src/bank-lane.ts
+++ b/services/slack-operator/src/bank-lane.ts
@@ -76,6 +76,27 @@ function amount(read: SourcedRead, decimals: number, unit: string, nowMs: number
   return { text: `${formatUnits(value, decimals)} ${unit} · ${groupDigits(value)} raw`, tone: "ok" };
 }
 
+/**
+ * A read source, short enough to sit inside a sentence.
+ *
+ * The producer emits an exact, machine-shaped identifier —
+ * `erc20:0x2ec4884088d84e5c2970a034732e5209b0acfa93.balanceOf(0x98f0033e…)` —
+ * which is precisely right for the job it must be exact for: deciding whether
+ * a calibration proof still applies after a retarget. It is ~100 characters,
+ * and interpolated into "zero from X, and this read path has never observed
+ * funds" it buries the sentence.
+ *
+ * So the FULL string is compared and the SHORT string is displayed. Never the
+ * other way round: shortening before comparison would let two different
+ * addresses share a proof, which is the retarget hole this rule exists to
+ * close.
+ */
+export function shortSource(source: string): string {
+  // Keep the ledger tag and elide the middle of every long hex run, so both
+  // ends of every address stay legible and greppable.
+  return source.replace(/0x[a-fA-F0-9]{16,}/g, (hex) => `${hex.slice(0, 10)}…${hex.slice(-6)}`);
+}
+
 /** 28463 → "28,463". String grouping, so a large bigint cannot lose precision. */
 export function groupDigits(value: bigint): string {
   const negative = value < 0n;
@@ -127,6 +148,7 @@ export function bankLaneView(input: {
     raw: feed.position.raw,
     ...(feed.position.lastError ? { readError: feed.position.lastError } : {}),
     source: feed.position.source,
+    shorten: shortSource,
     calibration: feed.calibration ?? null,
     readAtMs: feed.position.readAtMs,
     nowMs,
@@ -207,18 +229,33 @@ function requestLine(requests: BankRequests, nowMs: number, staleAfterMs: number
   if (overdue.length > 0) {
     const lead = overdue.reduce((a, b) => (b.ageSeconds > a.ageSeconds ? b : a));
     return {
-      text: `${overdue.length} OVERDUE · ${lead.id} ${lead.phase} for ${formatAge(lead.ageSeconds)}`,
+      text: `${overdue.length} OVERDUE · ${lead.id} ${lead.phase} ${describeAge(lead)}`,
       tone: "red",
     };
   }
   const lead = live.reduce((a, b) => (b.ageSeconds > a.ageSeconds ? b : a));
-  const base = `${live.length} in flight · oldest ${lead.id} ${lead.phase} ${formatAge(lead.ageSeconds)}`;
+  const base = `${live.length} in flight · oldest ${lead.id} ${lead.phase} ${describeAge(lead)}`;
   if (unknown.length > 0) {
     // Verbatim, so the value is searchable against the observer's own source.
     const u = unknown[0]!;
     return { text: `${base} · UNRECOGNISED PHASE "${u.phase}" on ${u.id}`, tone: "degraded" };
   }
   return { text: base, tone: "ok" };
+}
+
+/**
+ * How long it has been in flight — or that we cannot say.
+ *
+ * The producer sends `ageSeconds: 0` when a request's `startedAt` is
+ * unparseable, because the field is a number and zero is the only available
+ * placeholder. Rendered literally that becomes "OVERDUE · req-x for 0s", which
+ * states an age nobody measured — absence-as-zero, in miniature, on an alarm.
+ *
+ * It always arrives paired with `phase: "timing-unknown"`, so the honest
+ * rendering is available: say the age is unknown rather than say it is none.
+ */
+function describeAge(request: BankRequest): string {
+  return request.phase === "timing-unknown" ? "· age unknown" : `for ${formatAge(request.ageSeconds)}`;
 }
 
 function formatAge(seconds: number): string {

--- a/services/slack-operator/src/position-display.ts
+++ b/services/slack-operator/src/position-display.ts
@@ -69,6 +69,12 @@ export interface PositionView {
 export const POSITION_STALE_AFTER_MS = 15 * 60 * 1000;
 
 export function decidePositionDisplay(input: {
+  /**
+   * Renders the source for HUMAN text only. Comparison always uses the full
+   * string — shortening before comparison would let two different addresses
+   * share one proof, which is the retarget hole this rule closes.
+   */
+  shorten?: (source: string) => string;
   /** Raw units read, as a decimal string. Null when the read failed. */
   raw: string | null;
   /** Why the read failed, when it did. */
@@ -82,7 +88,8 @@ export function decidePositionDisplay(input: {
   nowMs: number;
   staleAfterMs?: number;
 }): PositionView {
-  const src = input.source || "an unnamed source";
+  const full = input.source || "an unnamed source";
+  const src = input.shorten ? input.shorten(full) : full;
 
   if (input.readError) {
     return { status: "unverified", raw: null, detail: `position unreadable — ${input.readError}` };
@@ -120,13 +127,15 @@ export function decidePositionDisplay(input: {
       detail: `zero from ${src}, and this read path has never observed funds — not yet evidence of an empty position`,
     };
   }
-  if (cal.provenSource !== input.source) {
+  if (cal.provenSource !== full) {
     // A retarget invalidates the proof: the old path's calibration says nothing
     // about a new address or a different ledger.
     return {
       status: "unverified",
       raw: null,
-      detail: `zero from ${src}, but the proof was taken against ${cal.provenSource} — recalibrate before believing a zero here`,
+      detail: `zero from ${src}, but the proof was taken against ${
+        input.shorten ? input.shorten(cal.provenSource) : cal.provenSource
+      } — recalibrate before believing a zero here`,
     };
   }
   return {

--- a/services/slack-operator/src/product-health.ts
+++ b/services/slack-operator/src/product-health.ts
@@ -39,6 +39,8 @@ import { summarizeLifecycle, type LifecycleSummary } from "./job-lifecycle.js";
 import { bucketPayoutsByHour, isHistogramUnavailable, type PayoutHistogram } from "./payout-histogram.js";
 import { endpointHost, pinnedCompareRange, type CrossCheckView } from "./payout-crosscheck.js";
 import { burnBasisLabel, isBurnUnmeasurable, type MeasuredBurn } from "./gas-burn-rate.js";
+import { readBankFeed } from "./bank-feed-fetch.js";
+import { bankLaneView, BANK_FEED_ABSENT, type BankLaneView } from "./bank-lane.js";
 import { createCrossCheckCache, type CrossCheckCache } from "./payout-crosscheck-cache.js";
 import { createGasSpendCache, type GasSpendCache, type GasSpendSnapshot, type GasUnreadable } from "./gas-spend-cache.js";
 import { alertProvenance, decideMoneyAlert } from "./money-alert.js";
@@ -630,6 +632,8 @@ export interface ProductHealthConfig {
   payoutTolerance: number;
   /** A SECOND provider, so the proof is not one endpoint's opinion. */
   payoutCrossCheckRpcUrl: string;
+  /** Internal URL of the backend's read-only Bank lane feed. Empty ⇒ no lane. */
+  bankFeedUrl: string;
   /** Filesystem the monitor writes to. Container `/` sees real host capacity. */
   diskPath: string;
   /** Free-space floor in GiB — below this the disk probe goes red. */
@@ -745,6 +749,7 @@ export function loadProductHealthConfig(env: NodeJS.ProcessEnv = process.env): P
     payoutLookbackBlocks: num(env.PRODUCT_HEALTH_PAYOUT_LOOKBACK_BLOCKS, 60000),
     payoutTolerance: num(env.PRODUCT_HEALTH_PAYOUT_TOLERANCE, 1),
     payoutCrossCheckRpcUrl: (env.PRODUCT_HEALTH_PAYOUT_CROSSCHECK_RPC_URL ?? "").trim(),
+    bankFeedUrl: (env.PRODUCT_HEALTH_BANK_FEED_URL ?? "").trim(),
     // Off by default. A pass is ~174 RPC calls against an endpoint that
     // rate-limits by answering 404, so the operator opts in knowingly.
     gasAttributionEnabled: truthy(env.PRODUCT_HEALTH_GAS_ATTRIBUTION_ENABLED),
@@ -2440,6 +2445,19 @@ export interface ProductHealthSnapshotBlocks {
    * slope through balances. Declared now because the projection reads it.
    */
   gas?: GasSpendSnapshot | GasUnreadable;
+  /**
+   * The Bank lane, or the reason it cannot be shown.
+   *
+   * Absent entirely when no feed URL is configured: a lane nobody wired must
+   * not produce a line complaining about itself. `unavailable` only ever means
+   * a CONFIGURED feed that failed, which is worth saying out loud.
+   */
+  bank?: BankBlock;
+}
+
+export interface BankBlock {
+  lane?: BankLaneView;
+  unavailable?: string;
 }
 
 function resolveProductHealthNetwork(chainId: number | undefined): "testnet" | "mainnet" | "unknown" {
@@ -2679,10 +2697,20 @@ export async function collectProductHealthProbes(
     haltStatus: chainHaltStatus(chainId, config.haltSeverity),
     fetchImpl,
   });
+  // The Bank lane. The view is decided HERE so the board renders one answer
+  // rather than forming its own — same rule as the ops verdict.
+  const bankRead = await readBankFeed({ url: config.bankFeedUrl, fetchImpl });
+  const bank: BankBlock | undefined = bankRead.feed
+    ? { lane: bankLaneView({ feed: bankRead.feed, nowMs: chainCtx.nowMs }) ?? undefined }
+    : bankRead.reason
+      ? { unavailable: bankRead.reason }
+      : undefined; // not configured — no lane at all, and no complaint
+
   const snapshot: ProductHealthSnapshotBlocks = {
     chainId: chainId ?? null,
     ...(selfFreshness.selfFreshness ? { self: selfFreshness.selfFreshness } : {}),
     network: resolveProductHealthNetwork(chainId),
+    ...(bank ? { bank } : {}),
     // Block ticker data — same values the chain_height probe judged this cycle,
     // structured instead of embedded in the detail string. Only emitted when a
     // real height was observed (never a placeholder number).

--- a/services/slack-operator/test/unit/bank-feed-fetch.test.ts
+++ b/services/slack-operator/test/unit/bank-feed-fetch.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, test } from "vitest";
+
+import { normalizeBankFeed, readBankFeed } from "../../src/bank-feed-fetch.js";
+
+const good = {
+  position: { raw: "0", source: "erc20:0x2ec4…fa93.balanceOf(0x98f0…b68e)", readAtMs: 1_785_900_000_000 },
+  float: { raw: "149412", source: "substrate_tokens:22", readAtMs: 1_785_900_000_000 },
+  postage: { raw: "15100000000", source: "substrate_system:15Xbeap…", readAtMs: 1_785_900_000_000 },
+  requests: { items: [], readAtMs: 1_785_900_000_000, lastError: null },
+  calibration: null,
+};
+
+describe("not wired is not broken", () => {
+  test("no URL yields no feed AND no reason — the lane simply does not exist", () => {
+    // A lane nobody configured must not produce a line complaining about it.
+    return readBankFeed({ url: "", fetchImpl: (() => { throw new Error("must not fetch"); }) as never })
+      .then((r) => {
+        expect(r.feed).toBeUndefined();
+        expect(r.reason).toBeUndefined();
+      });
+  });
+
+  test("a CONFIGURED feed that fails gets a reason", async () => {
+    const r = await readBankFeed({
+      url: "http://backend:8787/monitor/bank-feed",
+      fetchImpl: (async () => { throw new Error("ECONNREFUSED"); }) as never,
+    });
+    expect(r.feed).toBeUndefined();
+    expect(r.reason).toContain("ECONNREFUSED");
+  });
+
+  test("a non-2xx names the status", async () => {
+    const r = await readBankFeed({
+      url: "http://backend:8787/monitor/bank-feed",
+      fetchImpl: (async () => ({ ok: false, status: 503 })) as never,
+    });
+    expect(r.reason).toContain("503");
+  });
+});
+
+describe("nothing that crossed the network is trusted", () => {
+  test("a well-formed payload passes through intact", () => {
+    const r = normalizeBankFeed(good);
+    expect(r.reason).toBeUndefined();
+    expect(r.feed!.float.raw).toBe("149412");
+    expect(r.feed!.position.readAtMs).toBe(1_785_900_000_000);
+  });
+
+  test("a NUMERIC raw is refused, not coerced", () => {
+    // The dangerous case: a number renders fine, having already lost the
+    // precision the decimal string existed to preserve. 149412 survives, but a
+    // 30-digit balance would not, and nothing on screen would show it.
+    const r = normalizeBankFeed({ ...good, float: { ...good.float, raw: 149412 } });
+    expect(r.feed).toBeUndefined();
+    expect(r.reason).toContain("float.raw must be a decimal string");
+  });
+
+  test("each rejection names its field, so the reader knows which repo to open", () => {
+    expect(normalizeBankFeed({ ...good, position: undefined }).reason).toContain("position");
+    expect(normalizeBankFeed({ ...good, postage: { ...good.postage, source: "" } }).reason).toContain("postage");
+    expect(normalizeBankFeed({ ...good, requests: { items: "nope", readAtMs: 1 } }).reason).toContain("requests.items");
+  });
+
+  test("a request entry missing overdue is refused rather than defaulted", () => {
+    // Defaulting `overdue` to false would invent an all-clear on the stuck-
+    // pending alarm — the exact failure the section provenance exists to stop.
+    const r = normalizeBankFeed({
+      ...good,
+      requests: { items: [{ id: "req-1", phase: "leg1-dispatched", ageSeconds: 10 }], readAtMs: 1 },
+    });
+    expect(r.feed).toBeUndefined();
+    expect(r.reason).toContain("overdue");
+  });
+
+  test("an unknown phase passes through verbatim", () => {
+    const r = normalizeBankFeed({
+      ...good,
+      requests: {
+        items: [{ id: "req-1", kind: "deposit", phase: "timing-unknown", ageSeconds: 0, overdue: true }],
+        readAtMs: 1,
+      },
+    });
+    expect(r.feed!.requests.items[0]!.phase).toBe("timing-unknown");
+  });
+});
+
+describe("a malformed calibration is dropped, never repaired", () => {
+  test("a zero or negative proof is discarded", () => {
+    for (const provenRaw of ["0", "-5"]) {
+      const r = normalizeBankFeed({
+        ...good,
+        calibration: { provenAtMs: 1, provenRaw, provenSource: good.position.source },
+      });
+      expect(r.feed!.calibration ?? null).toBeNull();
+    }
+  });
+
+  test("a proof with no source is discarded", () => {
+    const r = normalizeBankFeed({ ...good, calibration: { provenAtMs: 1, provenRaw: "100000", provenSource: "" } });
+    expect(r.feed!.calibration ?? null).toBeNull();
+  });
+
+  test("dropping it costs a zero reading as unverified — the conservative direction", () => {
+    // Repairing a calibration would mean inventing the proof that a read path
+    // works, which is the one thing the record exists to refuse.
+    const r = normalizeBankFeed({ ...good, calibration: { garbage: true } });
+    expect(r.feed).toBeDefined();
+    expect(r.feed!.calibration ?? null).toBeNull();
+  });
+
+  test("a good proof survives", () => {
+    const r = normalizeBankFeed({
+      ...good,
+      calibration: { provenAtMs: 1, provenRaw: "100000", provenSource: good.position.source },
+    });
+    expect(r.feed!.calibration!.provenRaw).toBe("100000");
+  });
+});


### PR DESCRIPTION
The consumer half of the Bank lane. Producer endpoint is `averray-agent/agent#924`; this is the board that reads it.

```
BANK — HYDRATION USDC
POSITION   UNVERIFIED — zero from erc20:0x2ec48840…acfa93.balanceOf(0x98f0033e…fcb68e),
           and this read path has never observed funds — not yet evidence of an empty position
FLOAT      0.149412 USDC · 149,412 raw
POSTAGE    1.51 DOT · 15,100,000,000 raw · committed postage, no withdraw path
REQUESTS   no requests in flight
```

That is the live shape today: leg 1 executed, the float is real, and POSITION stays honestly unverified until leg 2 proves the aToken read path.

## The two follow-ups I owed from the gate

**`shortSource`** — the producer's identifier is exact and ~100 characters, which is right for the job it must be exact for: deciding whether a calibration proof survives a retarget. Interpolated into a sentence it buried it. **The full string is compared, the short string is displayed** — never the reverse, since shortening before comparison would let two different addresses share one proof.

**`describeAge`** — `ageSeconds: 0` on unparseable `startedAt` rendered as *"OVERDUE · req-x for 0s"*, stating an age nobody measured. It always arrives paired with `phase: "timing-unknown"`, so it now says the age is unknown rather than that it is none.

## Nothing that crossed the network is trusted

`bank-feed-fetch.ts` shape-checks the payload and names the field in every rejection. The dangerous case is a `raw` arriving as a **number**: it renders fine, having already lost the precision the decimal string existed to preserve, and nothing on screen would show it.

A malformed calibration is **dropped, never repaired** — dropping costs a zero rendering as `unverified` and self-corrects on the next good read; repairing would mean inventing the proof that a read path works.

## Absence is not a lane

No feed URL → no `bank` block → the component renders **nothing**. Not four "awaiting" tiles, not a line complaining about its own absence. Only a *configured* feed that failed gets a line.

## Caught by looking — and one correction

The lane rendered nothing in the preview and I diagnosed "built but not wired". **I was wrong**: the wiring was correct; my fixture had landed in `OPS_FIXTURE_POPULATED` while the preview renders `OPS_FIXTURE_NOMINAL`. The component was correctly rendering nothing for an unconfigured feed.

The near-miss is real though. `BankLane`'s own tests pass by rendering the component directly, which says nothing about whether the board ever mounts it — so `money-lines-wired.test.ts` now asserts **every ops panel appears in `OpsBoard`**, one level up from the money-line check it already made.

And `PRODUCT_HEALTH_BANK_FEED_URL` was missing from compose. The compose-env guard caught it — the second time this session it has caught this exact class.

## Verification

- **2614 tests pass**, typecheck clean on both packages
- 7 render tests, 12 fetch/normalize tests, plus the new panel-mount guard
- rendered in the preview at the live shape

🤖 Generated with [Claude Code](https://claude.com/claude-code)