### PR TITLE
fix(bank): render terminal recovery reconciliation honestly

### DIFF
--- a/services/slack-operator/src/bank-feed-fetch.ts
+++ b/services/slack-operator/src/bank-feed-fetch.ts
@@ -150,6 +150,7 @@ function requestsBlock(raw: unknown): { requests: BankRequests } | { reason: str
     if (typeof e.ageSeconds !== "number" || typeof e.overdue !== "boolean") {
       return { reason: `bank feed request ${e.id} needs numeric ageSeconds and boolean overdue` };
     }
+    const reconciliation = terminalReconciliation(e.reconciliation);
     items.push({
       id: e.id,
       kind: typeof e.kind === "string" ? e.kind : "unknown",
@@ -158,6 +159,8 @@ function requestsBlock(raw: unknown): { requests: BankRequests } | { reason: str
       phase: e.phase,
       ageSeconds: e.ageSeconds,
       overdue: e.overdue,
+      ...(typeof e.status === "string" ? { status: e.status } : {}),
+      ...(reconciliation ? { reconciliation } : {}),
     });
   }
   return {
@@ -166,6 +169,28 @@ function requestsBlock(raw: unknown): { requests: BankRequests } | { reason: str
       readAtMs: (r.readAtMs as number | null) ?? null,
       ...(typeof r.lastError === "string" ? { lastError: r.lastError } : {}),
     },
+  };
+}
+
+function terminalReconciliation(raw: unknown): BankRequest["reconciliation"] | undefined {
+  if (!raw || typeof raw !== "object") return undefined;
+  const r = raw as Record<string, unknown>;
+  const keys = [
+    "stagedRaw",
+    "leg1TransferFeeRaw",
+    "trappedWriteOff3Raw",
+    "remoteRecoverableRaw",
+    "unexplainedRaw",
+  ] as const;
+  if (keys.some((key) => typeof r[key] !== "string" || !/^\d+$/.test(r[key]))) return undefined;
+  if (typeof r.artifactLabel !== "string" || !r.artifactLabel.trim()) return undefined;
+  return {
+    stagedRaw: r.stagedRaw as string,
+    leg1TransferFeeRaw: r.leg1TransferFeeRaw as string,
+    trappedWriteOff3Raw: r.trappedWriteOff3Raw as string,
+    remoteRecoverableRaw: r.remoteRecoverableRaw as string,
+    unexplainedRaw: r.unexplainedRaw as string,
+    artifactLabel: r.artifactLabel,
   };
 }
 

--- a/services/slack-operator/src/bank-feed.ts
+++ b/services/slack-operator/src/bank-feed.ts
@@ -70,6 +70,20 @@ export interface BankRequest {
   ageSeconds: number;
   /** Past its observer deadline. THE stuck-pending alarm. */
   overdue: boolean;
+  /** Producer-owned terminal status; pending for in-flight rows. */
+  status?: string;
+  /**
+   * Presentation-safe terminal accounting. The producer deliberately omits
+   * raw contract recovery slots that are known accounting artifacts.
+   */
+  reconciliation?: {
+    stagedRaw: string;
+    leg1TransferFeeRaw: string;
+    trappedWriteOff3Raw: string;
+    remoteRecoverableRaw: string;
+    unexplainedRaw: string;
+    artifactLabel: string;
+  };
 }
 
 /** The observer's vocabulary as of today. Not exhaustive by construction. */

--- a/services/slack-operator/src/bank-lane.ts
+++ b/services/slack-operator/src/bank-lane.ts
@@ -303,6 +303,18 @@ function requestLine(requests: BankRequests, nowMs: number, staleAfterMs: number
   const unknown = requests.items.filter((r) => !isKnownPhase(r.phase));
   const live = requests.items.filter((r) => r.phase !== "terminal");
   if (live.length === 0) {
+    const terminal = requests.items.find((request) => request.phase === "terminal" && request.reconciliation);
+    if (terminal?.reconciliation) {
+      const r = terminal.reconciliation;
+      return {
+        text:
+          `TERMINAL ${String(terminal.status ?? "recorded").toUpperCase()} · ${terminal.id} · ` +
+          `${r.stagedRaw} staged − ${r.leg1TransferFeeRaw} leg-1 fee − ` +
+          `${r.trappedWriteOff3Raw} trapped write-off #3 = ${r.remoteRecoverableRaw} recoverable · ` +
+          `${r.unexplainedRaw} unexplained · ${r.artifactLabel}`,
+        tone: "degraded",
+      };
+    }
     return { text: "no requests in flight", tone: "ok" };
   }
   const overdue = live.filter((r) => r.overdue);

--- a/services/slack-operator/test/unit/bank-feed-fetch.test.ts
+++ b/services/slack-operator/test/unit/bank-feed-fetch.test.ts
@@ -82,6 +82,41 @@ describe("nothing that crossed the network is trusted", () => {
     });
     expect(r.feed!.requests.items[0]!.phase).toBe("timing-unknown");
   });
+
+  test("terminal reconciliation crosses the boundary without a raw recovery-slot receivable", () => {
+    const r = normalizeBankFeed({
+      ...good,
+      requests: {
+        items: [{
+          id: "req-terminal",
+          kind: "deposit",
+          phase: "terminal",
+          status: "failed",
+          ageSeconds: 100,
+          overdue: false,
+          reconciliation: {
+            stagedRaw: "150000",
+            leg1TransferFeeRaw: "525",
+            trappedWriteOff3Raw: "17932",
+            remoteRecoverableRaw: "131543",
+            unexplainedRaw: "0",
+            artifactLabel: "v2.1 accounting artifact, known-unrecoverable",
+            rawRecoveryAssetsOutstandingRaw: "150000",
+          },
+        }],
+        readAtMs: 1,
+      },
+    });
+    expect(r.feed!.requests.items[0]!.reconciliation).toEqual({
+      stagedRaw: "150000",
+      leg1TransferFeeRaw: "525",
+      trappedWriteOff3Raw: "17932",
+      remoteRecoverableRaw: "131543",
+      unexplainedRaw: "0",
+      artifactLabel: "v2.1 accounting artifact, known-unrecoverable",
+    });
+    expect(r.feed!.requests.items[0]!.reconciliation).not.toHaveProperty("rawRecoveryAssetsOutstandingRaw");
+  });
 });
 
 describe("a malformed calibration is dropped, never repaired", () => {

--- a/services/slack-operator/test/unit/bank-lane.test.ts
+++ b/services/slack-operator/test/unit/bank-lane.test.ts
@@ -201,6 +201,36 @@ describe("an overdue request is the stuck-pending alarm, named", () => {
     expect(v.requests.text).toBe("no requests in flight");
   });
 
+  test("terminal failure renders the five-line reconciliation and artifact label", () => {
+    const v = bankLaneView({
+      feed: feed({
+        requests: {
+          items: [req({
+            phase: "terminal",
+            status: "failed",
+            reconciliation: {
+              stagedRaw: "150000",
+              leg1TransferFeeRaw: "525",
+              trappedWriteOff3Raw: "17932",
+              remoteRecoverableRaw: "131543",
+              unexplainedRaw: "0",
+              artifactLabel: "v2.1 accounting artifact, known-unrecoverable",
+            },
+          })],
+          readAtMs: NOW,
+        },
+      }),
+      nowMs: NOW,
+    })!;
+    expect(v.requests.text).toContain("150000 staged");
+    expect(v.requests.text).toContain("17932 trapped write-off #3");
+    expect(v.requests.text).toContain("131543 recoverable");
+    expect(v.requests.text).toContain("0 unexplained");
+    expect(v.requests.text).toContain("v2.1 accounting artifact, known-unrecoverable");
+    expect(v.requests.text).not.toContain("recoveryAssetsOutstanding");
+    expect(v.requests.tone).toBe("degraded");
+  });
+
   test("overdue is the OBSERVER's judgement — never recomputed from the age", () => {
     // Two services deriving one deadline eventually disagree, and then there
     // are two answers to a question that must have one.


### PR DESCRIPTION
## What changed

- accepts the producer's presentation-safe terminal reconciliation for Bank XCM requests
- renders the five-line reconciliation when no request remains in flight
- labels the v2.1 residue as a known-unrecoverable accounting artifact
- deliberately drops recoveryAssetsOutstanding and any other raw contract slot from the board boundary

## Why

Request 0xb609f4d875e0c6f4f4b1dddd90efd687215d1ac9ecd90d0de51b9304f57ecaac was honestly terminalized Failed after a stale-fee XCM failure. The deployed v2.1 adapter records a 150,000 raw recovery slot even though chain reconciliation proves only 131,543 raw is remotely recoverable. The board must show the reconciliation and must never present that slot as a receivable.

## Checks

- npm run typecheck
- npm test (181 files passed, 2 skipped; 2,649 tests passed, 15 skipped)
- targeted Bank feed/lane unit tests (33 passed)

## Surface

- Slack operator / monitor board only
- no contracts, backend, indexer, Caddy, or public-site change
- no environment or VPS secret change

## Rollout dependency

Deploy after the producer-side change in averray-agent/agent#933. Before ceremony signatures, upsert the terminal watch with the complete safe reconciliation and verify this board renders it. The raw v2.1 recovery slot remains excluded.
