### PR TITLE
docs(int3): add Step 0, and record what the ceremony has actually been run against

### DIFF
--- a/docs/HARNESS_INT3_FIRST_SEND_CEREMONY.md
+++ b/docs/HARNESS_INT3_FIRST_SEND_CEREMONY.md
@@ -11,6 +11,19 @@ commit this document lands on.
 is not. Expect to stop at a step and fix something. Stopping is the intended
 outcome of a first run, not a failure of it.
 
+What *has* been executed against the real scripts, on 2026-08-04:
+
+| checked | result |
+|---|---|
+| builder refuses a token in its environment | `INT3D_TOKEN_ENVIRONMENT_REFUSED`, exit **65** as documented |
+| builder refuses missing flags | `INT3D_USAGE`, exit **64** as documented |
+| builder refuses a `token` key nested in the authorization file | `INT3D_AUTHORIZATION_CONTAINS_TOKEN`, exit **67** as documented |
+| that refusal does not echo the offending value | sentinel nested three deep, **0 occurrences** in output |
+
+Nothing past that. Everything from Step 2 onward — the store read, the Harness
+read, reconstruction, and the whole of shell B — is unexercised outside its
+tests.
+
 Read `HARNESS_INT3B_CREDENTIAL_RUNBOOK.md` first. It owns the credential
 boundary; this document owns the sequence and does not restate it.
 
@@ -43,6 +56,38 @@ So the ceremony runs in two terminals, and the split is the point:
 
 If you find yourself exporting the token in shell A to make something work, stop.
 That is the mistake the refusal exists to catch.
+
+## Step 0 — build, and prove the build
+
+Both scripts import from the workspace packages' `dist/`. Build before anything
+else:
+
+```bash
+npm run typecheck
+```
+
+**If that fails on a clean checkout** with errors like `Module '"@avg/mcp-common"'
+has no exported member 'query'`, the incremental build state is stale — not the
+code. `tsc -b` reads `.tsbuildinfo`, concludes a package is current, and leaves
+`dist/` partially emitted. The symptom downstream is an `ERR_MODULE_NOT_FOUND`
+naming a file that plainly exists in `src/`. This happened on a clean `main` on
+2026-08-04; CI never sees it because CI always builds from scratch.
+
+```bash
+npx tsc -b --clean packages/* services/*
+find . -maxdepth 3 -name "*.tsbuildinfo" -not -path "./node_modules/*" -delete
+npm run typecheck
+```
+
+Then prove the toolchain actually works, using a refusal that costs nothing:
+
+```bash
+node scripts/ops/int3d-build-packet.mjs
+```
+
+Expect `INT3D_USAGE` and exit **64**. A module-resolution stack trace instead
+means the build is still wrong, and you want to know that now rather than in
+shell B with a live token.
 
 ## Step 1 — the authorization file
 


### PR DESCRIPTION
Two additions to the first-send ceremony, both from trying to run part of it today.

## Step 0 — a real operator trap

`npm run typecheck` **failed on a clean checkout of `main`**:

```
packages/averray-mcp/src/agent-task-store.ts(1,10): error TS2305:
  Module '"@avg/mcp-common"' has no exported member 'query'.
```

`tsc -b` had read a stale `.tsbuildinfo`, concluded `mcp-common` was current, and left its `dist/` with two of its modules emitted. Downstream that surfaces as `ERR_MODULE_NOT_FOUND` naming a file that plainly exists in `src/` — which reads as a broken script rather than a broken build.

CI never sees this because CI always builds from scratch. An operator opening a checkout that has been sitting around hits it alone, at the start of a ceremony, with no reason to suspect the build.

Step 0 gives the clean-and-rebuild, then proves the toolchain with a refusal that costs nothing:

```bash
node scripts/ops/int3d-build-packet.mjs   # expect INT3D_USAGE, exit 64
```

A module-resolution stack trace instead means the build is still wrong — better known now than in shell B with a live token.

## Narrowing "nobody has run this"

The original claim was true but pessimistic. Three of the builder's refusals have now been executed against the real script:

| checked | result |
|---|---|
| token in the builder's environment | `INT3D_TOKEN_ENVIRONMENT_REFUSED`, exit **65** as documented |
| missing flags | `INT3D_USAGE`, exit **64** as documented |
| `token` key nested in the authorization file | `INT3D_AUTHORIZATION_CONTAINS_TOKEN`, exit **67** as documented |
| that refusal does not echo the value | sentinel nested three deep, **0 occurrences** in output |

Everything from Step 2 onward is still unexercised outside its tests, and the doc now says exactly that rather than leaving the reader to guess where the verified part ends.

The step-2 dry run I proposed turned out not to be free: the dispatcher database was torn down after the paid ceremony, so running the builder against `ceremony-paid-glm-20260802-004` needs the whole environment stood back up.

Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)