### PR TITLE
test(int3c): assert the token is absent from refusal-path output

### DIFF
--- a/test/integration/int3c-operator-driver.test.ts
+++ b/test/integration/int3c-operator-driver.test.ts
@@ -213,6 +213,8 @@ describe.sequential("INT-3c operator driver", () => {
 
     expect(exitCode).toBe(testCase.expectedExit());
     expect(output.stderr.text).toContain(testCase.expectedMessage);
+    expect(output.stderr.text).not.toContain(TOKEN_SENTINEL);
+    expect(output.stdout.text).not.toContain(TOKEN_SENTINEL);
     expect(fakeGitHub.remoteCalls).toBe(0);
     await expect(readFile(evidencePath, "utf8")).rejects.toMatchObject({
       code: "ENOENT",


### PR DESCRIPTION
Closes #700. Two lines, test-only.

**Published on the implementer's behalf** — the branch was never pushed. Commit `78b4078` is theirs, unmodified, and the SHA matches what the handback stated.

```diff
     expect(output.stderr.text).toContain(testCase.expectedMessage);
+    expect(output.stderr.text).not.toContain(TOKEN_SENTINEL);
+    expect(output.stdout.text).not.toContain(TOKEN_SENTINEL);
     expect(fakeGitHub.remoteCalls).toBe(0);
```

The six parameterized refusal cases already ran with the sentinel token in the environment and asserted stderr *content*; they never asserted the sentinel was *absent*. Error paths are where a credential most plausibly surfaces.

## The demonstration

Writing the token to stderr on a refusal path makes the new assertion fire:

```
× refuses 'mismatched confirmation' before any GitHub call
  expected 'INT3C_CONFIRMATION_REQUIRED: --confir…'
    not to contain 'INT3C_TEST_TOKEN_SENTINEL_DO_NOT_USE'

 ❯ test/integration/int3c-operator-driver.test.ts:219:36
```

Line 219 — the stderr assertion, not the `toContain` above it. So it is genuinely load-bearing on these paths, which is what the issue was uncertain about.

## On the stdout line

Refusal paths write nothing to stdout today, so line 220 is unexercised. It is not vacuous, though, and the distinction matters: nothing asserts stdout is empty here, so a future change that writes the token there would trip it. That is unlike the success path, where `expect(stderr.text).toBe("")` sits two lines above the sentinel check and would catch a leak first — making the sentinel check there genuinely redundant.

## Worth recording

The implementer's first attempt used a Vitest title filter that silently matched nothing, because the parameterized labels contain quotes. The case was skipped, and a skipped case in that output reads much like a passing one. They caught it, rejected the run as evidence, and re-ran executing the case.

That is the exact failure class this whole effort keeps finding — a probe too narrow to match, whose miss is indistinguishable from success. Catching it in your own evidence before submitting it is the behaviour worth keeping.

Verified independently: 8/8 at `78b4078` on a detached checkout.