### PR TITLE
Make the Hermes upgrade cheap to abort, and correct the v0.19.1 root cause

### DIFF
--- a/docs/HERMES_UPGRADE_v019.md
+++ b/docs/HERMES_UPGRADE_v019.md
@@ -195,6 +195,27 @@ contract ABI: the artifact beats the description.
 
 ### 3.5.4 The opt-in was NECESSARY BUT NOT SUFFICIENT — verdict: WAIT
 
+> **⚠ CORRECTED 2026-08-04 — THE ROOT CAUSE BELOW IS WRONG. See
+> [HERMES_UPGRADE_v020.md §1](HERMES_UPGRADE_v020.md).**
+>
+> Both suspects were cleared by running the real config loader inside both
+> images with this repo's own `hermes/config/hermes.yaml` mounted:
+> `api_server` was always in `PORT_BINDING_PLATFORM_VALUES`, and `extra` always
+> resolved to `['host','key','port']` — **identically on v0.19.1 and v0.20.0**.
+> #75348 is about Baileys WhatsApp being *absent* from the allowlist and never
+> applied to us; #74505 concerns top-level YAML keys, while our key arrives via
+> env, which writes `extra` directly.
+>
+> The deciding check named below resolves to **present**, so the conclusion it
+> was meant to support does not follow. The failure is downstream of config, in
+> the adapter's `connect()` / bind.
+>
+> Left in place rather than deleted: it is an accurate record of what was
+> believed on 2026-07-31, and the black-box method is still worth reading. Only
+> the root cause and the "wait for upstream" conclusion are wrong — and a wrong
+> root cause left standing in a doc misdirects the next attempt, which this one
+> already did.
+
 With the `platforms:` block live and mounted (verified inside the container),
 `No messaging platforms enabled` **drops to 0** — the platform registers. But
 **8642 still never binds**, and the gateway log is silent: no error, no bind

--- a/docs/HERMES_UPGRADE_v020.md
+++ b/docs/HERMES_UPGRADE_v020.md
@@ -1,0 +1,142 @@
+# Hermes v0.18.0 → v0.20.0 — and why the v0.19.1 NO-GO was wrong
+
+Written 2026-08-04. Companion to `HERMES_UPGRADE_v018.md` / `v019.md`; same
+shape — upstream diffed against **what we actually use**, not a feature tour.
+
+## 0. Bottom line
+
+| | |
+|---|---|
+| Running | **v0.18.0** (`nousresearch/hermes-agent:v2026.7.1`), since 2026-07-02 |
+| Latest | **v0.20.0** (`v2026.8.3`), released 2026-08-03 |
+| Skipped | v0.19.1 — NO-GO on 2026-07-31, **on a diagnosis that was wrong** (§1) |
+| Verdict | **Attempt it.** Not because the release is proven, but because the
+abort is cheap and the wait was not buying anything (§3) |
+
+It is **v0.20.0**, not "2.0" — the project is still on a 0.x line.
+
+## 1. The v0.19.1 diagnosis was wrong
+
+`HERMES_UPGRADE_v019.md` §3.5.4 concluded that the Session API never bound
+because of one of two upstream bugs: [#74505](https://github.com/NousResearch/hermes-agent/issues/74505)
+(top-level `api_server:` YAML keys not bridged into `extra`) or
+[#75348](https://github.com/NousResearch/hermes-agent/issues/75348)
+(`PORT_BINDING_PLATFORM_VALUES` not containing the platform). It named a
+deciding check: *is `api_server` in that allowlist?*
+
+Both were resolved by running the real config loader inside both images, with
+this repo's own committed `hermes/config/hermes.yaml` mounted and our real
+env-var shape (dummy 44-character key, same strength class as production):
+
+```
+                        v0.19.1 (v2026.7.30)   v0.20.0 (v2026.8.3)
+api_server registered            True                 True
+enabled                          True                 True
+extra keys              ['host','key','port']  ['host','key','port']
+in bind allowlist                True                 True
+```
+
+**Identical, and correct, on both.** So:
+
+- `api_server` was always in the allowlist — #75348 is about Baileys WhatsApp
+  being *absent* from it and never applied to us.
+- The `extra` bridge always populated for us — our key arrives via **env**
+  (`API_SERVER_KEY`, from `HERMES_GATEWAY_API_KEY`), not top-level YAML, and the
+  env path writes `extra` directly. #74505 was never our code path. It is also
+  fixed in the shipped image regardless: `gateway/config.py` bridges all five
+  keys (`port`, `key`, `host`, `cors_origins`, `model_name`) even though the PR
+  is still open on GitHub — *a PR's open state does not tell you what is in a
+  release.*
+
+A third theory — that `has_usable_secret(key, min_length=16)` was silently
+skipping the whole env branch — also died on contact: the production key is 44
+characters and passes.
+
+**So the failure is downstream of config resolution**, in the adapter's
+`connect()` or the bind itself. `gateway/platforms/api_server.py` did change
+between the two versions (6,955 → 7,146 lines, different hash), which makes a
+fix *possible* and **not established**. Only a boot answers it — hence §4.
+
+The correction matters more than the conclusion: a wrong root cause left
+standing in a doc misdirects the next attempt, and this one already did.
+
+## 2. What is actually ours to break
+
+Nothing about Hermes is forked. The entire surface we ship into it:
+
+| | |
+|---|---|
+| `hermes/config/` | 2 files — `hermes.yaml`, `policy.yaml` |
+| `hermes/plugins/` | 1 file — `averray_trace_plugin.py` |
+| `hermes/skills/` | 1 skill — `ops/averray-ops` |
+| image | stock upstream, pinned by `HERMES_IMAGE` |
+
+The coupling is **integration**, not customisation, and it is thin:
+
+1. **The Session API** — `HermesSessionClient` calls `/api/sessions`, `/chat`,
+   `/chat/stream`, `/fork`. The only point that has ever blocked an upgrade.
+2. **The MCP bundle** — five servers published into `avg-app`; tool lists
+   register once at consumer startup. v0.20.0 changes exactly this with lazy
+   startup from a fingerprint-keyed on-disk schema cache.
+3. Skills volume, trace plugin, gateway port — trivially replaceable.
+
+**The board does not depend on Hermes.** The money path runs through a failed
+upgrade untouched, and #657 already made that deploy gate advisory.
+
+## 3. Why "wait until it settles" was the wrong policy
+
+Every release is two days old at some point and every one has open bugs, so a
+rule that says "not yet" has no exit condition — it resolves to never
+upgrading, while the jump grows and each attempt gets harder to debug. We spent
+a month on v0.18 and a day on a wrong diagnosis.
+
+Release age is a *proxy* for risk. A restorable snapshot plus two narrow checks
+is a *measurement* of it. `ops/upgrade-hermes.sh` replaces the proxy.
+
+**The one real unknown is on-disk state.** `/opt/data` holds `memory.db`,
+sessions and plugins; both versions carry SQLite schema handling and v0.20.0
+adds `session_recovery.py`. If the new version migrates that volume, an older
+image may not read it back — which is the only thing that could turn "revert the
+tag" into a loss. The snapshot converts that unknown into a controlled fact
+instead of a reason to postpone.
+
+## 4. The procedure
+
+```bash
+ops/upgrade-hermes.sh v2026.8.3     # snapshot, pin, recreate, check
+ops/upgrade-hermes.sh --check-only  # run the checks against what is live now
+```
+
+1. **Snapshot `avg_avg-hermes`** to a tarball named for the version it came
+   *from*. Fatal if it fails — nothing else runs.
+2. **Pin the tag in `.env.prod`** (with a timestamped backup), not as a one-shot
+   override that would silently revert on the next deploy.
+3. **Recreate only `hermes` + `hermes-gateway`**, with `--no-deps` — pulling
+   deps would re-run `hermes-permissions` and its `chmod -R 0777 /opt/data`,
+   re-opening the volume Hermes secures to 0700.
+4. **Two checks**, deliberately narrow because a check that tests everything is
+   a check nobody runs:
+   - **Session API binds and answers** — `POST /api/sessions` returns 201.
+     `/health` is *not* sufficient: on v0.19.1 the gateway reported healthy
+     while nothing listened. The check distinguishes *nothing listening* from
+     *bound but not serving*; both failure modes were exercised locally.
+   - **MCP tool surface** — reported, not asserted. The fingerprint-keyed cache
+     could fix the stale-tool-list problem of 2026-08-02 or add a second stale
+     layer; the script prints what the gateway says so it can be compared.
+
+It does **not** roll back on its own. A failed check prints the exact revert
+commands and stops — humans own deploy, and auto-restoring a data volume is not
+a decision a script should take.
+
+## 5. Still unverified
+
+- **Whether v0.20.0 binds.** Config resolution is clean; the bind is not proven.
+- **The MCP schema cache's effect on bundle-consumer restarts** —
+  `deploy-monitor.sh` currently compensates by hand for tool lists registering
+  once at startup. If the cache changes that, that compensation may become
+  wrong rather than merely redundant.
+- **The SessionState consolidation** (19 session-keyed dicts → one scoped
+  object) sits under `HermesSessionClient`. No breaking changes are documented,
+  which is not the same as none.
+- **Buzz** lands as a bundled gateway platform in v0.20.0. Out of scope here;
+  this doc covers getting onto the version, not the cutover.

--- a/ops/.env.example
+++ b/ops/.env.example
@@ -6,11 +6,19 @@
 # docs/DEPLOY.md.
 # AVERRAY_IMAGE=
 
-# Pinned Hermes Agent v0.17.0 / v2026.6.19 — matches the live prod pin in .env.prod.
-# Refresh intentionally after testing a new Hermes release — staged smoke first
-# (see docs/HERMES_UPGRADE_v018.md). For stricter pinning, resolve the tag to a
-# digest: `docker buildx imagetools inspect nousresearch/hermes-agent:v2026.6.19`.
-HERMES_IMAGE=nousresearch/hermes-agent:v2026.6.19
+# Pinned Hermes Agent v0.20.0 / v2026.8.3 — the upgrade target.
+#
+# The claim "matches the live prod pin" was on this line while it read
+# v2026.6.19 and prod ran v2026.7.1 — a month of drift, so a fresh deploy from
+# this example would have installed an OLDER Hermes than the one being upgraded
+# from. It is not a claim this file can keep true on its own; treat it as the
+# target, and `ops/upgrade-hermes.sh` as what moves prod to it.
+#
+# Bump with `ops/upgrade-hermes.sh <tag>`: it snapshots /opt/data first and runs
+# the two checks a version bump has ever broken (docs/HERMES_UPGRADE_v020.md).
+# For stricter pinning, resolve the tag to a digest:
+# `docker buildx imagetools inspect nousresearch/hermes-agent:v2026.8.3`.
+HERMES_IMAGE=nousresearch/hermes-agent:v2026.8.3
 
 POSTGRES_USER=avg_agent
 POSTGRES_PASSWORD=change-me

--- a/ops/upgrade-hermes.sh
+++ b/ops/upgrade-hermes.sh
@@ -1,0 +1,240 @@
+#!/usr/bin/env bash
+#
+# Upgrade Hermes to a pinned image tag — snapshot first, two checks after.
+#
+# WHY THIS EXISTS: we sat on v0.18.0 for a month because every candidate release
+# was "too new to trust". That is a policy with no exit condition — every release
+# is two days old at some point, and every one of them has open bugs — so it
+# resolves to never upgrading, while the eventual jump grows and gets harder to
+# debug. The v0.19.1 attempt already cost a day chasing a root cause that turned
+# out to be wrong (see HERMES_UPGRADE_v020.md §1).
+#
+# The fix is not more waiting. It is making the upgrade CHEAP TO ABORT, so it can
+# be attempted on evidence rather than on confidence. Release age is a proxy for
+# risk; a restorable snapshot and two narrow checks are a measurement of it.
+#
+# WHAT MAKES THIS SAFE TO JUST TRY:
+#   • The board does not depend on Hermes. The money path keeps running through
+#     a failed upgrade, and #657 already made the deploy gate advisory.
+#   • Nothing about Hermes is forked. We ship 4 files (2 config, 1 plugin, 1
+#     skill) against a stock upstream image, so a rollback is a tag, not a
+#     migration.
+#   • The ONE real unknown is on-disk state: /opt/data holds memory.db, sessions
+#     and plugins, both versions carry SQLite schema handling, and v0.20.0 adds
+#     session_recovery.py. If the new version migrates that volume, an older
+#     image may not read it back. That is what the snapshot is for — it turns
+#     the unknown into a controlled fact instead of a reason to postpone.
+#
+# Usage, from the repo root on the VPS:
+#   ops/upgrade-hermes.sh v2026.8.3          # snapshot, bump, recreate, check
+#   ops/upgrade-hermes.sh --check-only       # run the two checks against today
+#
+# This script does NOT roll back on its own. A failed check prints the exact
+# revert commands and stops; humans own deploy (invariant #1), and an automatic
+# restore of a data volume is not a decision a script should take.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+PROJECT=avg
+ENV_FILE=.env.prod
+HERMES_VOLUME="${PROJECT}_avg-hermes"
+CHECK_ONLY=false
+TARGET=""
+
+for arg in "$@"; do
+  case "$arg" in
+    --check-only) CHECK_ONLY=true ;;
+    -*) echo "unknown flag: $arg" >&2; exit 2 ;;
+    *) TARGET="$arg" ;;
+  esac
+done
+
+[ -f "$ENV_FILE" ] || { echo "ERROR: $ENV_FILE not found — run from the repo root on the VPS." >&2; exit 1; }
+
+# The command-center profile is REQUIRED: hermes-gateway lives behind it, and it
+# is the service that serves the Session API on 8642. Without the profile
+# compose silently matches nothing and reports success having done nothing —
+# the same shape as the `compose restart hermes-gateway` no-op in
+# deploy-monitor.sh.
+COMPOSE=(docker compose -p "$PROJECT" --env-file "$ENV_FILE"
+  --profile command-center
+  -f ops/compose.yml
+  -f ops/compose.prod.yml
+  -f ops/compose.command-center.yml
+  -f ops/compose.cloudflare-access.yml)
+
+current_tag() {
+  grep '^HERMES_IMAGE=' "$ENV_FILE" | tail -1 | sed 's/^HERMES_IMAGE=//'
+}
+
+# ── THE TWO CHECKS ────────────────────────────────────────────────────────
+#
+# Narrow on purpose. These are the only two things a Hermes version bump has
+# ever broken for us, and a check that tests everything is a check nobody runs.
+
+# CHECK 1 — does the Session API actually BIND and answer?
+#
+# This is the v0.19.1 failure, and /health is NOT sufficient to detect it: on
+# v0.19.1 the gateway reported healthy while nothing listened on 8642 and the
+# four session endpoints had never returned 201. So this creates a real session.
+#
+# The key is read from the env file and passed in a header. It is never echoed;
+# `set -x` is deliberately not used anywhere in this script.
+check_session_api() {
+  local port key code
+  port="$(grep '^HERMES_GATEWAY_PORT=' "$ENV_FILE" | tail -1 | sed 's/^HERMES_GATEWAY_PORT=//')"
+  port="${port:-8642}"
+  key="$(grep '^HERMES_GATEWAY_API_KEY=' "$ENV_FILE" | tail -1 | sed 's/^HERMES_GATEWAY_API_KEY=//')"
+  if [ -z "$key" ]; then
+    echo "  CHECK 1 SKIPPED: HERMES_GATEWAY_API_KEY is unset — cannot authenticate." >&2
+    return 1
+  fi
+  # `|| echo 000` here would CONCATENATE with curl's own "000" on a refused
+  # connection, yielding "000000", missing the case below, and reporting
+  # "bound, but not serving sessions" when nothing was listening at all. Caught
+  # by running this against a box with no gateway — a check that misnames the
+  # failure is worse than no check, and this one exists to name exactly that
+  # failure.
+  code="$(curl -s -o /dev/null -w '%{http_code}' --max-time 10 \
+    -X POST "http://127.0.0.1:${port}/api/sessions" \
+    -H "Authorization: Bearer ${key}" \
+    -H 'Content-Type: application/json' \
+    -d '{}' 2>/dev/null)" || true
+  [ -n "$code" ] || code=000
+  case "$code" in
+    200|201)
+      echo "  CHECK 1 PASS: POST /api/sessions -> $code (the Session API binds and answers)" ;;
+    000)
+      echo "  CHECK 1 FAIL: nothing listening on 127.0.0.1:${port} — this is the v0.19.1 symptom." >&2
+      return 1 ;;
+    *)
+      echo "  CHECK 1 FAIL: POST /api/sessions -> $code (bound, but not serving sessions)." >&2
+      return 1 ;;
+  esac
+}
+
+# CHECK 2 — did the MCP tool surface survive?
+#
+# v0.20.0 introduces lazy MCP startup from a fingerprint-keyed on-disk
+# tool-schema cache. Our five MCP servers are NOT in anyone's image — they live
+# in the avg-app volume, which mcp-bundle rewrites on every deploy — and a
+# consumer registers its tool list ONCE at startup. That combination already bit
+# us on 2026-08-02, when hermes-gateway kept advertising a stale list and
+# answered an operator's health question from the wrong tool.
+#
+# A CACHE keyed by fingerprint could fix that, or could add a second stale
+# layer. This does not guess: it prints what the container reports so the
+# operator can compare it against the previous run. Reported, not asserted —
+# the same honesty the v0.18 smoke used for undocumented shapes.
+check_mcp_tools() {
+  echo "  CHECK 2 (report, not verdict) — MCP registration lines from the gateway:"
+  "${COMPOSE[@]}" logs --tail 400 hermes-gateway 2>/dev/null \
+    | grep -iE 'mcp|tool.*(cache|schema|registered)' | tail -12 | sed 's/^/    /' \
+    || echo "    (no MCP lines in the last 400 log lines — worth a closer look)"
+}
+
+run_checks() {
+  echo
+  echo "── checks ──────────────────────────────────────────────────────────"
+  local failed=false
+  check_session_api || failed=true
+  check_mcp_tools
+  echo
+  [ "$failed" = false ]
+}
+
+if [ "$CHECK_ONLY" = true ]; then
+  echo "running checks against the CURRENT deployment ($(current_tag))"
+  run_checks || exit 1
+  exit 0
+fi
+
+[ -n "$TARGET" ] || { echo "ERROR: give a target image tag, e.g. ops/upgrade-hermes.sh v2026.8.3" >&2; exit 2; }
+
+FROM_IMAGE="$(current_tag)"
+TO_IMAGE="nousresearch/hermes-agent:${TARGET#nousresearch/hermes-agent:}"
+[ -n "$FROM_IMAGE" ] || { echo "ERROR: HERMES_IMAGE not set in $ENV_FILE." >&2; exit 1; }
+
+echo "Hermes upgrade"
+echo "  from : $FROM_IMAGE"
+echo "  to   : $TO_IMAGE"
+echo
+
+# ── 1. SNAPSHOT ───────────────────────────────────────────────────────────
+#
+# Before anything else, and FATAL if it fails. This is the whole reason the
+# upgrade is cheap to attempt: without a restorable copy of /opt/data, a version
+# that migrates the volume turns "revert the tag" into "lose the agent's memory
+# and session history". The snapshot is what converts an unknown into a fact.
+#
+# Named for the version it came FROM, because that is the version it can be
+# restored into. alpine:3.20 is already pinned in ops/compose.yml, so it is
+# local on any box being deployed to.
+STAMP="$(date -u +%Y%m%dT%H%M%SZ)"
+SNAPSHOT="hermes-data-${FROM_IMAGE##*:}-${STAMP}.tgz"
+echo "snapshotting ${HERMES_VOLUME} -> ${SNAPSHOT}"
+docker run --rm -v "${HERMES_VOLUME}:/d:ro" -v "$PWD:/backup" alpine:3.20 \
+  tar czf "/backup/${SNAPSHOT}" -C /d . \
+  || { echo "ERROR: snapshot failed — NOT upgrading. Nothing has changed." >&2; exit 1; }
+ls -lh "$SNAPSHOT" | sed 's/^/  /'
+echo
+
+# ── 2. PIN THE NEW TAG ────────────────────────────────────────────────────
+#
+# Written to .env.prod, not passed as a one-shot override: an override reverts
+# on the next deploy, which would mean the upgrade worked today and silently
+# undid itself later. Same decay the Bank lane's network attachment had.
+cp "$ENV_FILE" "${ENV_FILE}.bak.${STAMP}"
+sed -i "s|^HERMES_IMAGE=.*|HERMES_IMAGE=${TO_IMAGE}|" "$ENV_FILE"
+# Verify the edit landed rather than trusting sed — a silently no-op'd
+# replacement would deploy the OLD image while reporting an upgrade.
+[ "$(current_tag)" = "$TO_IMAGE" ] || {
+  echo "ERROR: $ENV_FILE still reads '$(current_tag)' — restoring and stopping." >&2
+  mv "${ENV_FILE}.bak.${STAMP}" "$ENV_FILE"
+  exit 1
+}
+echo "pinned HERMES_IMAGE=${TO_IMAGE} (backup: ${ENV_FILE}.bak.${STAMP})"
+
+# ── 3. RECREATE ONLY THE TWO HERMES SERVICES ──────────────────────────────
+#
+# --no-deps is deliberate, for the reason deploy-monitor.sh gives: hermes
+# depends on hermes-permissions, a one-shot that runs `chmod -R 0777 /opt/data`.
+# Re-running it would re-open the data volume that Hermes spends its life
+# securing to 0700 — a permissions change nobody asked a version bump to make.
+# skills-sync is also pulled in by those deps and the skill tree does not change
+# with an image tag.
+echo
+echo "recreating hermes + hermes-gateway on ${TO_IMAGE}"
+"${COMPOSE[@]}" pull hermes hermes-gateway
+"${COMPOSE[@]}" up -d --no-deps hermes hermes-gateway
+
+# Give the gateway a moment to bind before asserting it did not.
+echo "waiting for the gateway to settle"
+for _ in $(seq 1 30); do
+  if "${COMPOSE[@]}" ps hermes-gateway 2>/dev/null | grep -q healthy; then break; fi
+  sleep 2
+done
+
+# ── 4. CHECK, AND MAKE THE ABORT EXACT ────────────────────────────────────
+if run_checks; then
+  echo "UPGRADE OK — ${FROM_IMAGE##*:} -> ${TO_IMAGE##*:}"
+  echo
+  echo "Keep ${SNAPSHOT} until you are satisfied; delete it once the version has run a day."
+else
+  echo >&2
+  echo "UPGRADE FAILED ITS CHECKS. Nothing has been rolled back automatically." >&2
+  echo >&2
+  echo "To revert — tag first, and restore the volume ONLY if the new version" >&2
+  echo "migrated it (a clean revert on the tag alone usually just works):" >&2
+  echo >&2
+  echo "  mv ${ENV_FILE}.bak.${STAMP} ${ENV_FILE}" >&2
+  echo "  ${COMPOSE[*]} up -d --no-deps hermes hermes-gateway" >&2
+  echo >&2
+  echo "  # only if the agent's memory/sessions came back wrong:" >&2
+  echo "  ${COMPOSE[*]} stop hermes hermes-gateway" >&2
+  echo "  docker run --rm -v ${HERMES_VOLUME}:/d -v \"\$PWD:/backup\" alpine:3.20 \\" >&2
+  echo "    sh -c 'rm -rf /d/* /d/..?* 2>/dev/null; tar xzf /backup/${SNAPSHOT} -C /d'" >&2
+  echo "  ${COMPOSE[*]} up -d --no-deps hermes hermes-gateway" >&2
+  exit 1
+fi

--- a/scripts/bootstrap-wallet.sh
+++ b/scripts/bootstrap-wallet.sh
@@ -20,7 +20,11 @@ const agentAccount = privateKeyToAccount(agentPrivateKey);
 const adminAccount = privateKeyToAccount(adminPrivateKey);
 const verifierAccount = privateKeyToAccount(verifierPrivateKey);
 
-console.log(`HERMES_IMAGE=nousresearch/hermes-agent:v2026.6.19`);
+// Held in lockstep with ops/.env.example by compose-env.test.ts. A bootstrap
+// that hands out a different pin than the example is a fresh install starting
+// on a version nobody is testing — which is exactly what happened while both
+// sat on v2026.6.19 and production ran v2026.7.1.
+console.log(`HERMES_IMAGE=nousresearch/hermes-agent:v2026.8.3`);
 console.log(`POSTGRES_USER=avg_agent`);
 console.log(`POSTGRES_PASSWORD=${randomUUID().replaceAll("-", "")}`);
 console.log(`POSTGRES_DB=avg_agent`);


### PR DESCRIPTION
> "if we wait to upgrade just about every new release has problems we will never upgrade"

Correct, and this PR acts on that. "Don't take a two-day-old release" has no exit condition — every release is two days old at some point and every one has open bugs — so it resolves to never upgrading, while the jump grows and each attempt gets harder to debug.

## The v0.19.1 NO-GO was wrong

`HERMES_UPGRADE_v019.md` §3.5.4 blamed one of two upstream bugs and named a deciding check. Running the **real config loader inside both images**, with this repo's own `hermes/config/hermes.yaml` mounted:

| | v0.19.1 (`v2026.7.30`) | v0.20.0 (`v2026.8.3`) |
|---|---|---|
| `api_server` registered | True | True |
| enabled | True | True |
| `extra` keys | `['host','key','port']` | `['host','key','port']` |
| in bind allowlist | True | True |

**Identical, and correct, on both.** So neither suspect ever applied:

- **#75348** is about Baileys WhatsApp being *absent* from `PORT_BINDING_PLATFORM_VALUES`. `api_server` was always in it.
- **#74505** concerns top-level YAML keys. Our key arrives via **env**, which writes `extra` directly — and it is fixed in the shipped image regardless, despite the PR still being open. *A PR's open state does not tell you what is in a release.*
- A third theory of mine — the key failing `has_usable_secret(min_length=16)` — also died: production's is 44 characters.

The failure is **downstream of config**, in the adapter's `connect()`/bind. `api_server.py` did change between versions (6,955 → 7,146 lines), which makes a fix *possible* and **not established**. Only a boot answers it.

That correction matters more than the conclusion: a wrong root cause left standing misdirects the next attempt, and this one already did — twice, today.

## What replaces "wait"

Release age is a proxy for risk. `ops/upgrade-hermes.sh` is a measurement of it.

1. **Snapshot `avg_avg-hermes`** — fatal if it fails. `/opt/data` holds `memory.db` and sessions; both versions carry SQLite schema handling and v0.20.0 adds `session_recovery.py`. If the new version migrates that volume, an older image may not read it back. That is the *only* thing that could make rollback expensive, and the snapshot turns it into a controlled fact instead of a reason to postpone.
2. **Pin the tag in `.env.prod`**, verified after the edit — not a one-shot override that silently reverts on the next deploy.
3. **Recreate only `hermes` + `hermes-gateway`, `--no-deps`** — pulling deps re-runs `hermes-permissions` and its `chmod -R 0777 /opt/data`, re-opening the volume Hermes secures to 0700.
4. **Two narrow checks.** `/health` is deliberately *not* one: on v0.19.1 the gateway reported healthy while nothing listened. Check 1 creates a real session; check 2 reports the MCP tool surface rather than asserting, since the new fingerprint-keyed schema cache could fix the 2026-08-02 stale-tool-list problem or add a second stale layer.

No auto-rollback — a failed check prints the exact revert commands and stops.

## The check was lying, and local testing caught it

`|| echo 000` concatenated with curl's own `000` into `000000`, missed the case, and reported **"bound, but not serving sessions"** when *nothing was listening*. A diagnostic that misnames the failure is worse than none — and naming that exact failure is this one's whole job.

Both branches now exercised against a live socket and a dead one:

```
nothing listening   -> "nothing listening on 127.0.0.1:8642 — this is the v0.19.1 symptom"
listening, 404      -> "POST /api/sessions -> 404 (bound, but not serving sessions)"
```

## Why this is safe to just try

Nothing about Hermes is forked — we ship **4 files** (2 config, 1 plugin, 1 skill) against a stock upstream image. The board does not depend on Hermes, and #657 already made that deploy gate advisory, so the money path runs through a failed upgrade untouched.

## Also

`ops/.env.example` claimed to match the live prod pin while reading `v2026.6.19` against prod's `v2026.7.1` — a month of drift, so a fresh deploy from it would have installed an **older** Hermes than the one being upgraded from.

## Verification

`bash -n` clean; both check branches exercised; `compose config` valid on the bumped example. **The upgrade itself is unrun** — this PR makes it cheap to attempt, it does not claim v0.20.0 works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)