### PR TITLE
docs(int3): the first-send operator ceremony

### DIFF
--- a/docs/HARNESS_INT3_FIRST_SEND_CEREMONY.md
+++ b/docs/HARNESS_INT3_FIRST_SEND_CEREMONY.md
@@ -1,0 +1,197 @@
+# The first send — operator ceremony
+
+The first time this system opens a pull request on a repository outside itself.
+
+Everything below is read from the merged scripts, not from the work orders that
+specified them. Flags, environment variables, and exit codes were taken from
+`scripts/ops/int3d-build-packet.mjs` and `scripts/ops/int3c-send.mjs` at the
+commit this document lands on.
+
+**Nobody has run this end to end.** Each piece is tested and gated; the sequence
+is not. Expect to stop at a step and fix something. Stopping is the intended
+outcome of a first run, not a failure of it.
+
+Read `HARNESS_INT3B_CREDENTIAL_RUNBOOK.md` first. It owns the credential
+boundary; this document owns the sequence and does not restate it.
+
+## Before anything
+
+Two decisions, both yours, neither reversible by a later step:
+
+1. **The target repository.** One repository, and it should be one you would not
+   mind an unwanted commit landing on. Not this repository.
+2. **The credential owner** — whose GitHub App, and where its private key lives.
+
+Then, per the credential runbook: create the App, install it on exactly that one
+repository, and mint an installation access token. Selected-repository scope.
+Contents write, Pull requests write, and nothing else.
+
+## The shape: two shells, and why
+
+The builder reads the database. The sender holds the token. **Neither process may
+do both**, and the builder enforces it — `GITHUB_INSTALLATION_TOKEN` present in
+its environment is an immediate refusal with exit **65**, before it parses
+arguments or touches the store.
+
+So the ceremony runs in two terminals, and the split is the point:
+
+| | shell A — builder | shell B — sender |
+|---|---|---|
+| `DATABASE_URL` | set | not needed |
+| `GITHUB_INSTALLATION_TOKEN` | **must be absent** | set |
+| reaches | dispatcher DB, Harness, artifacts | GitHub |
+
+If you find yourself exporting the token in shell A to make something work, stop.
+That is the mistake the refusal exists to catch.
+
+## Step 1 — the authorization file
+
+From the token-issuance response, strip the token and save what remains:
+
+```json
+{
+  "identity": "<app>#installation-<id>",
+  "repositorySelection": "selected",
+  "permissions": {
+    "contents": "write",
+    "pullRequests": "write",
+    "extraWriteScopes": []
+  }
+}
+```
+
+The builder walks this file recursively and refuses on any key named `token` at
+any depth — exit **67**. It does not trust that you stripped it.
+
+`extraWriteScopes` must be empty. The sender requires it, and a non-empty list
+means the installation has authority the ceremony did not approve.
+
+## Step 2 — build the packet (shell A, no token)
+
+```bash
+node scripts/ops/int3d-build-packet.mjs \
+  --work-item <id> \
+  --repository-root <path> \
+  --base-ref <ref> \
+  --patch-artifact-root <path> \
+  --payload-artifact-root <path> \
+  --authorization ./authorization.json \
+  --out ./packet.json
+```
+
+Also reads `DATABASE_URL`, `HARNESS_BIN` (default `harness`),
+`HARNESS_DISPATCH_READ_TIMEOUT_MS`, `HALT_FILE` (default `/data/HALT`), and
+`HARNESS_REPOSITORY_HALT_FILE`.
+
+This reconstructs the handoff from durable inputs rather than reading a stored
+one — the handoff was never persisted. `verifiedAt` still comes from the Harness
+run's own timestamp, so it stays true however long afterwards you build.
+`generatedAt` is when you built it, which is what that field means.
+
+### If it refuses
+
+| exit | meaning |
+|---|---|
+| 64 | usage — a required flag is missing |
+| 65 | `GITHUB_INSTALLATION_TOKEN` is set — you are in the wrong shell |
+| 66 | authorization file is not valid JSON, or not an object |
+| 67 | authorization file contains a `token` key |
+| 68 | `--out` already exists — it will not overwrite |
+| 69 | no `AgentTask` for that work item |
+| 70 | run binding unavailable or inconsistent |
+| 71 | the bound run is not terminal |
+| 72 | task lifecycle is not `handoff_ready` |
+| 73 / 74 | global / repository HALT declared |
+
+**71 and 72 are the interesting ones.** 71 means the run is still moving and
+reconstruction would describe a state that has since changed. 72 can also mean a
+*newer* task version exists that has not reached `handoff_ready` — the builder
+takes the highest version, so a re-approved task blocks shipping the old one's
+work. That is intended.
+
+## Step 3 — pre-flight (shell B, token set)
+
+```bash
+node scripts/ops/int3c-send.mjs preflight \
+  --handoff ./packet.json \
+  --repo <owner/name> \
+  --evidence ./preflight-evidence.json
+```
+
+This is a **live API call** against the real repository with the real token. It
+reads authorization, resolves the repository, looks up the deterministic head,
+reads the live base, and re-checks HALT. It cannot open a pull request — the
+module containing that operation is not loaded on this path.
+
+Expect `ready`, or `adoptable` if the exact PR already exists.
+
+## Step 4 — read the evidence, then stop
+
+Open `preflight-evidence.json` and check it by eye, not by exit code:
+
+- `repositorySelection` is `selected`
+- the repository is the one you chose, spelled the way you meant
+- `contents` and `pullRequests` are `write`, `extraWriteScopes` is `[]`
+- `liveBaseSha` matches what you expect the base branch to be
+- `derivedHeadRef` is the `harness/*` ref you expect
+
+This is the last point where nothing has happened yet. Everything before it is
+reversible by deleting a file.
+
+## Step 5 — the send
+
+```bash
+node scripts/ops/int3c-send.mjs send \
+  --handoff ./packet.json \
+  --repo <owner/name> \
+  --evidence ./send-evidence.json \
+  --confirm <owner/name>
+```
+
+`--confirm` must repeat `--repo` exactly, or exit **67**. It exists so that
+recalling the previous command and editing it cannot reach a send.
+
+**Run it once.** Do not loop, do not retry on a timeout, do not re-run because
+the output looked wrong. If the process dies after GitHub accepted the create,
+one re-run resolves it correctly: the sender finds the deterministic head, adopts
+the existing PR, and does not create a second one. That is a deliberate
+operator decision, not an automatic retry.
+
+### Sender exit codes
+
+| exit | meaning |
+|---|---|
+| 64 | usage |
+| 65 | packet invalid — includes canonical-bytes mismatch |
+| 66 | `GITHUB_INSTALLATION_TOKEN` absent or empty |
+| 67 | `--confirm` missing or not equal to `--repo` |
+| 68 | handoff not eligible for PR open |
+| 69 / 70 | global / repository HALT |
+| 71 | operation refused |
+| 72 | evidence could not be written |
+
+## Step 6 — record
+
+Keep both evidence files. `send-evidence.json` carries the PR number, head commit
+SHA, payload artifact hash, and confirmation that the remote head tree equals the
+payload's `treeSha`.
+
+Neither file contains the token. That is enforced by a test that runs the driver
+with a sentinel token and greps every output for it — and the test has been seen
+failing, so it is known to be capable of catching a leak.
+
+**Merging the PR is a human action.** The sender has no merge, close, comment,
+force-push, or branch-protection operation, and will not acquire one.
+
+## If something goes wrong
+
+Declare HALT first, then diagnose. `HALT_FILE` for global,
+`HARNESS_REPOSITORY_HALT_FILE` for one repository. Both are re-checked by the
+sender on every operation, including between pre-flight and send.
+
+Revocation is in the credential runbook §"Rotation and revocation". The short
+version: HALT, stop the sender, revoke the installation token, and keep HALT
+active until a fresh pre-flight passes.
+
+Preserve evidence rather than retrying. A failed first send that leaves a clear
+record is a better outcome than a successful second attempt that leaves none.


### PR DESCRIPTION
The sequence, now that the chain is complete.

Every flag, environment variable, and exit code is read out of the merged `int3d-build-packet.mjs` and `int3c-send.mjs` — not from the work orders that specified them. Twice this stretch I described the ceremony from what I intended the scripts to do, and both times the gap was in something I assumed rather than checked.

## Two shells, and the split is the point

| | shell A — builder | shell B — sender |
|---|---|---|
| `DATABASE_URL` | set | not needed |
| `GITHUB_INSTALLATION_TOKEN` | **must be absent** | set |
| reaches | dispatcher DB, Harness, artifacts | GitHub |

The builder refuses with exit 65 if the token is in its environment, before parsing arguments or touching the store. If you find yourself exporting the token in shell A to make something work, that's the mistake the refusal exists to catch.

## What it says that a normal runbook wouldn't

**Nobody has run this end to end.** Each piece is tested and gated; the sequence is not. Stopping at a step is the expected outcome of a first run, not a failure of it.

**Step 4 is "read the evidence, then stop."** Exit code 0 is not the check — the check is reading `repositorySelection`, the repository spelling, the permission set, the live base SHA, and the derived head by eye. It's the last point where nothing has happened and everything is undone by deleting a file.

**Run the send once.** No loop, no retry on timeout, no re-run because the output looked odd. A process death after GitHub accepted the create is resolved by one deliberate re-run that adopts the existing PR — an operator decision, not an automatic retry.

**Exit 71 and 72 from the builder get explained rather than listed.** 71 means the run is still moving and reconstruction would describe a state that has since changed. 72 can also mean a *newer* task version exists — the builder takes the highest, so a re-approved task blocks shipping the old one's work.

Docs-only. Does not authorise the send.

🤖 Generated with [Claude Code](https://claude.com/claude-code)