### PR TITLE
Record the live v0.20.0 upgrade, and make CHECK 2 a verdict

### DIFF
--- a/docs/HERMES_UPGRADE_v020.md
+++ b/docs/HERMES_UPGRADE_v020.md
@@ -7,11 +7,11 @@ shape — upstream diffed against **what we actually use**, not a feature tour.
 
 | | |
 |---|---|
-| Running | **v0.18.0** (`nousresearch/hermes-agent:v2026.7.1`), since 2026-07-02 |
-| Latest | **v0.20.0** (`v2026.8.3`), released 2026-08-03 |
+| Running | **v0.20.0** (`v2026.8.3`) since 2026-08-04 — was v0.18.0 (`v2026.7.1`) for a month |
+| Released | v0.20.0 shipped 2026-08-03; taken the next day |
 | Skipped | v0.19.1 — NO-GO on 2026-07-31, **on a diagnosis that was wrong** (§1) |
-| Verdict | **Attempt it.** Not because the release is proven, but because the
-abort is cheap and the wait was not buying anything (§3) |
+| Verdict | **DONE — upgraded and verified 2026-08-04.** See §6 |
+
 
 It is **v0.20.0**, not "2.0" — the project is still on a 0.x line.
 
@@ -53,9 +53,33 @@ skipping the whole env branch — also died on contact: the production key is 44
 characters and passes.
 
 **So the failure is downstream of config resolution**, in the adapter's
-`connect()` or the bind itself. `gateway/platforms/api_server.py` did change
-between the two versions (6,955 → 7,146 lines, different hash), which makes a
-fix *possible* and **not established**. Only a boot answers it — hence §4.
+`connect()` or the bind itself.
+
+### 1.1 SETTLED 2026-08-04 — a weak key IN THE SMOKE, not a v0.19.1 defect
+
+The v0.19.1 smoke container was still on the box, exited, three days later. Its
+log names the cause outright:
+
+```
+ERROR gateway.platforms.api_server: [Api_Server] Refusing to start:
+  API_SERVER_KEY is a placeholder or too short (<16 chars).
+ERROR gateway.run: Gateway hit a non-retryable startup conflict
+ERROR gateway.run: Gateway exiting cleanly
+```
+
+Platform registers, nothing binds, no bind attempt logged — the exact symptom,
+fully explained. `has_usable_secret(key, min_length=16)` gates the whole
+`API_SERVER_*` env branch, and the smoke's key failed it.
+
+**v0.19.1 was almost certainly never broken.** The NO-GO was an artifact of the
+test harness. Production's `HERMES_GATEWAY_API_KEY` is 44 characters and passes
+the same guard — which is why v0.20.0 bound on the first attempt.
+
+The near-miss worth recording: this mechanism was found hours earlier and then
+discarded, because **production's** key was measured instead of the **smoke's**.
+A correct reading of the wrong subject — the same failure class as the Bank
+lane's stale-subject incident that same day, and the reason a month went into
+waiting for an upstream fix that was never needed.
 
 The correction matters more than the conclusion: a wrong root cause left
 standing in a doc misdirects the next attempt, and this one already did.
@@ -120,9 +144,10 @@ ops/upgrade-hermes.sh --check-only  # run the checks against what is live now
      `/health` is *not* sufficient: on v0.19.1 the gateway reported healthy
      while nothing listened. The check distinguishes *nothing listening* from
      *bound but not serving*; both failure modes were exercised locally.
-   - **MCP tool surface** — reported, not asserted. The fingerprint-keyed cache
-     could fix the stale-tool-list problem of 2026-08-02 or add a second stale
-     layer; the script prints what the gateway says so it can be compared.
+   - **MCP tool surface** — `hermes mcp test averray` must connect AND list
+     `averray_board_health`. Not a log grep: under lazy startup the boot log is
+     silent on MCP whether the surface is healthy or dead (§6). Not `mcp list`
+     either: that reports what is configured, and configured is not working.
 
 It does **not** roll back on its own. A failed check prints the exact revert
 commands and stops — humans own deploy, and auto-restoring a data volume is not
@@ -130,13 +155,59 @@ a decision a script should take.
 
 ## 5. Still unverified
 
-- **Whether v0.20.0 binds.** Config resolution is clean; the bind is not proven.
-- **The MCP schema cache's effect on bundle-consumer restarts** —
-  `deploy-monitor.sh` currently compensates by hand for tool lists registering
-  once at startup. If the cache changes that, that compensation may become
-  wrong rather than merely redundant.
+- ~~Whether v0.20.0 binds.~~ **Verified 2026-08-04: 201, see §6.**
+- **The MCP schema cache's effect on bundle-consumer restarts.** The surface is
+  verified healthy (§6), but `deploy-monitor.sh` still restarts bundle consumers
+  by hand because tool lists registered once at startup. Under LAZY startup that
+  compensation may now be redundant — or still necessary if the fingerprint
+  cache does not notice a republished bundle. Untested either way.
 - **The SessionState consolidation** (19 session-keyed dicts → one scoped
   object) sits under `HermesSessionClient`. No breaking changes are documented,
   which is not the same as none.
 - **Buzz** lands as a bundled gateway platform in v0.20.0. Out of scope here;
   this doc covers getting onto the version, not the cutover.
+
+## 6. The live run, 2026-08-04
+
+Upgraded v0.18.0 → v0.20.0 in about 90 seconds. Snapshot 360M, unused.
+
+| | |
+|---|---|
+| Session API | `POST /api/sessions` → **201** (baseline on v0.18 also 201) |
+| MCP `averray` | connected in **553ms**, **37 tools**, `averray_board_health` present |
+| gateway | healthy; `avg-hermes-1` up |
+| snapshot | `hermes-data-v2026.7.1-20260804T091837Z.tgz` — keep ~1 day |
+
+### What the run taught that reading could not
+
+**CHECK 2 was designed wrong, not merely windowed wrong.** It grepped the boot
+log for MCP lines. On v0.20.0 the gateway logs *nothing* about MCP at boot,
+because lazy startup means nothing has connected — so **silence is the healthy
+output**, and identical to what a completely broken server would produce. The
+check reported "no MCP lines" against a perfectly good tool surface.
+
+It now runs `hermes mcp test averray`, which **connects** and enumerates: the
+act of asking is what proves the path. `hermes mcp list` is not a substitute —
+it listed all five servers as "enabled" while none had connected. Configured is
+not working.
+
+### Two things v0.20.0 surfaced
+
+**A security warning that was previously silent** (new warning, almost certainly
+not a new condition):
+
+> API server is network-accessible (0.0.0.0) AND the terminal backend is
+> 'local' (unsandboxed). Agent work dispatched through this endpoint runs as
+> the host user with full terminal/file access.
+
+Compose publishes `127.0.0.1:8642:8642`, so the `0.0.0.0` is the bind *inside*
+the container and it is not internet-reachable. But every container on
+`avg_avg-internal` can reach `hermes-gateway:8642` directly, so the accurate
+statement is: anything on that network holding the key has host-level code
+execution as the container user. `terminal.backend: docker` is the upstream
+mitigation. **A real decision, not upgrade cleanup — tracked separately.**
+
+**The skills tree did not move with the image.** ~26 bundled skills report
+"you already have a local skill by this name — yours was kept", so the agent
+runs v0.18-era bundled skills under a v0.20.0 binary. `ops/averray-ops` is
+unaffected (bind-mounted from the repo, synced by `deploy-monitor.sh`).

--- a/ops/upgrade-hermes.sh
+++ b/ops/upgrade-hermes.sh
@@ -123,15 +123,36 @@ check_session_api() {
 # us on 2026-08-02, when hermes-gateway kept advertising a stale list and
 # answered an operator's health question from the wrong tool.
 #
-# A CACHE keyed by fingerprint could fix that, or could add a second stale
-# layer. This does not guess: it prints what the container reports so the
-# operator can compare it against the previous run. Reported, not asserted —
-# the same honesty the v0.18 smoke used for undocumented shapes.
+# THIS WAS A LOG GREP, AND A LOG GREP CANNOT WORK HERE.
+#
+# The 2026-08-04 run proved it: on v0.20.0 the gateway logs NOTHING about MCP at
+# boot, because lazy startup means nothing has connected yet. Silence is the
+# HEALTHY output — and it is also what a totally broken server would produce, so
+# the check could not tell them apart. It reported "no MCP lines" against a
+# gateway whose tool surface turned out to be perfectly fine.
+#
+# `mcp test` inverts that: it CONNECTS and enumerates, so the act of asking is
+# what proves the path. `mcp list` is not a substitute — that reports what is
+# CONFIGURED, and configured is not working (it listed all five as "enabled"
+# while none had connected).
 check_mcp_tools() {
-  echo "  CHECK 2 (report, not verdict) — MCP registration lines from the gateway:"
-  "${COMPOSE[@]}" logs --tail 400 hermes-gateway 2>/dev/null \
-    | grep -iE 'mcp|tool.*(cache|schema|registered)' | tail -12 | sed 's/^/    /' \
-    || echo "    (no MCP lines in the last 400 log lines — worth a closer look)"
+  local out count
+  out="$("${COMPOSE[@]}" exec -T hermes-gateway hermes mcp test averray 2>&1)" || true
+  if ! printf '%s' "$out" | grep -q "Tools discovered"; then
+    echo "  CHECK 2 FAIL: could not enumerate the averray MCP server." >&2
+    printf '%s\n' "$out" | tail -8 | sed 's/^/    /' >&2
+    return 1
+  fi
+  count="$(printf '%s' "$out" | sed -n 's/.*Tools discovered: \([0-9][0-9]*\).*/\1/p' | head -1)"
+  # Name the specific tool rather than trusting a count. A cache that served a
+  # stale or truncated schema would still report SOME number, and the 2026-08-02
+  # incident was precisely a plausible-looking tool list missing the one that
+  # answers "is Averray working?".
+  if ! printf '%s' "$out" | grep -q "averray_board_health"; then
+    echo "  CHECK 2 FAIL: averray connected (${count} tools) but averray_board_health is MISSING." >&2
+    return 1
+  fi
+  echo "  CHECK 2 PASS: averray MCP connected, ${count} tools, averray_board_health present"
 }
 
 run_checks() {
@@ -139,7 +160,7 @@ run_checks() {
   echo "── checks ──────────────────────────────────────────────────────────"
   local failed=false
   check_session_api || failed=true
-  check_mcp_tools
+  check_mcp_tools || failed=true
   echo
   [ "$failed" = false ]
 }


### PR DESCRIPTION
**v0.18.0 → v0.20.0 is done.** ~90 seconds. Session API **201**, `averray` MCP connected in **553ms** with **37 tools** including `averray_board_health`, gateway healthy. The 360M snapshot went unused.

## The v0.19.1 post-mortem is closed — by evidence, not reasoning

The smoke container was still on the box, exited, three days later. Its log names the cause outright:

```
ERROR gateway.platforms.api_server: [Api_Server] Refusing to start:
  API_SERVER_KEY is a placeholder or too short (<16 chars).
ERROR gateway.run: Gateway hit a non-retryable startup conflict
```

Platform registers, nothing binds, no bind attempt logged — the exact symptom, fully explained.

**v0.19.1 was almost certainly never broken.** The NO-GO was an artifact of the smoke harness running a weak key, while production's has always been 44 characters. That is a month of waiting on a test-environment defect.

And I had it: this mechanism was found hours earlier and **discarded, because production's key was measured instead of the smoke's.** A correct reading of the wrong subject — same failure class as the Bank lane incident the same day. Recorded in §1.1, because a wrong root cause left standing in a doc misdirects the next reader, and this one already did exactly that.

## CHECK 2 was designed wrong, not merely windowed wrong

It grepped the boot log for MCP lines. On v0.20.0 the gateway logs **nothing** about MCP at boot — lazy startup means nothing has connected — so **silence is the healthy output**, and identical to what a dead server produces. It reported "no MCP lines" against a perfectly good tool surface.

```diff
- "${COMPOSE[@]}" logs --tail 400 hermes-gateway | grep -iE 'mcp|tool.*(cache|schema)'
+ "${COMPOSE[@]}" exec -T hermes-gateway hermes mcp test averray
```

`mcp test` **connects** and enumerates, so the act of asking is what proves the path. `mcp list` is not a substitute — it showed all five servers `✓ enabled` while none had connected. *Configured is not working.*

It asserts `averray_board_health` **by name** rather than trusting a count: a stale or truncated schema would still report some number, and 2026-08-02 was precisely a plausible-looking tool list missing the one tool that answers "is Averray working?".

CHECK 2 is now a verdict and can fail the run — previously it was report-only and could not.

## Two things v0.20.0 surfaced (neither a regression)

**A previously-silent security warning.** `api_server` binds `0.0.0.0` with an unsandboxed `local` terminal backend. Compose publishes `127.0.0.1:8642`, so it is not internet-reachable — but any container on `avg_avg-internal` holding the key has host-level execution as the container user. The warning is new; the condition almost certainly is not. **A real decision, tracked separately, not bundled into upgrade cleanup.**

**The skills tree did not move with the image.** ~26 bundled skills kept their local v0.18-era copies. `ops/averray-ops` is unaffected — bind-mounted from the repo, synced by `deploy-monitor.sh`.

## Also

Fixed three places where the doc had started contradicting itself: §0 still said "Running v0.18.0", §4 described CHECK 2 as report-only, §5 listed the bind as unverified.

## Verification

`bash -n` clean. Both checks exercised against an environment where neither can succeed — they now fail **loudly and distinctly** (`exit 1`) rather than one of them silently reporting nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)