### PR TITLE
Attach the Bank lane's network declaratively, and fail soft without it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,6 +83,16 @@ jobs:
       - name: Validate Compose file
         run: docker compose --env-file ops/.env.example -f ops/compose.yml -f ops/compose.prod.yml config
 
+      # The Bank lane overlay is conditional at deploy time (deploy-monitor.sh
+      # adds it only when the platform network exists), so nothing else here
+      # would ever parse it. `config` does not contact the daemon about an
+      # external network, so this validates the merge on a runner that has no
+      # such network — which is the point.
+      - name: Validate Compose file (with the Bank lane overlay)
+        run: >-
+          docker compose --env-file ops/.env.example
+          -f ops/compose.yml -f ops/compose.prod.yml -f ops/compose.bank-feed.yml config
+
   int2-supervised-dispatch:
     name: INT-2 real dispatcher integration
     runs-on: ubuntu-latest

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,6 +71,7 @@ If you touched `ops/`, the `Dockerfile`, or compose files, also validate what CI
 
 ```bash
 docker compose --env-file ops/.env.example -f ops/compose.yml -f ops/compose.prod.yml config
+docker compose --env-file ops/.env.example -f ops/compose.yml -f ops/compose.prod.yml -f ops/compose.bank-feed.yml config
 ```
 
 **Golden path for a task:** branch from fresh `origin/main` → make the change →
@@ -99,7 +100,7 @@ that SSH in to invoke Hermes. Don't edit the platform repo from here.
 | `services/slack-operator/` | Serves the `/monitor` board, the Codex task queue + runner, testbed mission runner |
 | `services/skills-observer/` | Sidecar ingesting Hermes skill files |
 | `services/test-wallet-signer/` | T3 test-wallet signer sidecar; mints cached API/browser sessions without exposing keys to agents |
-| `ops/` | Docker Compose stack (`compose.yml`, `compose.prod.yml`, `compose.command-center.yml`, `compose.cloudflare-access.yml`), migrations |
+| `ops/` | Docker Compose stack (`compose.yml`, `compose.prod.yml`, `compose.command-center.yml`, `compose.cloudflare-access.yml`, `compose.bank-feed.yml`), migrations |
 | `hermes/` | Hermes config (`hermes.yaml`, `policy.yaml`) + trace plugin |
 | `test/unit/` | Vitest suites (alongside `*.test.ts(x)` colocated in packages) |
 | `test/integration/` | Postgres and supervised-dispatch integration suites; slow external prerequisites are explicit and fail-required in their CI jobs |

--- a/ops/compose.bank-feed.yml
+++ b/ops/compose.bank-feed.yml
@@ -1,0 +1,57 @@
+# The Bank lane's one wire — the board reaching the platform backend's
+# read-only feed over the BACKEND's own private network.
+#
+# `PRODUCT_HEALTH_BANK_FEED_URL` points at `agent-mainnet-backend:8787`, which
+# is a name only the platform stack's network resolves. Without this file the
+# URL is configured and unreachable, and the lane says so forever.
+#
+# ── WHY A FILE AND NOT `docker network connect` ───────────────────────────
+#
+# The imperative command works instantly and vanishes on the next container
+# recreate: the lane would read fine today and silently stop after a deploy,
+# with nothing in the tree recording that it was ever connected. Attachment is
+# configuration, so it belongs in configuration.
+#
+# ── WHY A SEPARATE FILE AND NOT THE BASE COMPOSE ──────────────────────────
+#
+# `external: true` is a hard start-time precondition. In ops/compose.yml, a
+# missing `agent-mainnet-internal` would stop THE WHOLE monitor stack from
+# coming up — including the board that exists to tell you the platform is
+# down. A read-only display must never make its own availability depend on the
+# network of the thing it watches; that is the coupling #657 removed when a
+# Hermes crash could red a deploy.
+#
+# So it lives here, and ops/deploy-monitor.sh adds it only when the network is
+# actually present. Network gone ⇒ overlay skipped ⇒ the board still boots and
+# the lane reports the feed unreachable. One line of text instead of an outage.
+#
+# ── WHY THIS DIRECTION ────────────────────────────────────────────────────
+#
+# The board joins the platform's network; never the reverse. Putting the
+# money-rail backend onto `avg_avg-internal` would hand it reach to
+# avg-postgres, avg-cloudflared and every task runner — a real widening of the
+# platform's blast radius, to make a display work. This direction adds one
+# read-only consumer to a network the backend can already be reached from, and
+# nothing else.
+
+services:
+  slack-operator:
+    # BOTH networks spelled out in full, deliberately.
+    #
+    # Compose normalises the short list form to a mapping and unions the keys,
+    # so restating avg-internal is redundant under today's merge rule — and
+    # still correct under a replace rule. Getting that wrong silently would cut
+    # the board off from Postgres, which is a worse failure than the one this
+    # file fixes.
+    networks: [avg-internal, agent-mainnet-internal]
+
+networks:
+  # Created and owned by the platform stack (averray-agent/agent), whose
+  # compose names it. Nothing here creates it, and `compose down` in this
+  # project must never remove it — `external: true` is what guarantees both.
+  #
+  # The name is the platform's to change. If it does, `docker network inspect`
+  # in deploy-monitor.sh stops finding it, the overlay is skipped with a note,
+  # and the lane reports unreachable — visible, and not an outage.
+  agent-mainnet-internal:
+    external: true

--- a/ops/compose.yml
+++ b/ops/compose.yml
@@ -593,6 +593,12 @@ services:
       # Unset by default, and absent means the lane does not render AT ALL —
       # not a row of "awaiting" tiles and not a complaint about its own
       # absence. Only a configured feed that fails is worth a line on screen.
+      #
+      # SETTING THIS IS HALF THE WIRE. The host in it resolves only on the
+      # platform stack's own network, which this project joins via
+      # ops/compose.bank-feed.yml — added automatically by ops/deploy-monitor.sh
+      # when that network exists. Deploy by hand without that -f and the URL is
+      # configured, unreachable, and says so on the board.
       PRODUCT_HEALTH_BANK_FEED_URL: ${PRODUCT_HEALTH_BANK_FEED_URL:-}
       # Gas attribution — what the signer's burn went ON, by operation.
       #

--- a/ops/deploy-monitor.sh
+++ b/ops/deploy-monitor.sh
@@ -113,6 +113,30 @@ COMPOSE=(docker compose -p "$PROJECT" --env-file .env.prod
   -f ops/compose.command-center.yml
   -f ops/compose.cloudflare-access.yml)
 
+# THE BANK LANE'S NETWORK — attached only when it is really there.
+#
+# ops/compose.bank-feed.yml joins slack-operator to the platform stack's
+# private network so the board can read the backend's read-only Bank feed. It
+# declares that network `external: true`, which Compose treats as a hard
+# precondition: if it is absent, EVERY service in this project refuses to
+# start, this one included.
+#
+# That is the wrong trade for a display. The board is how you find out the
+# platform is down; it must not be unable to boot for the same reason. So the
+# overlay goes in only when the network exists, and its absence costs one line
+# of text on the board instead of the monitor. Same call as the skills sync
+# below, and the same one #657 made for the Hermes health gate.
+BANK_FEED_NETWORK=agent-mainnet-internal
+if docker network inspect "$BANK_FEED_NETWORK" >/dev/null 2>&1; then
+  COMPOSE+=(-f ops/compose.bank-feed.yml)
+else
+  echo "note: docker network ${BANK_FEED_NETWORK} not found — deploying WITHOUT"
+  echo "      the Bank lane's network attachment. The lane will report its feed"
+  echo "      unreachable; everything else deploys normally. Re-run this script"
+  echo "      once the platform stack is up to reattach it."
+  echo
+fi
+
 # The volume the MCP servers actually run from, project-prefixed as Docker
 # names it. See the bundle-consumer restart at the end of this script.
 BUNDLE_VOLUME="${PROJECT}_avg-app"


### PR DESCRIPTION
The Bank lane's feed URL points at `agent-mainnet-backend:8787` — a name only the platform stack's private network resolves. On the VPS we proved the path with `docker network connect agent-mainnet-internal avg-slack-operator-1`. That works instantly and **decays on the next container recreate**: the lane reads fine today and silently stops after a deploy, with nothing in the tree recording that it was ever connected.

## What this does

`ops/compose.bank-feed.yml` declares `agent-mainnet-internal` as an external network and attaches it to `slack-operator` alongside `avg-internal`. The attachment now survives recreation because it is configuration, not a command someone typed once.

## Why it is a separate file and not `ops/compose.yml`

`external: true` is a hard start-time precondition. In the base compose, a missing `agent-mainnet-internal` would stop **the whole monitor stack** from coming up — including the board that exists to tell you the platform is down. A read-only display must not make its own availability depend on the network of the thing it watches.

So `ops/deploy-monitor.sh` adds the overlay only when `docker network inspect` finds the network, and prints why when it does not:

```
note: docker network agent-mainnet-internal not found — deploying WITHOUT
      the Bank lane's network attachment. The lane will report its feed
      unreachable; everything else deploys normally.
```

Absence costs one line of text on the board instead of the monitor. Same call #657 made for the Hermes health gate, and the same shape as the advisory skills sync directly below it.

## Why board → platform and never the reverse

Putting the money-rail backend onto `avg_avg-internal` would hand it reach to `avg-postgres`, `avg-cloudflared` and every task runner — a real widening of the platform's blast radius to make a display work. This direction adds one read-only consumer to a network the backend can already be reached from, and nothing else.

## Verification

- `compose config` merges to `{avg-internal, agent-mainnet-internal}` on `slack-operator`, with `avg-internal` intact and the external network resolving unprefixed to `agent-mainnet-internal`. Only that one service is attached.
- `config` **succeeds with the network absent**, which is why CI can validate the overlay on a runner that has no such network — added as a second validation step.
- Both branches of the deploy conditional exercised under `set -euo pipefail`; `bash -n` clean.

No TypeScript touched.

## Not in this PR

- Setting `PRODUCT_HEALTH_BANK_FEED_URL` and enabling `BANK_LANE_FEED_ENABLED` on the backend — operator steps, not code.
- The renderer gap I own: a *disabled but reachable* feed currently draws four "unreadable" rows where it should draw the single quiet line, like the cross-check's `not-configured`. Follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)