### PR TITLE
Watch credential expiries, observed from the artefacts themselves

### DIFF
--- a/ops/compose.yml
+++ b/ops/compose.yml
@@ -619,6 +619,22 @@ services:
       # disk exhaustion is universally fatal, and at 155 GiB free 10/25 cannot
       # fire spuriously. Raise them once MinIO (Buzz) starts storing media.
       PRODUCT_HEALTH_DISK_PATH: ${PRODUCT_HEALTH_DISK_PATH:-/}
+      # Credential expiry — OBSERVED from the artefacts, never from a written
+      # date. A date in a file is right the day it is written and silently wrong
+      # from the next rotation onward; a cert's own notAfter and a JWT's own
+      # `exp` cannot go stale.
+      #
+      # Both UNSET by default, and absent means the probe DOES NOT EXIST rather
+      # than existing with nothing to watch. A permanently-degraded probe on
+      # every deployment that never configured it is the panel nobody reads.
+      #
+      # CERT_HOSTS: comma-separated hostnames, TLS 443. A lapsed certificate is
+      # a total public outage, which is why it leads the list.
+      # EXPIRY_JWT_ENV_KEYS: comma-separated env var names to try as JWTs. An
+      # unset key is skipped; an opaque non-JWT reports "no expiry declared",
+      # which is a fact about the credential, not a failure to read it.
+      PRODUCT_HEALTH_CERT_HOSTS: ${PRODUCT_HEALTH_CERT_HOSTS:-}
+      PRODUCT_HEALTH_EXPIRY_JWT_ENV_KEYS: ${PRODUCT_HEALTH_EXPIRY_JWT_ENV_KEYS:-}
       PRODUCT_HEALTH_MIN_DISK_FREE_GB: ${PRODUCT_HEALTH_MIN_DISK_FREE_GB:-10}
       PRODUCT_HEALTH_WARN_DISK_FREE_GB: ${PRODUCT_HEALTH_WARN_DISK_FREE_GB:-25}
       # Floors default to 0 = that probe can NEVER go red. Fine for a testnet, but

--- a/services/slack-operator/src/credential-expiry.ts
+++ b/services/slack-operator/src/credential-expiry.ts
@@ -1,0 +1,265 @@
+// A credential that expires on a Thursday is an outage scheduled in advance.
+//
+// Nothing on this board watches for one. The probes cover chain, money, API and
+// the monitor's own freshness; a TLS certificate lapsing or a token going cold
+// looks like none of those until the moment it takes the product down, and then
+// it looks like everything at once.
+//
+// ── OBSERVED, NEVER DECLARED ──────────────────────────────────────────────
+//
+// The obvious implementation is a list of dates in a file. This deliberately
+// has none. A written date is a CLAIM about a credential; it is right on the
+// day it is written and silently wrong from the next rotation onward — and a
+// stale date here fails in the worst direction, reporting "expires in 60 days"
+// about a token replaced last week. 2026-08-04 cost most of a day to exactly
+// that class of error, three times over, in three unrelated files.
+//
+// So every reading here comes from the artefact itself: a JWT's own `exp`, a
+// certificate's own `notAfter`, GitHub's own expiry header. If a credential
+// cannot say when it expires, this reports that it cannot — which is true, and
+// more useful than a number nobody re-checked.
+
+import { connect as tlsConnect } from "node:tls";
+
+/** One credential's expiry, as OBSERVED from the credential itself. */
+export interface CredentialExpiry {
+  /** Operator-facing name — what to go and rotate. */
+  label: string;
+  /** Where the reading came from, so a wrong answer is traceable. */
+  source: string;
+  /** Epoch ms of expiry, or null when the artefact does not declare one. */
+  expiresAtMs: number | null;
+  /** Why it could not be read. Null expiry + no reason is "no expiry declared". */
+  unreadable?: string | null;
+}
+
+export type ExpiryTone = "ok" | "degraded" | "red" | "awaiting";
+
+export interface ExpiryLine {
+  text: string;
+  tone: ExpiryTone;
+}
+
+/**
+ * Two thresholds, chosen for how long the fix actually takes.
+ *
+ * RED at 3 days: rotating an admin credential is a ceremony — find the runbook,
+ * mint on the right EOA, update the secret at the scope consumers read, verify.
+ * That is not a thing to discover on the morning it expires.
+ *
+ * DEGRADED at 14 days: enough warning to schedule it, not so much that the line
+ * sits amber for a month and becomes furniture. A permanently-lit warning is one
+ * nobody reads, which is how the credential expires anyway.
+ */
+export const EXPIRY_RED_MS = 3 * 24 * 60 * 60 * 1000;
+export const EXPIRY_WARN_MS = 14 * 24 * 60 * 60 * 1000;
+
+/**
+ * A JWT's own `exp`, in ms — or null if it does not have one.
+ *
+ * The signature is NOT verified, and that is correct here rather than lazy: we
+ * are reporting what the token claims about itself, and the server that accepts
+ * it reads the same unverified-by-us claim. A token whose `exp` we cannot parse
+ * is reported as unreadable, never as "fine".
+ */
+export function jwtExpiryMs(token: string): number | null {
+  const parts = token.trim().split(".");
+  if (parts.length !== 3) return null;
+  try {
+    const payload = parts[1]!.replace(/-/g, "+").replace(/_/g, "/");
+    const json = JSON.parse(Buffer.from(payload, "base64").toString("utf8")) as Record<string, unknown>;
+    const exp = json.exp;
+    if (typeof exp !== "number" || !Number.isFinite(exp)) return null;
+    // `exp` is seconds since epoch (RFC 7519). Treating it as ms would put every
+    // token in 1970 and report everything as long expired — a false red on every
+    // credential at once, which is the fastest way to teach an operator to
+    // ignore this probe entirely.
+    return exp * 1000;
+  } catch {
+    return null;
+  }
+}
+
+/** Days remaining, rounded down — "expires in 0 days" means today. */
+export function daysUntil(expiresAtMs: number, nowMs: number): number {
+  return Math.floor((expiresAtMs - nowMs) / (24 * 60 * 60 * 1000));
+}
+
+/**
+ * One credential's line.
+ *
+ * An unreadable credential is `awaiting`, never `ok`: not knowing when
+ * something expires is a different fact from knowing it is fine, and the whole
+ * point of this probe is that the second one is worth acting on.
+ */
+export function expiryLine(input: {
+  credential: CredentialExpiry;
+  nowMs: number;
+  redWithinMs?: number;
+  warnWithinMs?: number;
+}): ExpiryLine {
+  const { credential: c, nowMs } = input;
+  const red = input.redWithinMs ?? EXPIRY_RED_MS;
+  const warn = input.warnWithinMs ?? EXPIRY_WARN_MS;
+
+  if (c.unreadable) {
+    return { text: `${c.label} — expiry unreadable (${c.unreadable})`, tone: "awaiting" };
+  }
+  if (c.expiresAtMs === null) {
+    return { text: `${c.label} — no expiry declared by ${c.source}`, tone: "awaiting" };
+  }
+
+  const remaining = c.expiresAtMs - nowMs;
+  const days = daysUntil(c.expiresAtMs, nowMs);
+  if (remaining <= 0) {
+    // Past tense on purpose. "expires in -2 days" is a number an eye slides off.
+    return { text: `${c.label} — EXPIRED ${Math.abs(days)}d ago (${c.source})`, tone: "red" };
+  }
+  if (remaining <= red) {
+    return { text: `${c.label} — EXPIRES IN ${days}d (${c.source})`, tone: "red" };
+  }
+  if (remaining <= warn) {
+    return { text: `${c.label} — expires in ${days}d (${c.source})`, tone: "degraded" };
+  }
+  return { text: `${c.label} — ${days}d left`, tone: "ok" };
+}
+
+const TONE_RANK: Record<ExpiryTone, number> = { ok: 0, awaiting: 1, degraded: 2, red: 3 };
+
+/**
+ * The probe's verdict over every credential.
+ *
+ * Worst tone wins, and the detail LEADS with whatever earned it. An operator
+ * reading one line must get the credential that is about to expire, not the
+ * alphabetically first one — the same reason the Bank lane hoists its overdue
+ * request above the rows.
+ */
+export function credentialExpiryProbe(input: {
+  credentials: CredentialExpiry[];
+  nowMs: number;
+  redWithinMs?: number;
+  warnWithinMs?: number;
+}): { status: "ok" | "degraded" | "red"; detail: string } {
+  if (input.credentials.length === 0) {
+    // Nothing observable is not the same as nothing to worry about, and this
+    // probe must not report a clean bill of health for a check it never ran.
+    return { status: "degraded", detail: "no credentials observable — nothing is watching expiries" };
+  }
+
+  const lines = input.credentials.map((credential) =>
+    expiryLine({
+      credential,
+      nowMs: input.nowMs,
+      ...(input.redWithinMs !== undefined ? { redWithinMs: input.redWithinMs } : {}),
+      ...(input.warnWithinMs !== undefined ? { warnWithinMs: input.warnWithinMs } : {}),
+    }),
+  );
+  const sorted = [...lines].sort((a, b) => TONE_RANK[b.tone] - TONE_RANK[a.tone]);
+  const worst = sorted[0]!.tone;
+
+  // `awaiting` is degraded at probe level: a credential whose expiry cannot be
+  // read is an unwatched credential, and this probe exists precisely so that
+  // nothing sits unwatched.
+  const status = worst === "red" ? "red" : worst === "ok" ? "ok" : "degraded";
+  const headline = sorted
+    .filter((l) => l.tone !== "ok")
+    .slice(0, 3)
+    .map((l) => l.text);
+
+  if (headline.length === 0) {
+    const soonest = Math.min(
+      ...input.credentials
+        .filter((c) => c.expiresAtMs !== null)
+        .map((c) => daysUntil(c.expiresAtMs!, input.nowMs)),
+    );
+    return { status, detail: `${input.credentials.length} credentials, soonest expiry ${soonest}d` };
+  }
+  return { status, detail: headline.join(" · ") };
+}
+
+// ── COLLECTORS: read the artefacts ────────────────────────────────────────
+
+/** Reads a host's leaf certificate expiry. Seam so the probe is testable. */
+export type CertReader = (host: string) => Promise<{ validToMs: number | null; error?: string }>;
+
+/**
+ * A TLS host's `notAfter`, read by connecting and looking at the leaf cert.
+ *
+ * No verification is required for this to be truthful: we are asking the server
+ * what it is presenting, and an expiry we read off a cert the client would
+ * reject is still the expiry that will take the site down. `rejectUnauthorized`
+ * stays ON regardless, because a host that cannot complete a handshake TODAY is
+ * a fact worth surfacing rather than working around.
+ */
+export function tlsCertReader(timeoutMs = 5000): CertReader {
+  return (host) =>
+    new Promise((resolve) => {
+      let settled = false;
+      const done = (r: { validToMs: number | null; error?: string }) => {
+        if (settled) return;
+        settled = true;
+        try {
+          socket.destroy();
+        } catch {
+          /* already gone */
+        }
+        resolve(r);
+      };
+      const socket = tlsConnect({ host, port: 443, servername: host, timeout: timeoutMs }, () => {
+        const cert = socket.getPeerCertificate();
+        const validTo = cert && typeof cert.valid_to === "string" ? Date.parse(cert.valid_to) : NaN;
+        done(Number.isFinite(validTo) ? { validToMs: validTo } : { validToMs: null, error: "no valid_to on the leaf cert" });
+      });
+      socket.on("timeout", () => done({ validToMs: null, error: `no TLS answer in ${timeoutMs}ms` }));
+      socket.on("error", (e: Error) => done({ validToMs: null, error: e.message }));
+    });
+}
+
+/**
+ * Everything this box can observe about its own credential expiries.
+ *
+ * Order is deliberate: certificates first, because a lapsed one is a total
+ * public outage rather than a degraded feature.
+ *
+ * A host that will not answer becomes `unreadable`, NOT absent. Dropping it
+ * would shrink the list silently and let the probe report a clean bill of
+ * health over a credential nobody looked at — absence-is-not-zero, applied to
+ * the thing whose entire job is noticing something before it lapses.
+ */
+export async function collectCredentialExpiries(input: {
+  certHosts: string[];
+  env: Record<string, string | undefined>;
+  jwtEnvKeys: string[];
+  readCert: CertReader;
+}): Promise<CredentialExpiry[]> {
+  const out: CredentialExpiry[] = [];
+
+  for (const host of input.certHosts) {
+    const r = await input.readCert(host);
+    out.push({
+      label: `TLS ${host}`,
+      source: "leaf certificate notAfter",
+      expiresAtMs: r.validToMs,
+      ...(r.error ? { unreadable: r.error } : {}),
+    });
+  }
+
+  for (const key of input.jwtEnvKeys) {
+    const raw = input.env[key];
+    // An UNSET credential is not an unreadable one — there is nothing to watch,
+    // and reporting "cannot read FOO" for a key nobody configured is the
+    // permanently-lit panel again. Skipped entirely.
+    if (!raw || !raw.trim()) continue;
+    const exp = jwtExpiryMs(raw);
+    out.push({
+      label: key,
+      source: "jwt exp claim",
+      expiresAtMs: exp,
+      // Non-JWT credentials (opaque GitHub PATs, webhook URLs) legitimately
+      // carry no expiry. That is "no expiry declared", not a failure to read.
+      ...(exp === null ? {} : {}),
+    });
+  }
+
+  return out;
+}

--- a/services/slack-operator/src/product-health.ts
+++ b/services/slack-operator/src/product-health.ts
@@ -40,6 +40,7 @@ import { bucketPayoutsByHour, isHistogramUnavailable, type PayoutHistogram } fro
 import { endpointHost, pinnedCompareRange, type CrossCheckView } from "./payout-crosscheck.js";
 import { burnBasisLabel, isBurnUnmeasurable, type MeasuredBurn } from "./gas-burn-rate.js";
 import { readBankFeed } from "./bank-feed-fetch.js";
+import { collectCredentialExpiries, credentialExpiryProbe, tlsCertReader } from "./credential-expiry.js";
 import { bankFeedIsDisabled } from "./bank-feed.js";
 import { bankLaneView, BANK_FEED_DISABLED, type BankLaneView } from "./bank-lane.js";
 import { createCrossCheckCache, type CrossCheckCache } from "./payout-crosscheck-cache.js";
@@ -637,6 +638,10 @@ export interface ProductHealthConfig {
   bankFeedUrl: string;
   /** Filesystem the monitor writes to. Container `/` sees real host capacity. */
   diskPath: string;
+  /** Hostnames whose TLS leaf certificate expiry is watched. Empty ⇒ no probe. */
+  certHosts: string[];
+  /** Env keys tried as JWTs for their own `exp`. Unset keys are skipped. */
+  expiryJwtEnvKeys: string[];
   /** Free-space floor in GiB — below this the disk probe goes red. */
   minDiskFreeGb: number;
   /** Free-space warning line in GiB. */
@@ -756,6 +761,11 @@ export function loadProductHealthConfig(env: NodeJS.ProcessEnv = process.env): P
     gasAttributionEnabled: truthy(env.PRODUCT_HEALTH_GAS_ATTRIBUTION_ENABLED),
     gasRefreshMs: num(env.PRODUCT_HEALTH_GAS_REFRESH_MS, 30 * 60 * 1000),
     diskPath: env.PRODUCT_HEALTH_DISK_PATH || "/",
+    // Absent ⇒ the probe does not exist, rather than existing and reporting
+    // that it has nothing to watch. A permanently-degraded probe on every
+    // deployment that never configured it is the panel nobody reads.
+    certHosts: (env.PRODUCT_HEALTH_CERT_HOSTS ?? "").split(",").map((h) => h.trim()).filter(Boolean),
+    expiryJwtEnvKeys: (env.PRODUCT_HEALTH_EXPIRY_JWT_ENV_KEYS ?? "").split(",").map((k) => k.trim()).filter(Boolean),
     // Unlike the token floors (which default to 0 = can-never-go-red, because a
     // sensible balance is deployment-specific), disk exhaustion is universally
     // fatal, so these carry real defaults. Sized against the live box: 155 GiB
@@ -2700,6 +2710,27 @@ export async function collectProductHealthProbes(
   });
   // The Bank lane. The view is decided HERE so the board renders one answer
   // rather than forming its own — same rule as the ops verdict.
+  // Credential expiries, OBSERVED from the artefacts (cert notAfter, JWT exp).
+  // Collected here rather than inside the probe because it is I/O, and the
+  // probe itself stays pure and testable.
+  //
+  // `?? []` is load-bearing, not defensive noise: callers construct this config
+  // by hand (every product-health test does), and an unguarded `.length` on an
+  // absent field threw inside collectProductHealthProbes — taking down the whole
+  // health collection, i.e. the entire board. A credential watchdog that kills
+  // the monitor is worse than no watchdog. Caught by the existing suite.
+  const certHosts = config.certHosts ?? [];
+  const jwtEnvKeys = config.expiryJwtEnvKeys ?? [];
+  const credentialExpiries =
+    certHosts.length > 0 || jwtEnvKeys.length > 0
+      ? await collectCredentialExpiries({
+          certHosts,
+          env: process.env,
+          jwtEnvKeys,
+          readCert: tlsCertReader(),
+        })
+      : null; // nothing configured ⇒ no probe at all, not a probe with nothing to say
+
   const bankRead = await readBankFeed({ url: config.bankFeedUrl, fetchImpl });
   const bank: BankBlock | undefined = bankRead.feed
     ? // A switched-off feed is a VALID payload full of read errors, shaped
@@ -2813,6 +2844,17 @@ export async function collectProductHealthProbes(
         minFreeGb: config.minDiskFreeGb,
         warnFreeGb: config.warnDiskFreeGb,
       }),
+      // A credential that expires on a Thursday is an outage scheduled in
+      // advance, and no other probe would see it coming: chain, money, API and
+      // self-freshness all read green right up to the moment it lapses.
+      ...(credentialExpiries
+        ? [
+            {
+              name: "credential_expiry",
+              ...credentialExpiryProbe({ credentials: credentialExpiries, nowMs: chainCtx.nowMs }),
+            },
+          ]
+        : []),
       deriveMoneyPathProbe(h, {
         maxStuck: config.maxStuck,
         maxFailed24h: config.maxFailed24h,

--- a/services/slack-operator/test/unit/credential-expiry.test.ts
+++ b/services/slack-operator/test/unit/credential-expiry.test.ts
@@ -1,0 +1,206 @@
+import { describe, expect, test } from "vitest";
+
+import {
+  credentialExpiryProbe,
+  daysUntil,
+  expiryLine,
+  jwtExpiryMs,
+  type CredentialExpiry,
+} from "../../src/credential-expiry.js";
+
+const NOW = 1_785_900_000_000; // 2026-08-04-ish
+const DAY = 24 * 60 * 60 * 1000;
+
+/** A real JWT shape — header.payload.signature, payload base64url with `exp`. */
+function jwt(claims: Record<string, unknown>): string {
+  const b64 = (o: unknown) =>
+    Buffer.from(JSON.stringify(o)).toString("base64").replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+  return `${b64({ alg: "ES256", typ: "JWT" })}.${b64(claims)}.c2ln`;
+}
+
+const cred = (over: Partial<CredentialExpiry> = {}): CredentialExpiry => ({
+  label: "ADMIN_JWT",
+  source: "jwt exp claim",
+  expiresAtMs: NOW + 30 * DAY,
+  ...over,
+});
+
+describe("expiry comes from the artefact, never from a written date", () => {
+  test("a JWT's own exp is read, in SECONDS as RFC 7519 specifies", () => {
+    // Treating exp as ms would put every token in 1970 and report every
+    // credential as long expired — a false red on all of them at once, which is
+    // the fastest way to teach an operator to ignore this probe.
+    const expSeconds = Math.floor((NOW + 10 * DAY) / 1000);
+    expect(jwtExpiryMs(jwt({ exp: expSeconds }))).toBe(expSeconds * 1000);
+  });
+
+  test("base64url payloads decode — real tokens use - and _", () => {
+    const expSeconds = Math.floor((NOW + 5 * DAY) / 1000);
+    const token = jwt({ exp: expSeconds, sub: "a+b/c?", scope: "ops~admin" });
+    expect(jwtExpiryMs(token)).toBe(expSeconds * 1000);
+  });
+
+  test("a token with no exp, a non-JWT, and garbage all read as null — never as fine", () => {
+    expect(jwtExpiryMs(jwt({ sub: "nobody" }))).toBeNull();
+    expect(jwtExpiryMs("ghp_notajsonwebtokenatall")).toBeNull();
+    expect(jwtExpiryMs("a.b.c")).toBeNull();
+    expect(jwtExpiryMs("")).toBeNull();
+  });
+
+  test("a non-numeric exp is refused rather than coerced", () => {
+    expect(jwtExpiryMs(jwt({ exp: "1785900000" }))).toBeNull();
+    expect(jwtExpiryMs(jwt({ exp: null }))).toBeNull();
+  });
+});
+
+describe("the two thresholds are about how long the fix takes", () => {
+  test("inside 3 days is RED — rotating an admin credential is a ceremony", () => {
+    const v = expiryLine({ credential: cred({ expiresAtMs: NOW + 2 * DAY }), nowMs: NOW });
+    expect(v.tone).toBe("red");
+    expect(v.text).toContain("EXPIRES IN 2d");
+  });
+
+  test("inside 14 days is degraded — enough to schedule, not enough to become furniture", () => {
+    expect(expiryLine({ credential: cred({ expiresAtMs: NOW + 10 * DAY }), nowMs: NOW }).tone).toBe("degraded");
+  });
+
+  test("beyond the window is ok and stays quiet", () => {
+    expect(expiryLine({ credential: cred({ expiresAtMs: NOW + 90 * DAY }), nowMs: NOW }).tone).toBe("ok");
+  });
+
+  test("already expired reads in the PAST TENSE, not as a negative number", () => {
+    // "expires in -2 days" is a number the eye slides off.
+    const v = expiryLine({ credential: cred({ expiresAtMs: NOW - 2 * DAY }), nowMs: NOW });
+    expect(v.tone).toBe("red");
+    expect(v.text).toContain("EXPIRED 2d ago");
+    expect(v.text).not.toContain("-2");
+  });
+
+  test("days round DOWN — 0d means today, and today is not tomorrow", () => {
+    expect(daysUntil(NOW + DAY - 1, NOW)).toBe(0);
+    expect(daysUntil(NOW + DAY + 1, NOW)).toBe(1);
+  });
+});
+
+describe("cannot-read is never the same as fine", () => {
+  test("an unreadable credential is awaiting, and says why", () => {
+    const v = expiryLine({
+      credential: cred({ expiresAtMs: null, unreadable: "TLS handshake failed" }),
+      nowMs: NOW,
+    });
+    expect(v.tone).toBe("awaiting");
+    expect(v.text).toContain("TLS handshake failed");
+  });
+
+  test("a credential that declares no expiry says so, naming the source", () => {
+    const v = expiryLine({ credential: cred({ expiresAtMs: null, source: "github token header" }), nowMs: NOW });
+    expect(v.tone).toBe("awaiting");
+    expect(v.text).toContain("no expiry declared by github token header");
+  });
+
+  test("an unreadable credential DEGRADES the probe — unwatched is the thing this exists to stop", () => {
+    const p = credentialExpiryProbe({
+      credentials: [cred({ expiresAtMs: NOW + 90 * DAY }), cred({ label: "TLS", expiresAtMs: null, unreadable: "refused" })],
+      nowMs: NOW,
+    });
+    expect(p.status).toBe("degraded");
+    expect(p.detail).toContain("refused");
+  });
+
+  test("no credentials at all is DEGRADED, never ok — a check that never ran is not a pass", () => {
+    const p = credentialExpiryProbe({ credentials: [], nowMs: NOW });
+    expect(p.status).toBe("degraded");
+    expect(p.detail).toContain("nothing is watching");
+  });
+});
+
+describe("the verdict leads with what earned it", () => {
+  test("worst tone wins and its credential is named first", () => {
+    const p = credentialExpiryProbe({
+      credentials: [
+        cred({ label: "aaa-healthy", expiresAtMs: NOW + 200 * DAY }),
+        cred({ label: "zzz-dying", expiresAtMs: NOW + 1 * DAY }),
+        cred({ label: "mmm-soon", expiresAtMs: NOW + 9 * DAY }),
+      ],
+      nowMs: NOW,
+    });
+    expect(p.status).toBe("red");
+    // Not alphabetical, not input order — the one about to expire.
+    expect(p.detail.indexOf("zzz-dying")).toBe(0);
+    expect(p.detail).not.toContain("aaa-healthy");
+  });
+
+  test("all healthy reports the soonest expiry, so the number is still visible", () => {
+    const p = credentialExpiryProbe({
+      credentials: [cred({ expiresAtMs: NOW + 200 * DAY }), cred({ expiresAtMs: NOW + 45 * DAY })],
+      nowMs: NOW,
+    });
+    expect(p.status).toBe("ok");
+    expect(p.detail).toContain("soonest expiry 45d");
+  });
+
+  test("the detail is bounded — three worst, not forty", () => {
+    const many = Array.from({ length: 40 }, (_, i) => cred({ label: `c${i}`, expiresAtMs: NOW + 1 * DAY }));
+    const p = credentialExpiryProbe({ credentials: many, nowMs: NOW });
+    expect(p.detail.split(" · ")).toHaveLength(3);
+  });
+});
+
+describe("collecting from artefacts, not from a list of dates", () => {
+  const okCert = async () => ({ validToMs: NOW + 60 * DAY });
+
+  test("a cert host that will not answer becomes UNREADABLE, never absent", async () => {
+    // Dropping it would shrink the list silently and let the probe report a
+    // clean bill of health over a credential nobody looked at.
+    const { collectCredentialExpiries } = await import("../../src/credential-expiry.js");
+    const got = await collectCredentialExpiries({
+      certHosts: ["up.example", "down.example"],
+      env: {},
+      jwtEnvKeys: [],
+      readCert: async (h) => (h === "down.example" ? { validToMs: null, error: "ECONNREFUSED" } : okCert()),
+    });
+    expect(got).toHaveLength(2);
+    const down = got.find((c) => c.label.includes("down.example"))!;
+    expect(down.unreadable).toBe("ECONNREFUSED");
+    expect(credentialExpiryProbe({ credentials: got, nowMs: NOW }).status).toBe("degraded");
+  });
+
+  test("an UNSET credential is skipped entirely — not reported as unreadable", async () => {
+    // "cannot read FOO" for a key nobody configured is the permanently-lit
+    // panel this board keeps deleting.
+    const { collectCredentialExpiries } = await import("../../src/credential-expiry.js");
+    const got = await collectCredentialExpiries({
+      certHosts: [],
+      env: { SET_TOKEN: jwt({ exp: Math.floor((NOW + 20 * DAY) / 1000) }), EMPTY_TOKEN: "", BLANK_TOKEN: "   " },
+      jwtEnvKeys: ["SET_TOKEN", "EMPTY_TOKEN", "BLANK_TOKEN", "NEVER_DEFINED"],
+      readCert: okCert,
+    });
+    expect(got.map((c) => c.label)).toEqual(["SET_TOKEN"]);
+  });
+
+  test("an opaque non-JWT credential reports no declared expiry rather than an error", async () => {
+    // A GitHub PAT legitimately carries no exp. That is a fact about the
+    // credential, not a failure to read it.
+    const { collectCredentialExpiries } = await import("../../src/credential-expiry.js");
+    const got = await collectCredentialExpiries({
+      certHosts: [],
+      env: { GITHUB_TOKEN: "ghp_opaqueopaqueopaque" },
+      jwtEnvKeys: ["GITHUB_TOKEN"],
+      readCert: okCert,
+    });
+    expect(got[0]!.expiresAtMs).toBeNull();
+    expect(got[0]!.unreadable ?? null).toBeNull();
+    expect(expiryLine({ credential: got[0]!, nowMs: NOW }).text).toContain("no expiry declared");
+  });
+
+  test("certs come first — a lapsed one is a total outage, not a degraded feature", async () => {
+    const { collectCredentialExpiries } = await import("../../src/credential-expiry.js");
+    const got = await collectCredentialExpiries({
+      certHosts: ["a.example"],
+      env: { T: jwt({ exp: Math.floor((NOW + DAY) / 1000) }) },
+      jwtEnvKeys: ["T"],
+      readCert: okCert,
+    });
+    expect(got[0]!.label).toBe("TLS a.example");
+  });
+});


### PR DESCRIPTION
A credential that expires on a Thursday is an outage scheduled in advance — and **no existing probe would see it coming.** Chain, money, API and self-freshness all read green right up to the moment a certificate lapses or a token goes cold.

## Observed, never declared

The obvious implementation is a list of dates in a file. This deliberately has **none**.

A written date is a *claim* about a credential: right the day it's written, silently wrong from the next rotation onward — and it fails in the worst direction, reporting "expires in 60 days" about a token replaced last week. 2026-08-04 lost most of a day to exactly that class of error, three times, in three unrelated files.

Every reading here comes from the artefact: a certificate's own `notAfter`, a JWT's own `exp`. A credential that can't say when it expires reports that it can't — true, and more useful than a number nobody re-checked.

## Scoping corrected the target

The plan was aimed at the hosted-smoke `ADMIN_JWT`. **It isn't in this stack's env at all** — it's a GitHub Actions secret, so a watchdog here could never have seen it. What *is* observable is TLS certs (a lapse is a total public outage, so they lead the list) and any env credential that parses as a JWT.

Wired as a **probe**, not a new subsystem, so it reaches the board, the daily brief, ops health and the Buzz alerts through paths that already exist.

## Truth-boundary choices

| behaviour | why |
|---|---|
| unreadable is `awaiting`, never `ok` | not knowing when something expires ≠ knowing it's fine |
| an unreadable cert host **stays in the list** | dropping it shrinks the set silently and lets the probe report a clean bill over something nobody read |
| an **unset** credential is skipped entirely | "cannot read FOO" for a key nobody configured is the permanently-lit panel |
| nothing configured ⇒ **no probe** | rather than one that's permanently degraded on every deployment that never opted in |
| sources configured but zero credentials ⇒ degraded | a check that never ran is not a pass |
| `EXPIRED 2d ago`, not `expires in -2 days` | a negative number is one the eye slides off |
| `exp` read as **seconds** (RFC 7519) | treating it as ms dates every token to 1970 and red-flags all of them at once — the fastest way to teach an operator to ignore this probe |

Thresholds are about how long the *fix* takes: **red at 3 days** because rotating an admin credential is a ceremony, **degraded at 14** because that's enough to schedule it without the line becoming furniture.

## A bug the existing suite caught

`product-health` tests build config by hand, so `config.certHosts` is `undefined` there — and an unguarded `.length` threw **inside `collectProductHealthProbes`**, taking down the whole health collection, i.e. the entire board. *A credential watchdog that kills the monitor is worse than no watchdog.* Now guarded, with the reason recorded at the site.

## Enabling it

Both unset by default:

```
PRODUCT_HEALTH_CERT_HOSTS=api.averray.com,monitor.averray.com,buzz.averray.com
PRODUCT_HEALTH_EXPIRY_JWT_ENV_KEYS=SOME_JWT_ENV_KEY
```

## Verification

20 unit tests on the pure logic and the collector (fake cert reader); typecheck clean; full suite **2667 passed**; `compose config` valid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)