### PR TITLE
Clear Hermes's tool-schema cache on bundle change — the restart stopped being enough

### DIFF
--- a/docs/HERMES_UPGRADE_v020.md
+++ b/docs/HERMES_UPGRADE_v020.md
@@ -156,11 +156,17 @@ a decision a script should take.
 ## 5. Still unverified
 
 - ~~Whether v0.20.0 binds.~~ **Verified 2026-08-04: 201, see §6.**
-- **The MCP schema cache's effect on bundle-consumer restarts.** The surface is
-  verified healthy (§6), but `deploy-monitor.sh` still restarts bundle consumers
-  by hand because tool lists registered once at startup. Under LAZY startup that
-  compensation may now be redundant — or still necessary if the fingerprint
-  cache does not notice a republished bundle. Untested either way.
+- ~~The MCP schema cache's effect on bundle-consumer restarts.~~ **TESTED
+  2026-08-04 — the compensation is NOT redundant, it became INSUFFICIENT.**
+  `tools/mcp_schema_cache.py` keys on `config_fingerprint(command, args, url,
+  transport, tool filters)` and does **not** hash server code, so republishing
+  the bundle leaves the fingerprint identical and the cache serves the old
+  manifest. It refreshes on a live connect, so a CHANGED tool self-heals on
+  first use — but a NEWLY ADDED tool cannot: the model never learns it exists,
+  so it never calls it, so the refreshing connect never happens. The cache lives
+  at `/opt/data/cache/mcp_schema_cache.json` on the persisted `avg-hermes`
+  volume (confirmed on the live box), so it survives restarts *and* recreates.
+  `deploy-monitor.sh` now deletes it whenever the bundle id changes.
 - **The SessionState consolidation** (19 session-keyed dicts → one scoped
   object) sits under `HermesSessionClient`. No breaking changes are documented,
   which is not the same as none.

--- a/ops/deploy-monitor.sh
+++ b/ops/deploy-monitor.sh
@@ -281,6 +281,51 @@ else
   fi
   echo "restarting everything that runs from it, so its tool list matches:"
 
+  # CLEAR HERMES'S ON-DISK TOOL-SCHEMA CACHE FIRST — since v0.20.0 a restart
+  # alone no longer makes the tool list match.
+  #
+  # Hermes registers MCP tools from a persistent cache
+  # (/opt/data/cache/mcp_schema_cache.json, in the avg-hermes volume) so lazy
+  # startup need not spawn every stdio child at boot. The key is `server name +
+  # config_fingerprint(command, args, url, transport, tool filters)` — it does
+  # NOT hash the server's CODE. All five of our servers run the same
+  # /app/scripts/run-mcp-server.sh, so republishing the bundle leaves the
+  # fingerprint identical and the cache keeps serving the OLD manifest.
+  #
+  # It refreshes on a live connect, so a CHANGED tool self-heals the first time
+  # something calls it. A NEWLY ADDED tool does not: the model never learns it
+  # exists, so it never calls it, so the connect that would refresh the cache
+  # never happens. Self-sustaining — and exactly the 2026-08-02 failure, where
+  # averray_board_health shipped in #657 and hermes-gateway went on answering
+  # from the previous list.
+  #
+  # What changed is that the stale list now sits on the PERSISTED volume, so it
+  # outlives both the restart below and a container recreate. The consumer
+  # restart stopped being sufficient at the v0.20.0 upgrade; deleting the cache
+  # is what restores it. No cache ⇒ Hermes connects to enumerate, which is the
+  # pre-lazy behaviour and the correct one here.
+  #
+  # ADVISORY, like the skills sync above: a monitor deploy must not fail because
+  # a cache file could not be removed, and a stale tool list announces itself
+  # (a tool that "does not exist"). Same call #657 made.
+  # The existence check is NOT defensive padding, for the reason read_bundle_id
+  # gives above: `docker run -v <name>:...` CREATES a missing volume, and a
+  # volume created outside Compose carries none of Compose's labels — the exact
+  # state Compose then refuses to adopt. Clearing a cache must not be able to
+  # break the stack it is tidying.
+  HERMES_VOLUME="${PROJECT}_avg-hermes"
+  echo "  clearing the MCP tool-schema cache (v0.20.0 keys it on config, not code)"
+  if ! docker volume inspect "${HERMES_VOLUME}" >/dev/null 2>&1; then
+    echo "  no ${HERMES_VOLUME} volume — nothing cached, nothing to clear"
+  elif docker run --rm -v "${HERMES_VOLUME}:/d" alpine:3.20 \
+      rm -f /d/cache/mcp_schema_cache.json 2>/dev/null; then
+    echo "  cache cleared — consumers re-enumerate on boot"
+  else
+    echo "  WARNING: could not clear the MCP schema cache. A tool ADDED by this" >&2
+    echo "           bundle may stay invisible even after the restart below." >&2
+    echo "           Check with: ops/upgrade-hermes.sh --check-only" >&2
+  fi
+
   BUNDLE_CONSUMERS="$(docker ps \
     --filter "volume=${BUNDLE_VOLUME}" \
     --filter "label=com.docker.compose.project=${PROJECT}" \


### PR DESCRIPTION
Found while checking whether v0.20.0's MCP schema cache made `deploy-monitor.sh`'s consumer-restart redundant. It did the opposite: **the compensation became insufficient, silently, at yesterday's upgrade.**

## The mechanism

`tools/mcp_schema_cache.py` keys entries on:

```python
config_fingerprint(command, args, url, transport, tools_include, tools_exclude)
```

**It does not hash the server's code.** All five of our MCP servers run the same `/app/scripts/run-mcp-server.sh`, so `mcp-bundle` republishing the volume leaves the fingerprint *identical* — and the cache goes on serving the old manifest.

It refreshes `after a successful live connect`, so a **changed** tool self-heals the first time something calls it. A **newly added** tool cannot:

> the model never learns the tool exists → so it never calls it → so the connect that would refresh the cache never happens

Self-sustaining. And it is exactly the **2026-08-02** failure: `averray_board_health` shipped in #657, and `hermes-gateway` went on answering an operator's health question from the previous list.

## Why it's worse than before

The stale manifest now lives at `/opt/data/cache/mcp_schema_cache.json` — on the **persisted `avg-hermes` volume**, confirmed on the live box:

```
/opt/data/cache/mcp_schema_cache.json
```

So it outlives the consumer restart this script performs *and* a container recreate. On v0.18 a restart re-enumerated; that is no longer true.

## The fix

Delete the cache when the bundle id changes, before restarting consumers. No cache ⇒ Hermes connects to enumerate — the pre-lazy behaviour, and the right one here.

**Advisory, not fatal**, like the skills sync directly above it: a monitor deploy must not fail because a cache file could not be removed, and a stale tool list announces itself as a tool that "does not exist". Same call #657 made.

## A bug I wrote and caught before committing

The first version was `docker run -v "${PROJECT}_avg-hermes:/d" …` with no existence check — and this script *already documents* why that is dangerous, in `read_bundle_id`:

> `docker run -v <name>:...` CREATES a missing volume, and a volume created outside Compose has none of Compose's labels — which is exactly the state Compose refuses to adopt.

Clearing a cache must not be able to break the stack it is tidying. Now guarded by `docker volume inspect` first.

## Verification

Live-fired against a real volume rather than reasoned about:

- seeded `/d/cache/mcp_schema_cache.json`, ran the exact command from the script → **removed, exit 0**
- absent-volume path → **skips, and creates nothing**
- `bash -n` clean

Also closes `HERMES_UPGRADE_v020.md` §5's "untested either way" item with the tested answer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)