### PR TITLE
docs(int3): say that every ceremony command runs from the repository root

### DIFF
--- a/docs/HARNESS_INT3_FIRST_SEND_CEREMONY.md
+++ b/docs/HARNESS_INT3_FIRST_SEND_CEREMONY.md
@@ -59,6 +59,15 @@ That is the mistake the refusal exists to catch.
 
 ## Step 0 — build, and prove the build
 
+**Every command in this document runs from the repository root.** Both shells,
+every step. A fresh terminal opens in your home directory, where the first
+command fails with `Cannot find module '/Users/you/scripts/ops/…'` — which looks
+like a missing script and is only a missing `cd`.
+
+```bash
+cd /path/to/averray-reference-agent
+```
+
 Both scripts import from the workspace packages' `dist/`. Build before anything
 else:
 


### PR DESCRIPTION
Step 0 failed on its first real use, in the way it was written to prevent.

Run from a fresh terminal — which opens in the home directory:

```
$ node scripts/ops/int3d-build-packet.mjs
Error: Cannot find module '/Users/pascalkuriger/scripts/ops/int3d-build-packet.mjs'
```

That reads as a missing script. It's a missing `cd`.

Step 0's entire job is to separate *"your build is stale"* from *"the tooling is fine"* before the operator reaches a live token. A repo-relative path with no stated working directory produces a third failure mode that looks like the first one, which is worse than not having the step.

Now states it once, up front, for both shells and every step.

Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)