### PR TITLE
A reading can be fresh, sourced, persisted — and about the wrong subject

### DIFF
--- a/packages/monitor-ui/src/components/ops/BankLane.test.tsx
+++ b/packages/monitor-ui/src/components/ops/BankLane.test.tsx
@@ -59,6 +59,37 @@ describe("a lane nobody wired occupies no board", () => {
   });
 });
 
+describe("the subject sits above the numbers it qualifies", () => {
+  test("a stale subject renders, and carries its own red tone", () => {
+    // 2026-08-04: four fresh, correctly-sourced, green tiles describing a
+    // wrapper retired that morning. A reader who took in the float and stopped
+    // had still read the wrong thing, so this line goes ABOVE the rows.
+    const { getByTestId } = render(
+      <BankLane
+        bank={lane({
+          subject: { text: "STALE SUBJECT — these read 0x8d1a…, the manifest declares 0x2AF3…", tone: "red" },
+        })}
+      />,
+    );
+    const subject = getByTestId("ops-bank-subject");
+    expect(subject.textContent).toContain("STALE SUBJECT");
+    expect(subject.getAttribute("data-tone")).toBe("red");
+    // Document order, not merely presence: a warning below the numbers it
+    // invalidates is a warning the reader meets too late.
+    expect(subject.compareDocumentPosition(getByTestId("ops-bank-position"))).toBe(
+      Node.DOCUMENT_POSITION_FOLLOWING,
+    );
+  });
+
+  test("a payload without the field still renders the lane", () => {
+    // Optional on the wire so a board deployed ahead of the monitor that fills
+    // it in does not crash on a payload that predates it.
+    const { queryByTestId, getByTestId } = render(<BankLane bank={lane()} />);
+    expect(queryByTestId("ops-bank-subject")).toBeNull();
+    expect(getByTestId("ops-bank-float")).toBeTruthy();
+  });
+});
+
 describe("the position tile states unverified rather than showing a zero", () => {
   test("an uncalibrated zero reads UNVERIFIED and stays warm grey", () => {
     const { getByTestId } = render(<BankLane bank={lane()} />);

--- a/packages/monitor-ui/src/components/ops/BankLane.tsx
+++ b/packages/monitor-ui/src/components/ops/BankLane.tsx
@@ -51,6 +51,16 @@ export function BankLane({ bank }: BankLaneProps) {
         ) : null}
       </div>
 
+      {/* WHAT these readings are about, above every number rather than beside
+          one. On 2026-08-04 this lane showed four fresh, correctly-sourced,
+          green tiles describing a wrapper retired that morning; a reader who
+          took in the float and stopped had still read the wrong thing. */}
+      {lane.subject ? (
+        <p className="ops-bank-subject" data-tone={lane.subject.tone} data-testid="ops-bank-subject">
+          {lane.subject.text}
+        </p>
+      ) : null}
+
       <dl className="ops-bank-rows">
         {/* POSITION carries a status word rather than only a number, because
             "unverified" is a real state here: a zero from a read path that has

--- a/packages/monitor-ui/src/lib/monitor/ops-fixtures.ts
+++ b/packages/monitor-ui/src/lib/monitor/ops-fixtures.ts
@@ -303,6 +303,7 @@ export const OPS_FIXTURE_NOMINAL: ProductHealth = {
       postage: { text: "1.51 DOT · 15,100,000,000 raw · committed postage, no withdraw path", tone: "ok" as const },
       requests: { text: "no requests in flight", tone: "ok" as const },
       overdueRequestId: null,
+      subject: { text: "subject bank-xcm-v2.1 — matches the deployment manifest", tone: "ok" as const },
       tone: "degraded" as const,
     },
   },

--- a/packages/monitor-ui/src/lib/monitor/product-health.ts
+++ b/packages/monitor-ui/src/lib/monitor/product-health.ts
@@ -254,6 +254,15 @@ export interface BankLaneView {
   postage: BankLine;
   requests: BankLine;
   overdueRequestId: string | null;
+  /**
+   * Which deployment generation every value below describes.
+   *
+   * Optional here and only here: a board deployed ahead of the monitor that
+   * renders it must not crash on a payload without the field. It is NOT
+   * optional in the view-model — the server always decides a subject line, and
+   * "cannot confirm" is one of its answers.
+   */
+  subject?: BankLine;
   tone: "ok" | "degraded" | "red" | "awaiting";
 }
 

--- a/packages/monitor-ui/src/styles/hermes4-ops.css
+++ b/packages/monitor-ui/src/styles/hermes4-ops.css
@@ -927,6 +927,24 @@ body,
   font-size: calc(11 * var(--ops-u));
   color: var(--tone, var(--h4-act));
 }
+/* WHAT the values below describe. Above the rows because it qualifies all of
+   them: on a stale subject every number underneath is a real reading of the
+   wrong address, and a reader who takes in the float and stops has still read
+   the wrong thing. */
+.ops-bank-subject {
+  margin: 0 0 calc(6 * var(--ops-u));
+  font-family: var(--h4-font-mono);
+  font-size: calc(10 * var(--ops-u));
+  line-height: 1.45;
+  color: var(--tone, var(--h4-tel));
+}
+/* A retired generation is the one state that invalidates the entire lane, so it
+   gets a rule of its own and not only a colour. The border does NOT scale —
+   same rule as every other hairline on this board. */
+.ops-bank-subject[data-tone="red"] {
+  padding-left: calc(8 * var(--ops-u));
+  border-left: 2px solid var(--h4-act);
+}
 .ops-bank-rows {
   display: grid;
   gap: calc(2 * var(--ops-u));

--- a/services/slack-operator/src/bank-feed-fetch.ts
+++ b/services/slack-operator/src/bank-feed-fetch.ts
@@ -21,7 +21,7 @@
 // and the board stays quiet. Only a CONFIGURED feed that fails is a problem
 // worth a line on screen.
 
-import type { BankFeed, BankRequest, BankRequests, SourcedRead } from "./bank-feed.js";
+import type { BankFeed, BankRequest, BankRequests, BankSubject, SourcedRead } from "./bank-feed.js";
 
 export interface BankFeedRead {
   feed?: BankFeed;
@@ -74,6 +74,7 @@ export function normalizeBankFeed(body: unknown): BankFeedRead {
   if ("reason" in requests) return requests;
 
   const calibration = calibrationRecord(b.calibration);
+  const subject = subjectRecord(b.subject);
   return {
     feed: {
       position: position.read,
@@ -81,7 +82,32 @@ export function normalizeBankFeed(body: unknown): BankFeedRead {
       postage: postage.read,
       requests: requests.requests,
       ...(calibration ? { calibration } : {}),
+      ...(subject ? { subject } : {}),
     },
+  };
+}
+
+/**
+ * A malformed subject is dropped, never guessed at.
+ *
+ * Dropping it costs the lane's visible "cannot confirm which generation" line,
+ * and it self-corrects on the next good read. Inventing either half would be
+ * worse in both directions: a fabricated match is exactly the confident green
+ * about an abandoned account this field exists to prevent, and a fabricated
+ * mismatch is a RED that stops a lane which is actually fine.
+ *
+ * Both halves are required together — a subject that names only what it read,
+ * with nothing to compare against, cannot answer the one question it is for.
+ */
+function subjectRecord(raw: unknown): BankSubject | undefined {
+  if (!raw || typeof raw !== "object") return undefined;
+  const s = raw as Record<string, unknown>;
+  if (typeof s.derivedFrom !== "string" || !s.derivedFrom.trim()) return undefined;
+  if (typeof s.declared !== "string" || !s.declared.trim()) return undefined;
+  return {
+    derivedFrom: s.derivedFrom,
+    declared: s.declared,
+    ...(typeof s.label === "string" && s.label ? { label: s.label } : {}),
   };
 }
 

--- a/services/slack-operator/src/bank-feed.ts
+++ b/services/slack-operator/src/bank-feed.ts
@@ -99,6 +99,46 @@ export interface BankRequests {
   lastError?: string | null;
 }
 
+/**
+ * WHICH DEPLOYMENT GENERATION THESE READINGS ARE ABOUT.
+ *
+ * On 2026-08-04 this lane's first live values were reads of a wrapper retired
+ * that same morning: float 149,412 at the RETIRED converted account while the
+ * live one held 149,475 with a request in flight, postage from the old wrapper
+ * image, and an empty request table because the observer had never seen the
+ * live wrapper. Every reading was fresh, correctly sourced and honestly
+ * rendered — and about the wrong subject. The redeploy never propagated to the
+ * feed's env or to the manifest.
+ *
+ * Nothing on this lane could have caught it. `readAtMs` guards staleness in
+ * TIME, `calibration` guards an unproven read path, shape validation guards
+ * network drift. None of them ask whether the address being read is still the
+ * one that matters — and a confident green tile about an abandoned account is a
+ * worse lie than any of the ones those guards prevent.
+ *
+ * The two fields come from DIFFERENT places on purpose: `derivedFrom` from the
+ * env the reads actually used, `declared` from the deployment manifest. A
+ * producer that computed both from one source would agree with itself forever,
+ * which is precisely the failure this exists to detect.
+ */
+export interface BankSubject {
+  /** The wrapper generation the feed's ENV targets belong to. */
+  derivedFrom: string;
+  /** The wrapper generation `deployments/<profile>.json` declares current. */
+  declared: string;
+  /** Human label for the declared generation, e.g. "bank-xcm-v2.1". */
+  label?: string | null;
+}
+
+/** Do the readings describe the generation the manifest says is live? */
+export function bankSubjectIsCurrent(subject: BankSubject): boolean {
+  // Case-insensitive: these are hex addresses, and EIP-55 checksum casing
+  // differs between a manifest written by a deploy script and an env var typed
+  // by a human. Casing is not a retarget, and reporting it as one would make
+  // this the false alarm it exists to avoid being.
+  return subject.derivedFrom.trim().toLowerCase() === subject.declared.trim().toLowerCase();
+}
+
 export interface BankFeed {
   /** aToken position — `balanceOf(truncate20(convertedAccount))`. */
   position: SourcedRead;
@@ -126,6 +166,14 @@ export interface BankFeed {
    * projecting after a restart.
    */
   calibration?: PositionCalibration | null;
+  /**
+   * Which generation these readings describe. See BankSubject.
+   *
+   * Optional because the producer may not send it yet. Absent is NOT treated as
+   * agreement — the lane says it cannot confirm the subject, which is the
+   * honest reading of silence and the exact thing whose absence cost a morning.
+   */
+  subject?: BankSubject | null;
 }
 
 /**

--- a/services/slack-operator/src/bank-lane.ts
+++ b/services/slack-operator/src/bank-lane.ts
@@ -16,6 +16,7 @@
 import {
   PLANCK_PER_DOT,
   POSTAGE_FLOOR_DOT,
+  bankSubjectIsCurrent,
   isKnownPhase,
   type BankFeed,
   type BankRequest,
@@ -39,6 +40,14 @@ export interface BankLaneView {
   requests: BankLine;
   /** Names the request driving a degraded verdict, or null. */
   overdueRequestId: string | null;
+  /**
+   * WHAT these readings are about, rendered above them.
+   *
+   * Hoisted to the top of the lane rather than tucked beside a tile, because it
+   * qualifies every number below it. A reader who takes in the float and stops
+   * has still read the wrong thing.
+   */
+  subject: BankLine;
   /** The lane's contribution to the ops verdict. */
   tone: BankTone;
 }
@@ -168,15 +177,37 @@ export function bankLaneView(input: {
     staleAfterMs: stale,
   });
 
-  const float = amount(feed.float, 6, "USDC", nowMs, stale);
-  const postage = postageLine(feed.postage, nowMs, stale, input.postageFloorDot ?? POSTAGE_FLOOR_DOT);
-  const requests = requestLine(feed.requests, nowMs, stale);
+  const subject = subjectLine(feed);
+  const staleSubject = subject.tone === "red";
+
+  // On a stale subject every value below is a real reading of the wrong
+  // address, so none of them may render `ok`. Their numbers are kept — the
+  // retired account's dust is a real balance somebody has to reconcile — but a
+  // green tile would say "the bank is fine" about an account the bank left.
+  const demote = (line: BankLine): BankLine =>
+    staleSubject && line.tone === "ok" ? { ...line, tone: "degraded" } : line;
+
+  const float = demote(amount(feed.float, 6, "USDC", nowMs, stale));
+  const postage = demote(postageLine(feed.postage, nowMs, stale, input.postageFloorDot ?? POSTAGE_FLOOR_DOT));
+  const requests = demote(requestLine(feed.requests, nowMs, stale));
   const overdue = feed.requests.items.find((r) => r.overdue) ?? null;
 
   // The lane's verdict. An overdue request or an unusable position read are the
   // two states worth a degraded pillar — the rest is display.
+  //
+  // A stale subject is RED, above both. An overdue request costs money while
+  // you watch it; a stale subject means you are not watching at all, and the
+  // empty request table proves the point — it read "no requests in flight" as
+  // an all-clear while a real one sat staged on the live wrapper.
+  // An UNDECLARED subject deliberately does NOT move this. It is stated on the
+  // lane and left there: until the producer ships the field it is true of every
+  // healthy lane, so degrading on it would light the strip permanently amber
+  // for "the other service has not been upgraded yet" — the panel nobody reads,
+  // which is the failure this board keeps deleting. Position-unverified earns
+  // its degrade because it is temporary and resolves on the next dust cycle;
+  // a missing producer capability does not.
   const tone: BankTone =
-    overdue || postage.tone === "red"
+    staleSubject || overdue || postage.tone === "red"
       ? "red"
       : position.status === "unverified" ||
           float.tone === "degraded" ||
@@ -185,7 +216,43 @@ export function bankLaneView(input: {
         ? "degraded"
         : "ok";
 
-  return { position, float, postage, requests, overdueRequestId: overdue?.id ?? null, tone };
+  return { position, float, postage, requests, subject, overdueRequestId: overdue?.id ?? null, tone };
+}
+
+/**
+ * What generation these readings describe.
+ *
+ * Silence is NOT agreement. A producer that does not declare its subject gets
+ * an explicit "cannot confirm" rather than a blank, because the morning this
+ * check exists for looked exactly like a lane with nothing to say — every tile
+ * fresh, sourced and green, about a wrapper that had been retired hours
+ * earlier. Same rule as the payout cross-check's `not-configured`: an
+ * instrument that cannot see says so.
+ */
+function subjectLine(feed: BankFeed): BankLine {
+  const subject = feed.subject ?? null;
+  if (!subject) {
+    return {
+      text: "subject not declared by the feed — cannot confirm which wrapper generation these read",
+      tone: "awaiting",
+    };
+  }
+  if (!bankSubjectIsCurrent(subject)) {
+    // Both addresses in full. Shortened, two generations of the same deploy
+    // script can share a prefix and a suffix, and the one line whose entire job
+    // is telling them apart would be the line that hid the difference.
+    return {
+      text:
+        `STALE SUBJECT — these read ${subject.derivedFrom}, ` +
+        `the manifest declares ${subject.declared}${subject.label ? ` (${subject.label})` : ""}. ` +
+        "Every value below is a real reading of the retired generation.",
+      tone: "red",
+    };
+  }
+  return {
+    text: `subject ${subject.label ?? shortSource(subject.declared)} — matches the deployment manifest`,
+    tone: "ok",
+  };
 }
 
 /**

--- a/services/slack-operator/test/unit/bank-subject.test.ts
+++ b/services/slack-operator/test/unit/bank-subject.test.ts
@@ -1,0 +1,173 @@
+// A reading can be fresh, sourced, persisted — and about the wrong subject.
+//
+// 2026-08-04: the BANK lane's first live values were reads of a wrapper retired
+// that morning. float 149,412 at the RETIRED converted account while the live
+// one held 149,475 with a request staged for leg 2; postage from the old
+// wrapper image; an empty request table because the observer had never seen the
+// live wrapper. Every tile was fresh, correctly sourced and honestly rendered.
+//
+// Two checks were run against the request tile at the time and BOTH passed:
+// readAtMs was recent, and the state was Redis-backed so it had survived the
+// restart. Freshness and persistence. Neither asks WHAT was read, so two sound
+// checks produced a false all-clear on the stuck-pending alarm.
+
+import { describe, expect, test } from "vitest";
+
+import { bankSubjectIsCurrent, type BankFeed } from "../../src/bank-feed.js";
+import { bankLaneView } from "../../src/bank-lane.js";
+import { normalizeBankFeed } from "../../src/bank-feed-fetch.js";
+
+const NOW = 1_785_900_000_000;
+const V21 = "0x2AF394fA95f75D3ca1C786128f4dfA1eB0c9675D";
+const V20 = "0x8d1a1De9F5C4C8b4C0eB1a3f2D9a7B6c5E4d3C2b";
+
+/** The retired generation's numbers, exactly as the board showed them. */
+const feed = (over: Partial<BankFeed> = {}): BankFeed => ({
+  position: { raw: "0", source: "erc20:0x2ec4…fa93.balanceOf(0x98f0…b68e)", readAtMs: NOW - 30_000 },
+  float: { raw: "149412", source: "substrate_tokens:22", readAtMs: NOW - 30_000 },
+  postage: { raw: "14794550000", source: "substrate_system:15Xbeap…", readAtMs: NOW - 30_000 },
+  requests: { items: [], readAtMs: NOW - 30_000 },
+  ...over,
+});
+
+describe("the subject line is decided, never blank", () => {
+  test("silence is NOT agreement — an undeclared subject says so out loud", () => {
+    // The morning this exists for looked exactly like a lane with nothing to
+    // say. A producer that does not declare its subject gets an explicit
+    // "cannot confirm", not an empty space that reads as fine.
+    const v = bankLaneView({ feed: feed(), nowMs: NOW })!;
+    expect(v.subject.text).toContain("cannot confirm which wrapper generation");
+    // Awaiting, not red: not knowing is not the same as knowing it is wrong.
+    expect(v.subject.tone).toBe("awaiting");
+  });
+
+  test("...but it must NOT degrade the lane, or every healthy lane goes amber", () => {
+    // Caught by an existing test rather than by design: the first cut degraded
+    // on an undeclared subject, which is true of EVERY lane until the producer
+    // ships the field — a permanently-lit strip for "the other service has not
+    // been upgraded yet". Position-unverified earns its degrade because it is
+    // temporary and resolves on the next dust cycle. A missing producer
+    // capability does not.
+    const v = bankLaneView({
+      feed: feed({
+        calibration: {
+          provenAtMs: NOW - 86_400_000,
+          provenRaw: "100000",
+          provenSource: "erc20:0x2ec4…fa93.balanceOf(0x98f0…b68e)",
+        },
+      }),
+      nowMs: NOW,
+    })!;
+    expect(v.subject.tone).toBe("awaiting");
+    expect(v.tone).toBe("ok");
+  });
+
+  test("a matching subject is stated plainly, and costs the lane nothing", () => {
+    const v = bankLaneView({
+      feed: feed({ subject: { derivedFrom: V21, declared: V21, label: "bank-xcm-v2.1" } }),
+      nowMs: NOW,
+    })!;
+    expect(v.subject.tone).toBe("ok");
+    expect(v.subject.text).toContain("bank-xcm-v2.1");
+    expect(v.float.tone).toBe("ok");
+  });
+});
+
+describe("a stale subject invalidates every value below it", () => {
+  const stale = () =>
+    bankLaneView({
+      feed: feed({ subject: { derivedFrom: V20, declared: V21, label: "bank-xcm-v2.1" } }),
+      nowMs: NOW,
+    })!;
+
+  test("the lane goes RED — above an overdue request, not below it", () => {
+    // An overdue request costs money while you watch it. A stale subject means
+    // you are not watching at all, and the empty request table is the proof:
+    // it read as an all-clear while a real request sat staged on the live
+    // wrapper. Being blind outranks seeing something bad.
+    expect(stale().tone).toBe("red");
+  });
+
+  test("no value tile may render ok — a green float about an abandoned account is the lie", () => {
+    const v = stale();
+    for (const line of [v.float, v.postage, v.requests]) {
+      expect(line.tone).not.toBe("ok");
+    }
+  });
+
+  test("but the numbers are KEPT, because the retired account's dust is real money", () => {
+    // Withholding them would lose a balance somebody still has to reconcile.
+    // The fix is to say what they are about, not to hide them.
+    const v = stale();
+    expect(v.float.text).toContain("149,412 raw");
+    expect(v.postage.text).toContain("14,794,550,000 raw");
+  });
+
+  test("both addresses render IN FULL", () => {
+    // Two generations of the same deploy script can share a prefix and a
+    // suffix. The one line whose entire job is telling them apart must not be
+    // the line that elides the difference.
+    const v = stale();
+    expect(v.subject.text).toContain(V20);
+    expect(v.subject.text).toContain(V21);
+  });
+
+  test("a real overdue request still names itself — the alarm is not swallowed", () => {
+    const v = bankLaneView({
+      feed: feed({
+        subject: { derivedFrom: V20, declared: V21 },
+        requests: {
+          items: [{ id: "req-9c2f", kind: "deposit", phase: "leg2-dispatched", ageSeconds: 3600, overdue: true }],
+          readAtMs: NOW - 30_000,
+        },
+      }),
+      nowMs: NOW,
+    })!;
+    expect(v.overdueRequestId).toBe("req-9c2f");
+    expect(v.tone).toBe("red");
+  });
+});
+
+describe("checksum casing is not a retarget", () => {
+  test("the same address in different EIP-55 casing agrees", () => {
+    // A manifest written by a deploy script and an env var typed by a human
+    // differ in casing routinely. Reporting that as a stale subject would make
+    // this the false alarm it exists to prevent being.
+    expect(bankSubjectIsCurrent({ derivedFrom: V21.toLowerCase(), declared: V21.toUpperCase() })).toBe(true);
+    expect(bankSubjectIsCurrent({ derivedFrom: ` ${V21} `, declared: V21 })).toBe(true);
+  });
+
+  test("genuinely different addresses disagree", () => {
+    expect(bankSubjectIsCurrent({ derivedFrom: V20, declared: V21 })).toBe(false);
+  });
+});
+
+describe("a malformed subject is dropped, never guessed at", () => {
+  const payload = {
+    position: { raw: "0", source: "erc20:x", readAtMs: NOW },
+    float: { raw: "149412", source: "substrate_tokens:22", readAtMs: NOW },
+    postage: { raw: "14794550000", source: "substrate_system:x", readAtMs: NOW },
+    requests: { items: [], readAtMs: NOW },
+  };
+
+  test("half a subject cannot answer the question, so it is discarded", () => {
+    // derivedFrom with nothing to compare against is not evidence of anything.
+    const r = normalizeBankFeed({ ...payload, subject: { derivedFrom: V21 } });
+    expect(r.feed).toBeDefined();
+    expect(r.feed!.subject ?? null).toBeNull();
+  });
+
+  test("dropping it costs the visible 'cannot confirm' line — the conservative direction", () => {
+    // Inventing a match would be the confident green about an abandoned
+    // account; inventing a mismatch would RED a lane that is fine.
+    const r = normalizeBankFeed({ ...payload, subject: { garbage: true } });
+    expect(r.feed!.subject ?? null).toBeNull();
+    expect(bankLaneView({ feed: r.feed!, nowMs: NOW })!.subject.tone).toBe("awaiting");
+  });
+
+  test("a good subject survives the network boundary intact", () => {
+    const r = normalizeBankFeed({ ...payload, subject: { derivedFrom: V20, declared: V21, label: "bank-xcm-v2.1" } });
+    expect(r.feed!.subject!.derivedFrom).toBe(V20);
+    expect(r.feed!.subject!.label).toBe("bank-xcm-v2.1");
+  });
+});


### PR DESCRIPTION
This morning the BANK lane's first live values were reads of a wrapper **retired that same morning**. `float` 149,412 at the *retired* converted account while the live one held 149,475 with a request staged for leg 2. `postage` from the old wrapper image. An empty request table, because the observer had never seen the live wrapper.

Every tile was fresh, correctly sourced, and honestly rendered. All of them were about the wrong thing.

## Why nothing caught it, including me

I ran two checks against that request tile and reported it trustworthy "on two independent grounds": `readAtMs` was recent, and the state was Redis-backed so it had survived the restart. **Freshness and persistence.** Neither asks *what* was read — so two sound checks produced a false all-clear on the stuck-pending alarm.

That gap is structural, not a slip:

| guard | protects against |
|---|---|
| `readAtMs` | staleness in **time** |
| `calibration` | an **unproven read path** |
| shape validation | **network** drift |
| — | *reading the right thing at the wrong address* |

A confident green tile about an abandoned account is a worse lie than any of the ones those guards prevent.

## `subject`

```jsonc
"subject": {
  "derivedFrom": "0x…",          // the wrapper the ENV targets belong to
  "declared":    "0x…",          // what deployments/<profile>.json declares
  "label": "bank-xcm-v2.1"       // optional
}
```

Two **different** sources on purpose. A producer computing both from one source would agree with itself forever, which is exactly the failure this detects.

## What a mismatch does

- **The lane goes RED** — above an overdue request, not below it. An overdue request costs money while you watch it; a stale subject means you are not watching at all. This morning's empty request table is the proof: it read as an all-clear while a real request sat staged on the live wrapper.
- **No value tile may render `ok`.** A green float about an abandoned account is the lie.
- **The numbers are kept.** The retired account's dust is real money somebody has to reconcile. The fix is to say what they are *about*, not to hide them.
- **Both addresses render in full** — two generations of one deploy script can share a prefix *and* a suffix, so the one line whose job is telling them apart must not elide the difference.

Undeclared is **stated**, not assumed: *"cannot confirm which wrapper generation these read."* Silence is not agreement — the morning this exists for looked exactly like a lane with nothing to say.

## An existing test caught me shipping the thing I keep deleting

The first cut degraded the lane on an *undeclared* subject. That is true of **every** lane until the producer ships the field — a permanently amber strip meaning "the other service has not been upgraded yet", which is the panel nobody reads. `bank-lane.test.ts` failed on it.

It now states itself and leaves the tone alone. Position-unverified earns its degrade because it resolves on the next dust cycle; a missing producer capability does not.

## Sequencing

Optional throughout, so this lands with **no producer change** and lights up when the field arrives — same shape as `calibration`. The producer side is a small addition to the platform's repoint work, where the observer's wrapper and the manifest are both already in hand.

## Verification

Typecheck clean. Full suite **2647 passed**, 181 files. New suite covers: the real 2026-08-04 numbers as the mismatch case, EIP-55 casing not counting as a retarget, a half-subject being dropped rather than guessed at, the overdue alarm surviving a red subject, and document order — the warning renders *above* the values it invalidates, because a warning below them is one the reader meets too late.

🤖 Generated with [Claude Code](https://claude.com/claude-code)