### PR TITLE
A switched-off Bank feed is one grey line, not an amber lane

### DIFF
--- a/packages/monitor-ui/src/components/ops/BankLane.test.tsx
+++ b/packages/monitor-ui/src/components/ops/BankLane.test.tsx
@@ -45,6 +45,18 @@ describe("a lane nobody wired occupies no board", () => {
     const { getByTestId } = render(<BankLane bank={{ unavailable: "bank feed unreachable — ECONNREFUSED" }} />);
     expect(getByTestId("ops-bank-absent").textContent).toContain("ECONNREFUSED");
   });
+
+  test("a switched-off feed lands here too — one grey line, and no coloured lane", () => {
+    // The live backend answers a disabled feed with a VALID payload whose four
+    // reads all carry `lastError: bank_lane_feed_disabled`. Rendered as a lane
+    // that was an amber BANK strip for a feature nobody had enabled; the server
+    // now collapses it to `unavailable`, and this is what that must look like.
+    const { getByTestId, queryByTestId } = render(
+      <BankLane bank={{ unavailable: "bank lane switched off at the source — BANK_LANE_FEED_ENABLED is not set" }} />,
+    );
+    expect(queryByTestId("ops-bank")).toBeNull(); // no lane ⇒ no lane tone
+    expect(getByTestId("ops-bank-absent").getAttribute("data-tone")).toBe("awaiting");
+  });
 });
 
 describe("the position tile states unverified rather than showing a zero", () => {

--- a/services/slack-operator/src/bank-feed.ts
+++ b/services/slack-operator/src/bank-feed.ts
@@ -128,6 +128,43 @@ export interface BankFeed {
   calibration?: PositionCalibration | null;
 }
 
+/**
+ * The producer's own word for "this feature is switched off here".
+ *
+ * Emitted verbatim by the backend's `disabledFeed()` on every read when
+ * `BANK_LANE_FEED_ENABLED` is not set, alongside `raw: null` and
+ * `source: "unconfigured:<field>"`. Observed live on 2026-08-04.
+ */
+export const BANK_FEED_DISABLED_SENTINEL = "bank_lane_feed_disabled";
+
+/**
+ * Is this an ENTIRELY switched-off feed, rather than a working one with broken
+ * instruments?
+ *
+ * The distinction is the whole point. A disabled feed is a valid payload full
+ * of read errors, which is shaped exactly like four failed reads — and rendered
+ * as such it produced an amber BANK lane for a feature nobody had turned on.
+ * That is the permanently-lit panel this board keeps removing: a false amber
+ * teaches an operator to ignore the real one just as reliably as a false red.
+ *
+ * The test is deliberately strict, and the strictness runs toward showing more
+ * rather than less. A PARTIALLY disabled feed — which today's producer cannot
+ * emit, and which is therefore the interesting case if it ever appears — does
+ * NOT collapse: it keeps its rows and its honest degraded tone, because a feed
+ * that half-works is a fault and hiding it behind "switched off" would be the
+ * false green on the other side of the same mistake.
+ */
+export function bankFeedIsDisabled(feed: BankFeed): boolean {
+  const reads = [feed.position, feed.float, feed.postage];
+  // Every balance read reports the producer's sentinel — not merely "an error".
+  if (!reads.every((r) => r.lastError === BANK_FEED_DISABLED_SENTINEL)) return false;
+  // And the request table is not claiming to have read anything. Checked
+  // separately, and NOT by its lastError: the alarm tile is the one place where
+  // assuming the disabled shape would let real in-flight requests disappear
+  // behind a "switched off" line.
+  return feed.requests.readAtMs === null && feed.requests.items.length === 0;
+}
+
 /** DOT below which the postage account can no longer pay for an epoch. */
 export const POSTAGE_FLOOR_DOT = 0.07;
 

--- a/services/slack-operator/src/bank-lane.ts
+++ b/services/slack-operator/src/bank-lane.ts
@@ -43,9 +43,22 @@ export interface BankLaneView {
   tone: BankTone;
 }
 
-/** Said once, quietly, when nothing is wired. Never four "awaiting" tiles. */
-export const BANK_FEED_ABSENT =
-  "bank lane not configured — no read-only observer feed for the wrapper";
+/**
+ * Said once, quietly, when the feed is reachable and switched off at the source.
+ *
+ * There is deliberately no matching constant for an ABSENT feed: nothing wired
+ * renders nothing at all, not a line about its own absence. (One existed, was
+ * never rendered, and its own doc comment claimed otherwise — removed with this
+ * change rather than left to mislead the next reader.)
+ *
+ * Switched-off is different, and gets a sentence, because someone configured
+ * PRODUCT_HEALTH_BANK_FEED_URL and is entitled to know why no lane appeared.
+ * It names the variable and the side it lives on, because "disabled" alone
+ * sends an operator to the wrong repo.
+ */
+export const BANK_FEED_DISABLED =
+  "bank lane switched off at the source — the backend's feed is reachable but " +
+  "BANK_LANE_FEED_ENABLED is not set";
 
 /**
  * A raw token amount as a human figure, or the honest reason there isn't one.

--- a/services/slack-operator/src/product-health.ts
+++ b/services/slack-operator/src/product-health.ts
@@ -40,7 +40,8 @@ import { bucketPayoutsByHour, isHistogramUnavailable, type PayoutHistogram } fro
 import { endpointHost, pinnedCompareRange, type CrossCheckView } from "./payout-crosscheck.js";
 import { burnBasisLabel, isBurnUnmeasurable, type MeasuredBurn } from "./gas-burn-rate.js";
 import { readBankFeed } from "./bank-feed-fetch.js";
-import { bankLaneView, BANK_FEED_ABSENT, type BankLaneView } from "./bank-lane.js";
+import { bankFeedIsDisabled } from "./bank-feed.js";
+import { bankLaneView, BANK_FEED_DISABLED, type BankLaneView } from "./bank-lane.js";
 import { createCrossCheckCache, type CrossCheckCache } from "./payout-crosscheck-cache.js";
 import { createGasSpendCache, type GasSpendCache, type GasSpendSnapshot, type GasUnreadable } from "./gas-spend-cache.js";
 import { alertProvenance, decideMoneyAlert } from "./money-alert.js";
@@ -2701,7 +2702,13 @@ export async function collectProductHealthProbes(
   // rather than forming its own — same rule as the ops verdict.
   const bankRead = await readBankFeed({ url: config.bankFeedUrl, fetchImpl });
   const bank: BankBlock | undefined = bankRead.feed
-    ? { lane: bankLaneView({ feed: bankRead.feed, nowMs: chainCtx.nowMs }) ?? undefined }
+    ? // A switched-off feed is a VALID payload full of read errors, shaped
+      // exactly like four broken instruments. Rendered as a lane it lit BANK
+      // amber for a feature nobody had enabled — so it collapses to the same
+      // one quiet line an absent feed gets, with its own sentence.
+      bankFeedIsDisabled(bankRead.feed)
+      ? { unavailable: BANK_FEED_DISABLED }
+      : { lane: bankLaneView({ feed: bankRead.feed, nowMs: chainCtx.nowMs }) ?? undefined }
     : bankRead.reason
       ? { unavailable: bankRead.reason }
       : undefined; // not configured — no lane at all, and no complaint

--- a/services/slack-operator/test/unit/bank-feed-disabled.test.ts
+++ b/services/slack-operator/test/unit/bank-feed-disabled.test.ts
@@ -1,0 +1,99 @@
+// A switched-off feed is not four broken instruments.
+//
+// The payload below is the REAL one, copied from the mainnet backend on
+// 2026-08-04 while BANK_LANE_FEED_ENABLED was unset:
+//
+//   {"position":{"raw":null,"source":"unconfigured:position","readAtMs":null,
+//     "lastError":"bank_lane_feed_disabled"}, "float":{…}, "postage":{…}}
+//
+// It parses cleanly — the contract holds — and every read carries an error,
+// which is shaped exactly like four instruments that failed. Rendered as a lane
+// it lit BANK amber for a feature nobody had turned on.
+
+import { describe, expect, test } from "vitest";
+
+import { BANK_FEED_DISABLED_SENTINEL, bankFeedIsDisabled, type BankFeed } from "../../src/bank-feed.js";
+import { bankLaneView } from "../../src/bank-lane.js";
+import { normalizeBankFeed } from "../../src/bank-feed-fetch.js";
+
+const NOW = 1_785_900_000_000;
+
+/** Byte-for-byte the disabled producer's shape. */
+const DISABLED_PAYLOAD = {
+  position: { raw: null, source: "unconfigured:position", readAtMs: null, lastError: "bank_lane_feed_disabled" },
+  float: { raw: null, source: "unconfigured:float", readAtMs: null, lastError: "bank_lane_feed_disabled" },
+  postage: { raw: null, source: "unconfigured:postage", readAtMs: null, lastError: "bank_lane_feed_disabled" },
+  requests: { items: [], readAtMs: null, lastError: "bank_lane_feed_disabled" },
+  calibration: null,
+};
+
+function disabledFeed(): BankFeed {
+  const read = normalizeBankFeed(DISABLED_PAYLOAD);
+  // If this ever fails, the contract broke — which is a different bug, and the
+  // test should say so rather than quietly test a hand-built object.
+  expect(read.reason).toBeUndefined();
+  return read.feed!;
+}
+
+describe("the real disabled payload", () => {
+  test("still parses — a switched-off feed is a VALID feed, not a malformed one", () => {
+    const feed = disabledFeed();
+    expect(feed.position.raw).toBeNull();
+    expect(feed.position.lastError).toBe(BANK_FEED_DISABLED_SENTINEL);
+  });
+
+  test("is recognised as disabled", () => {
+    expect(bankFeedIsDisabled(disabledFeed())).toBe(true);
+  });
+
+  test("WOULD have rendered an amber lane — this is the defect being fixed", () => {
+    // Kept deliberately: it documents why the collapse exists. bankLaneView is
+    // still correct on its own terms — four failed reads ARE degraded — which is
+    // exactly why the judgement has to happen before the lane is built.
+    const lane = bankLaneView({ feed: disabledFeed(), nowMs: NOW })!;
+    expect(lane.tone).toBe("degraded");
+    expect(lane.float.text).toContain("unreadable");
+    expect(lane.requests.text).toContain("request table unreadable");
+  });
+});
+
+describe("what must NOT collapse", () => {
+  test("one working read means the feed is live and its errors are real faults", () => {
+    // A partially-disabled feed is a fault, and calling it "switched off" would
+    // be the false green on the other side of the same mistake.
+    const feed = disabledFeed();
+    feed.float = { raw: "28463", source: "asset 22 · Tokens.accounts(convertedAccount)", readAtMs: NOW - 30_000 };
+    expect(bankFeedIsDisabled(feed)).toBe(false);
+  });
+
+  test("a DIFFERENT error on every read is an outage, not a switch", () => {
+    // Only the producer's own sentinel counts. "every read failed" is the
+    // signature of the platform being down, which must stay visible.
+    const feed = disabledFeed();
+    for (const key of ["position", "float", "postage"] as const) {
+      feed[key] = { ...feed[key], lastError: "ECONNREFUSED" };
+    }
+    expect(bankFeedIsDisabled(feed)).toBe(false);
+  });
+
+  test("requests in flight veto the collapse, whatever the balances say", () => {
+    // The request table is the stuck-pending alarm. If it is carrying rows,
+    // hiding the lane behind "switched off" would hide the one thing on it
+    // where doing nothing costs money.
+    const feed = disabledFeed();
+    feed.requests = {
+      items: [{ id: "req-4a1c", kind: "deposit", phase: "leg2-dispatched", ageSeconds: 900, overdue: true }],
+      readAtMs: NOW - 30_000,
+    };
+    expect(bankFeedIsDisabled(feed)).toBe(false);
+    expect(bankLaneView({ feed, nowMs: NOW })!.overdueRequestId).toBe("req-4a1c");
+  });
+
+  test("a request table that was genuinely read veto the collapse even when empty", () => {
+    // readAtMs set with zero items is a real "no requests in flight" — the
+    // producer is running. Collapsing that would drop a working lane.
+    const feed = disabledFeed();
+    feed.requests = { items: [], readAtMs: NOW - 30_000 };
+    expect(bankFeedIsDisabled(feed)).toBe(false);
+  });
+});


### PR DESCRIPTION
Found by reading the live payload, not by a test. The mainnet backend answers a disabled feed like this:

```json
{"position":{"raw":null,"source":"unconfigured:position","readAtMs":null,
  "lastError":"bank_lane_feed_disabled"}, "float":{…}, "postage":{…}}
```

That is a **valid** payload — the #924 contract holds end to end — and it is shaped exactly like four instruments that failed. The renderer treated it as such: position `unverified`, float and postage `unreadable`, request table `degraded` → an **amber BANK lane for a feature nobody had turned on**.

A false amber costs what a false red costs. It teaches an operator to ignore the lane, which is the mistake this board has already removed twice.

## The fix

`bankFeedIsDisabled()` recognises the producer's own sentinel, and the block collapses to `unavailable` — the same single quiet grey line an unreachable feed gets, with its own sentence:

> BANK — bank lane switched off at the source — the backend's feed is reachable but BANK_LANE_FEED_ENABLED is not set

A different sentence from the unreachable case on purpose: "nobody wired it", "it's turned off", and "it broke" send an operator to different repos and different variables.

## What must NOT collapse

The predicate is strict, and the strictness runs toward showing **more**:

| Case | Collapses? | Why |
|---|---|---|
| All four reads carry the sentinel, table never read | yes | genuinely switched off |
| One read working | no | a feed that half-works is a **fault** |
| A different error on every read (`ECONNREFUSED`) | no | that is the platform being **down** |
| Request table has rows | no | the stuck-pending **alarm** must never hide |
| Table read successfully, zero rows | no | producer is running; real "none in flight" |

Calling a fault "switched off" would be the false green on the other side of the same mistake.

## Also

Removes `BANK_FEED_ABSENT` — defined, imported once, never used, and its doc comment claimed absence renders that line when absence renders nothing at all. Left in place it would have misled the next reader about the very behaviour this PR is about.

## Verification

- The disabled payload in the new suite is the **live** one, copied from the backend on 2026-08-04, and is run through the real `normalizeBankFeed` rather than hand-built.
- One test deliberately keeps asserting the old amber lane, to document why the collapse has to happen *before* the lane is built — `bankLaneView` is still correct on its own terms.
- Typecheck clean; full suite **2632 passed**, 180 files.

## Consequence for the rollout

With this in, the order stops mattering: pointing Hermes at a still-disabled feed shows one honest grey line instead of a broken-looking lane. Pairs with #705 (the network attachment) but does not depend on it — separate branches off `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)