### PR TITLE
Correct two stale conclusions about Buzz, both true when written

### DIFF
--- a/docs/BUZZ_DEPLOYMENT_PLAN.md
+++ b/docs/BUZZ_DEPLOYMENT_PLAN.md
@@ -161,6 +161,32 @@ already-tested, currently-inert feature real.
 **P4 — Hermes reads and answers there.** Separate work; see
 [[project_hermes_buzz_architecture]]. Read-only first, allowlist deferred.
 
+> **⚠ SUPERSEDED — STATUS AS OF 2026-08-04. P4 IS LIVE AND NOT READ-ONLY.**
+>
+> `BUZZ_INBOUND_ENABLED=true`, `BUZZ_INBOUND_REQUIRE_MENTION=true`,
+> `BUZZ_INBOUND_MAX_REPLIES_PER_HOUR=10`. A question in the ops channel is
+> handed to a **full Hermes session with its whole tool surface** — the guards
+> in `buzz-inbound.ts` (SELF / ECHO / RATE / mention) are anti-loop and
+> anti-spam, **not authority**. Authority lives downstream in
+> `hermes/config/policy.yaml` and averray-mcp's mutation policy.
+>
+> **"Allowlist deferred" is misleading and was never actioned as written** — it
+> was *delegated to the relay*, which runs closed: verified on the live relay
+> 2026-08-04, `BUZZ_REQUIRE_AUTH_TOKEN=true`, `BUZZ_ALLOW_NIP_OA_AUTH=true`,
+> `RELAY_OWNER_PUBKEY` set. Membership by issued credential IS the allowlist,
+> exactly as §"redundant" above argued it should be. The posture is sound; the
+> sentence describing it was not.
+>
+> Residual, and operator knowledge rather than config: **who holds issued relay
+> credentials.** `REQUIRE_AUTH_TOKEN=true` says a credential is needed, not how
+> many exist.
+>
+> **DO NOT enable Hermes v0.20.0's bundled Buzz gateway platform.** It is a
+> second Buzz→agent path answering only to Hermes's own allowlist, bypassing the
+> ops-channel scoping, mention requirement and rate limit above. Two paths with
+> different gates is how the strict one becomes optional (AGENTS.md invariant
+> #6). Keep it as a fallback if our client ever needs replacing.
+
 ## Risks worth naming up front
 
 - **Second Postgres.** We already run one. Two database servers on one small box

--- a/docs/HERMES_UPGRADE_v019.md
+++ b/docs/HERMES_UPGRADE_v019.md
@@ -17,6 +17,16 @@ closed 2026-07-29; v0.19.1 notes list *"continued platform work (Buzz/Nostr
 channel …)"*). It is **not backportable to v0.18** — the upgrade gates the Buzz
 work entirely.
 
+> **⚠ OVERTAKEN 2026-08-01, one day after this was written.** We built our own
+> Buzz client in `services/slack-operator` (`buzz-client` / `buzz-inbound` /
+> `buzz-subscribe` / `buzz-profile`) against the relay directly. The upgrade
+> gated nothing: as of 2026-08-04 the control plane is live and two-way on
+> v0.18 — `BUZZ_INBOUND_ENABLED=true`, mention required, 10 replies/hour.
+>
+> So this premise justified part of a month of waiting after it had already
+> stopped being true. When an upgrade is held for a capability, re-check whether
+> the capability arrived by another route before the next deferral.
+
 **⚠ VERDICT AFTER THE SMOKE (2026-07-31): WAIT FOR v0.19.2. NO-GO on v0.19.1.**
 The Session API our monitor depends on never binds — see §3.5.4. Two open
 upstream bugs match the symptom, v0.19.1 is ~1 day old rolling up ~2,789


### PR DESCRIPTION
Docs only. Both statements were accurate on their date and have quietly inverted since — the failure mode that cost real time three separate times on 2026-08-04.

## 1. `HERMES_UPGRADE_v019.md` — "the upgrade gates the Buzz work entirely"

Overtaken **the next day**. We built our own Buzz client in `services/slack-operator` (`buzz-client` / `buzz-inbound` / `buzz-subscribe` / `buzz-profile`) against the relay directly. The upgrade gated nothing — and that premise went on justifying part of a month of waiting after it had stopped being true.

The generalisable note goes in with it: *when an upgrade is held for a capability, re-check whether the capability arrived by another route before deferring again.*

## 2. `BUZZ_DEPLOYMENT_PLAN.md` — "Read-only first, allowlist deferred"

Misleading on **both** halves now.

**P4 is live and not read-only.** `BUZZ_INBOUND_ENABLED=true`, mention required, 10 replies/hour — and a question is handed to a full Hermes session with its whole tool surface. `buzz-inbound.ts`'s SELF / ECHO / RATE / mention guards are anti-loop and anti-spam, **not authority**; authority is downstream in `hermes/config/policy.yaml` and averray-mcp's mutation policy. Worth stating plainly, because those guard names read like an authorization layer and aren't one.

**The allowlist was never "deferred" in the sense of outstanding — it was delegated to the relay**, which runs closed. Verified live 2026-08-04:

```
BUZZ_REQUIRE_AUTH_TOKEN=true
BUZZ_ALLOW_NIP_OA_AUTH=true
RELAY_OWNER_PUBKEY=<set>
```

Membership by issued credential *is* the allowlist — exactly as the doc's own "it is redundant" argument said it should be. **The posture is sound; only the sentence describing it was wrong**, which is worse than an open TODO: it reads as a known gap and sends the next reader hunting for work that is already done. It sent me hunting today.

## Also recorded

**Do not enable Hermes v0.20.0's bundled Buzz gateway platform.** It would be a second Buzz→agent path answering only to Hermes's own allowlist, bypassing the ops-channel scoping, mention requirement and rate limit on ours. Two paths with different gates is how the strict one becomes optional (AGENTS.md invariant #6). Kept as a fallback if our client ever needs replacing.

**Residual, flagged not solved:** who holds issued relay credentials. `REQUIRE_AUTH_TOKEN=true` says a credential is needed, not how many exist. Operator knowledge, not config.

No code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)