### PR TITLE
Repoint the board's own fixtures off the retired v2.0 wrapper

### DIFF
--- a/packages/monitor-ui/src/components/ops/BankLane.test.tsx
+++ b/packages/monitor-ui/src/components/ops/BankLane.test.tsx
@@ -24,7 +24,7 @@ const lane = (over: Partial<NonNullable<BankBlock["lane"]>> = {}): BankBlock => 
       detail: "zero from aUSDC 0x2ec48840…acfa93, and this read path has never observed funds",
     },
     float: { text: "0.149412 USDC · 149,412 raw", tone: "ok" },
-    postage: { text: "1.51 DOT · committed postage, no withdraw path", tone: "ok" },
+    postage: { text: "0.2697 DOT · committed postage, no withdraw path", tone: "ok" },
     requests: { text: "no requests in flight", tone: "ok" },
     overdueRequestId: null,
     tone: "degraded",

--- a/packages/monitor-ui/src/lib/monitor/ops-fixtures.ts
+++ b/packages/monitor-ui/src/lib/monitor/ops-fixtures.ts
@@ -288,22 +288,40 @@ const MAINNET_PROBES: ProductHealthProbe[] = [
 ];
 
 export const OPS_FIXTURE_NOMINAL: ProductHealth = {
-  // The lane as it stands TODAY: leg 1 executed, 149,412 raw of asset 22 live
-  // at the converted account, and the position still honestly unverified
-  // because leg 2 has not yet proven the aToken read path.
+  // The lane as it stands TODAY, on the v2.1 wrapper: leg 1 executed, 149,475
+  // raw of asset 22 live at the converted account, and the position still
+  // honestly unverified because leg 2 has not yet proven the aToken read path.
+  //
+  // Every figure here described the RETIRED v2.0 generation until 2026-08-04 —
+  // 1.51 DOT at the old wrapper image, 149,412 at the old converted account —
+  // under a comment claiming to be current. A fixture is documentation, and
+  // this one was a small copy of the exact defect the lane spent that day
+  // learning to detect.
   bank: {
     lane: {
       position: {
         status: "unverified" as const,
         raw: null,
         detail:
-          "zero from erc20:0x2ec48840…acfa93.balanceOf(0x98f0033e…fcb68e), and this read path has never observed funds — not yet evidence of an empty position",
+          "zero from erc20:0x2ec48840…acfa93.balanceOf(0x85663dfd…99f8f4), and this read path has never observed funds — not yet evidence of an empty position",
       },
-      float: { text: "0.149412 USDC · 149,412 raw", tone: "ok" as const },
-      postage: { text: "1.51 DOT · 15,100,000,000 raw · committed postage, no withdraw path", tone: "ok" as const },
+      float: { text: "0.149475 USDC · 149,475 raw", tone: "ok" as const },
+      // 0.3 DOT committed at the v2.1 arming, ~0.2697 after leg 1's delivery
+      // fees. A far thinner cushion over the 0.07 floor than v2.0's 1.51
+      // bought, which is the operationally interesting part of the repoint.
+      postage: { text: "0.2697 DOT · 2,697,000,000 raw · committed postage, no withdraw path", tone: "ok" as const },
       requests: { text: "no requests in flight", tone: "ok" as const },
       overdueRequestId: null,
-      subject: { text: "subject bank-xcm-v2.1 — matches the deployment manifest", tone: "ok" as const },
+      // The honest state: the producer does not emit `subject`. It was dropped
+      // from platform #932 rather than shipped weaker than specified — both
+      // sides rendered from `contracts.xcmWrapper` in one pass, so they agreed
+      // by construction and would have read green straight through the incident
+      // that motivated the field. A real discriminator (the armed bit over the
+      // append-only deployment history) is specced separately.
+      subject: {
+        text: "subject not declared by the feed — cannot confirm which wrapper generation these read",
+        tone: "awaiting" as const,
+      },
       tone: "degraded" as const,
     },
   },

--- a/services/slack-operator/test/unit/bank-feed-fetch.test.ts
+++ b/services/slack-operator/test/unit/bank-feed-fetch.test.ts
@@ -5,7 +5,7 @@ import { normalizeBankFeed, readBankFeed } from "../../src/bank-feed-fetch.js";
 const good = {
   position: { raw: "0", source: "erc20:0x2ec4…fa93.balanceOf(0x98f0…b68e)", readAtMs: 1_785_900_000_000 },
   float: { raw: "149412", source: "substrate_tokens:22", readAtMs: 1_785_900_000_000 },
-  postage: { raw: "15100000000", source: "substrate_system:15Xbeap…", readAtMs: 1_785_900_000_000 },
+  postage: { raw: "2697000000", source: "substrate_system:1yKNU414…", readAtMs: 1_785_900_000_000 },
   requests: { items: [], readAtMs: 1_785_900_000_000, lastError: null },
   calibration: null,
 };

--- a/services/slack-operator/test/unit/bank-lane.test.ts
+++ b/services/slack-operator/test/unit/bank-lane.test.ts
@@ -4,13 +4,18 @@ import { BANK_STALE_AFTER_MS, bankLaneView } from "../../src/bank-lane.js";
 import type { BankFeed, BankRequest } from "../../src/bank-feed.js";
 
 const NOW = 1_785_900_000_000;
-const POS_SRC = "aUSDC 0x2ec48840…fa93 · balanceOf(0x98f0033E…B68E)";
+// v2.1 converted account, truncate20'd for the aUSDC balanceOf. Used
+// symmetrically as the calibration proven-source, so the retarget tests below
+// exercise the mechanism regardless of which generation it names.
+const POS_SRC = "aUSDC 0x2ec48840…fa93 · balanceOf(0x85663dfd…99f8f4)";
 
 const feed = (over: Partial<BankFeed> = {}): BankFeed => ({
   position: { raw: "0", source: POS_SRC, readAtMs: NOW - 30_000 },
   float: { raw: "28463", source: "asset 22 · Tokens.accounts(convertedAccount)", readAtMs: NOW - 30_000 },
-  // 1.51 DOT — the wrapper postage account as funded at the arming ceremony.
-  postage: { raw: "15100000000", source: "15Xbeap…SMAK", readAtMs: NOW - 30_000 },
+  // 0.2697 DOT at the v2.1 wrapper image — 0.3 committed at the arming
+  // ceremony, less leg 1's delivery fees. The v2.0 image (15Xbeap…SMAK, 1.51
+  // DOT) is retired and written off; reading it was the 2026-08-04 incident.
+  postage: { raw: "2697000000", source: "1yKNU414…UKBaZ", readAtMs: NOW - 30_000 },
   requests: { items: [], readAtMs: NOW - 30_000 },
   ...over,
 });
@@ -89,16 +94,16 @@ describe("float is displayed, or it reads as money that vanished", () => {
 });
 
 describe("postage is committed, and has its own floor", () => {
-  test("1.51 DOT reads as committed postage with no withdraw path", () => {
+  test("0.2697 DOT reads as committed postage with no withdraw path", () => {
     const v = bankLaneView({ feed: feed(), nowMs: NOW })!;
-    expect(v.postage.text).toContain("1.51 DOT");
+    expect(v.postage.text).toContain("0.2697 DOT");
     expect(v.postage.text).toContain("no withdraw path");
     expect(v.postage.tone).toBe("ok");
   });
 
   test("below the floor the wrapper cannot pay delivery — that stops the lane", () => {
     const v = bankLaneView({
-      feed: feed({ postage: { raw: "600000000", source: "15Xbeap…SMAK", readAtMs: NOW } }), // 0.06 DOT
+      feed: feed({ postage: { raw: "600000000", source: "1yKNU414…UKBaZ", readAtMs: NOW } }), // 0.06 DOT
       nowMs: NOW,
     })!;
     expect(v.postage.tone).toBe("red");


### PR DESCRIPTION
The board-side half of the v2.1 repoint. Assigned as "the committed-postage annotation 1.51 → 0.3"; it turned out to be a little more than that.

## The literal ask

`1.51 DOT` at `15Xbeap…SMAK` is the **v2.0** wrapper image — retired, written off. v2.1 committed **0.3 DOT** at `1yKNU414…UKBaZ`, ~**0.2697** after leg 1's delivery fees.

Worth noting operationally: that is a far thinner cushion over the 0.07 floor than 1.51 bought — roughly 4 epochs of headroom instead of 21. The floor itself is per-epoch and unchanged.

## Why it widened

The NOMINAL ops fixture was a compact copy of the entire incident. Under a comment reading *"the lane as it stands TODAY"* it carried:

| | was | now |
|---|---|---|
| postage | 1.51 DOT (v2.0 image) | 0.2697 DOT (v2.1 image) |
| float | 149,412 — the old converted account's **write-off** | 149,475 — the live balance |
| position detail | `balanceOf(0x98f0033e…fcb68e)` (v2.0 converted) | `balanceOf(0x85663dfd…99f8f4)` (v2.1) |

A fixture is documentation, and this one documented the retired generation while claiming to be current — the same defect, one layer down, inside the repo that just spent a day learning to detect it. `bank-lane.test.ts`'s `POS_SRC` went with it, so that file no longer pairs v2.1 postage with a v2.0 position.

## The `subject` line is now the honest one

I had the fixture reading `subject bank-xcm-v2.1 — matches the deployment manifest`. **That state will never exist.**

`subject` was dropped from platform #932 rather than shipped weaker than specified: `derivedFrom` and `declared` both rendered from `contracts.xcmWrapper` in a single generator pass, so they agreed by construction and would have read green straight through the incident that motivated the field. Dropping beat downgrading, since an emitted `subject` claiming independence is trustable by any consumer, not just this one.

The preview now shows what operators will actually see — *"subject not declared by the feed — cannot confirm which wrapper generation these read"*, awaiting-toned, no effect on the lane verdict. A real discriminator (the armed bit over the append-only deployment history: exactly one armed wrapper among all ever recorded, with the env pointing at it — chain truth a stale env fails) is specced separately.

## Deliberately NOT repointed

`bank-subject.test.ts` keeps `14,794,550,000` raw and `15Xbeap…`. Those are the readings the board really showed on 2026-08-04, and that suite exists to lock the incident as the regression case. Changing them would delete the evidence.

## Verification

Typecheck clean; full suite **2647 passed**, 181 files. No `1.51` or `15100000000` remains outside comments that explain the history.

🤖 Generated with [Claude Code](https://claude.com/claude-code)