### PR TITLE
fix(bank): render final v2.1 recovery reconciliation

### DIFF
--- a/services/slack-operator/src/bank-feed-fetch.ts
+++ b/services/slack-operator/src/bank-feed-fetch.ts
@@ -179,18 +179,30 @@ function terminalReconciliation(raw: unknown): BankRequest["reconciliation"] | u
     "stagedRaw",
     "leg1TransferFeeRaw",
     "trappedWriteOff3Raw",
-    "remoteRecoverableRaw",
     "unexplainedRaw",
   ] as const;
   if (keys.some((key) => typeof r[key] !== "string" || !/^\d+$/.test(r[key]))) return undefined;
   if (typeof r.artifactLabel !== "string" || !r.artifactLabel.trim()) return undefined;
+  const remoteShape = typeof r.remoteRecoverableRaw === "string" && /^\d+$/.test(r.remoteRecoverableRaw);
+  const finalKeys = [
+    "actualTreasuryReturnRaw",
+    "recoveryReturnFeeRaw",
+    "finalRawRecoverySlotResidueRaw",
+  ] as const;
+  const finalShape = finalKeys.every((key) => typeof r[key] === "string" && /^\d+$/.test(r[key]));
+  if (!remoteShape && !finalShape) return undefined;
   return {
     stagedRaw: r.stagedRaw as string,
     leg1TransferFeeRaw: r.leg1TransferFeeRaw as string,
     trappedWriteOff3Raw: r.trappedWriteOff3Raw as string,
-    remoteRecoverableRaw: r.remoteRecoverableRaw as string,
     unexplainedRaw: r.unexplainedRaw as string,
     artifactLabel: r.artifactLabel,
+    ...(remoteShape ? { remoteRecoverableRaw: r.remoteRecoverableRaw as string } : {}),
+    ...(finalShape ? {
+      actualTreasuryReturnRaw: r.actualTreasuryReturnRaw as string,
+      recoveryReturnFeeRaw: r.recoveryReturnFeeRaw as string,
+      finalRawRecoverySlotResidueRaw: r.finalRawRecoverySlotResidueRaw as string,
+    } : {}),
   };
 }
 

--- a/services/slack-operator/src/bank-feed.ts
+++ b/services/slack-operator/src/bank-feed.ts
@@ -80,9 +80,12 @@ export interface BankRequest {
     stagedRaw: string;
     leg1TransferFeeRaw: string;
     trappedWriteOff3Raw: string;
-    remoteRecoverableRaw: string;
     unexplainedRaw: string;
     artifactLabel: string;
+    remoteRecoverableRaw?: string;
+    actualTreasuryReturnRaw?: string;
+    recoveryReturnFeeRaw?: string;
+    finalRawRecoverySlotResidueRaw?: string;
   };
 }
 

--- a/services/slack-operator/src/bank-lane.ts
+++ b/services/slack-operator/src/bank-lane.ts
@@ -306,12 +306,20 @@ function requestLine(requests: BankRequests, nowMs: number, staleAfterMs: number
     const terminal = requests.items.find((request) => request.phase === "terminal" && request.reconciliation);
     if (terminal?.reconciliation) {
       const r = terminal.reconciliation;
+      const final = r.actualTreasuryReturnRaw !== undefined &&
+        r.recoveryReturnFeeRaw !== undefined &&
+        r.finalRawRecoverySlotResidueRaw !== undefined;
       return {
-        text:
-          `TERMINAL ${String(terminal.status ?? "recorded").toUpperCase()} · ${terminal.id} · ` +
-          `${r.stagedRaw} staged − ${r.leg1TransferFeeRaw} leg-1 fee − ` +
-          `${r.trappedWriteOff3Raw} trapped write-off #3 = ${r.remoteRecoverableRaw} recoverable · ` +
-          `${r.unexplainedRaw} unexplained · ${r.artifactLabel}`,
+        text: final
+          ? `TERMINAL ${String(terminal.status ?? "recorded").toUpperCase()} · ${terminal.id} · ` +
+            `${r.stagedRaw} staged = ${r.actualTreasuryReturnRaw} treasury + ` +
+            `${r.leg1TransferFeeRaw} leg-1 fee + ${r.trappedWriteOff3Raw} trapped write-off #3 + ` +
+            `${r.recoveryReturnFeeRaw} recovery fee · ${r.unexplainedRaw} unexplained · ` +
+            `${r.finalRawRecoverySlotResidueRaw} residue — ${r.artifactLabel}`
+          : `TERMINAL ${String(terminal.status ?? "recorded").toUpperCase()} · ${terminal.id} · ` +
+            `${r.stagedRaw} staged − ${r.leg1TransferFeeRaw} leg-1 fee − ` +
+            `${r.trappedWriteOff3Raw} trapped write-off #3 = ${r.remoteRecoverableRaw} recoverable · ` +
+            `${r.unexplainedRaw} unexplained · ${r.artifactLabel}`,
         tone: "degraded",
       };
     }

--- a/services/slack-operator/test/unit/bank-feed-fetch.test.ts
+++ b/services/slack-operator/test/unit/bank-feed-fetch.test.ts
@@ -96,10 +96,12 @@ describe("nothing that crossed the network is trusted", () => {
           overdue: false,
           reconciliation: {
             stagedRaw: "150000",
+            actualTreasuryReturnRaw: "130200",
             leg1TransferFeeRaw: "525",
             trappedWriteOff3Raw: "17932",
-            remoteRecoverableRaw: "131543",
+            recoveryReturnFeeRaw: "1343",
             unexplainedRaw: "0",
+            finalRawRecoverySlotResidueRaw: "19800",
             artifactLabel: "v2.1 accounting artifact, known-unrecoverable",
             rawRecoveryAssetsOutstandingRaw: "150000",
           },
@@ -109,10 +111,12 @@ describe("nothing that crossed the network is trusted", () => {
     });
     expect(r.feed!.requests.items[0]!.reconciliation).toEqual({
       stagedRaw: "150000",
+      actualTreasuryReturnRaw: "130200",
       leg1TransferFeeRaw: "525",
       trappedWriteOff3Raw: "17932",
-      remoteRecoverableRaw: "131543",
+      recoveryReturnFeeRaw: "1343",
       unexplainedRaw: "0",
+      finalRawRecoverySlotResidueRaw: "19800",
       artifactLabel: "v2.1 accounting artifact, known-unrecoverable",
     });
     expect(r.feed!.requests.items[0]!.reconciliation).not.toHaveProperty("rawRecoveryAssetsOutstandingRaw");

--- a/services/slack-operator/test/unit/bank-lane.test.ts
+++ b/services/slack-operator/test/unit/bank-lane.test.ts
@@ -210,10 +210,12 @@ describe("an overdue request is the stuck-pending alarm, named", () => {
             status: "failed",
             reconciliation: {
               stagedRaw: "150000",
+              actualTreasuryReturnRaw: "130200",
               leg1TransferFeeRaw: "525",
               trappedWriteOff3Raw: "17932",
-              remoteRecoverableRaw: "131543",
+              recoveryReturnFeeRaw: "1343",
               unexplainedRaw: "0",
+              finalRawRecoverySlotResidueRaw: "19800",
               artifactLabel: "v2.1 accounting artifact, known-unrecoverable",
             },
           })],
@@ -222,10 +224,11 @@ describe("an overdue request is the stuck-pending alarm, named", () => {
       }),
       nowMs: NOW,
     })!;
-    expect(v.requests.text).toContain("150000 staged");
+    expect(v.requests.text).toContain("150000 staged = 130200 treasury");
     expect(v.requests.text).toContain("17932 trapped write-off #3");
-    expect(v.requests.text).toContain("131543 recoverable");
+    expect(v.requests.text).toContain("1343 recovery fee");
     expect(v.requests.text).toContain("0 unexplained");
+    expect(v.requests.text).toContain("19800 residue");
     expect(v.requests.text).toContain("v2.1 accounting artifact, known-unrecoverable");
     expect(v.requests.text).not.toContain("recoveryAssetsOutstanding");
     expect(v.requests.tone).toBe("degraded");


### PR DESCRIPTION
## What changed

- extends the already-merged terminal Bank reconciliation surface with final recovery actuals
- renders 150,000 staged = 130,200 treasury + 525 leg-1 fee + 17,932 trapped write-off #3 + 1,343 recovery fee
- renders zero unexplained and the final 19,800 residue only with the explicit v2.1 accounting-artifact / known-unrecoverable label
- keeps the pre-release remote-recoverable shape backwards compatible
- continues to drop recoveryAssetsOutstanding and other raw contract slots at the monitor trust boundary

## Checks

- npm run typecheck
- targeted Bank feed/lane tests: 33/33 pass

## Surface

Slack operator / monitor board only. No contracts, backend, indexer, Caddy, public-site, environment, or secret change.

## Dependency

Pairs with averray-agent/agent's codex/bank-v21-final-release packet. The board must never present the remaining 19,800 v2.1 slot as recoverable capital.
