### PR TITLE
fix(dispatch): seed npm workspace links instead of refusing them

### DIFF
--- a/services/harness-dispatcher/src/workspace-prep.ts
+++ b/services/harness-dispatcher/src/workspace-prep.ts
@@ -2,8 +2,10 @@ import { spawn } from "node:child_process";
 import { createHash, randomUUID } from "node:crypto";
 import {
   cp as copyPath,
+  lstat as lstatPath,
   mkdir as mkdirPath,
   readFile as readFilePath,
+  readlink as readLinkPath,
   realpath as resolveRealPath,
   rename as renamePath,
   rm as removePath,
@@ -69,14 +71,16 @@ export interface WorkspacePrepDeps {
 interface FileStatus {
   isDirectory(): boolean;
   isFile(): boolean;
+  isSymbolicLink(): boolean;
 }
 
 interface DependencyCopyOptions {
   recursive: true;
-  dereference: true;
+  dereference: false;
+  verbatimSymlinks: true;
   force: false;
   errorOnExist: true;
-  filter(source: string): Promise<boolean>;
+  filter(source: string, destination: string): Promise<boolean>;
 }
 
 export interface DependencySeedDeps {
@@ -87,7 +91,9 @@ export interface DependencySeedDeps {
     options: DependencyCopyOptions,
   ): Promise<void>;
   stat(target: string): Promise<FileStatus>;
+  lstat(target: string): Promise<FileStatus>;
   readFile(target: string): Promise<Buffer>;
+  readlink(target: string): Promise<string>;
   realpath(target: string): Promise<string>;
   rename(source: string, destination: string): Promise<void>;
   rm(target: string): Promise<void>;
@@ -264,16 +270,18 @@ export async function seedWorkspaceDependencies(
   try {
     await resolved.cp(cachedNodeModulesReal, staging, {
       recursive: true,
-      dereference: true,
+      dereference: false,
+      verbatimSymlinks: true,
       force: false,
       errorOnExist: true,
       filter: async (source) => {
-        const sourceReal = await resolved.realpath(source);
-        assertContainedOrEqual(
+        await assertDependencyCopySource({
+          resolved,
+          source,
           cachedNodeModulesReal,
-          sourceReal,
-          "dependency_seed_failed",
-        );
+          workspaceRoot,
+          targetNodeModules: target,
+        });
         return true;
       },
     });
@@ -335,13 +343,65 @@ function dependencySeedDeps(
       await copyPath(source, destination, options);
     }),
     stat: deps.stat ?? statPath,
+    lstat: deps.lstat ?? lstatPath,
     readFile: deps.readFile ?? readFilePath,
+    readlink: deps.readlink ?? readLinkPath,
     realpath: deps.realpath ?? resolveRealPath,
     rename: deps.rename ?? renamePath,
     rm: deps.rm ?? (async (target) => {
       await removePath(target, { recursive: true, force: true });
     }),
   };
+}
+
+async function assertDependencyCopySource({
+  resolved,
+  source,
+  cachedNodeModulesReal,
+  workspaceRoot,
+  targetNodeModules,
+}: {
+  resolved: DependencySeedDeps;
+  source: string;
+  cachedNodeModulesReal: string;
+  workspaceRoot: string;
+  targetNodeModules: string;
+}): Promise<void> {
+  const sourcePath = path.resolve(source);
+  assertContainedOrEqual(
+    cachedNodeModulesReal,
+    sourcePath,
+    "dependency_seed_failed",
+  );
+  const sourceStatus = await resolved.lstat(sourcePath);
+  if (!sourceStatus.isSymbolicLink()) {
+    const sourceReal = await resolved.realpath(sourcePath);
+    assertContainedOrEqual(
+      cachedNodeModulesReal,
+      sourceReal,
+      "dependency_seed_failed",
+    );
+    return;
+  }
+
+  const declaredTarget = await resolved.readlink(sourcePath);
+  if (path.isAbsolute(declaredTarget)) {
+    throw dependencyError(
+      "dependency_seed_failed",
+      "Dependency cache symlink target escaped the prepared workspace",
+    );
+  }
+  const relativeSource = path.relative(cachedNodeModulesReal, sourcePath);
+  const destinationLink = path.join(targetNodeModules, relativeSource);
+  const destinationTarget = path.resolve(
+    path.dirname(destinationLink),
+    declaredTarget,
+  );
+  assertContainedOrEqual(
+    workspaceRoot,
+    destinationTarget,
+    "dependency_seed_failed",
+  );
 }
 
 function deriveContainedWorkspacePath(task: AgentTaskV1): string {

--- a/test/unit/workspace-prep.test.ts
+++ b/test/unit/workspace-prep.test.ts
@@ -3,7 +3,9 @@ import { readFileSync } from "node:fs";
 import {
   mkdir,
   mkdtemp,
+  lstat,
   readFile,
+  readlink,
   rm as removePath,
   stat,
   symlink,
@@ -325,6 +327,48 @@ describe("offline workspace dependency seeding", () => {
     )).resolves.toBe("export const seeded = true;\n");
   });
 
+  it("preserves an npm workspace package link as a symlink into the prepared workspace", async () => {
+    const fixture = await populatedSeedFixture();
+    const declaredTarget = "../../packages/mcp-common";
+    await Promise.all([
+      mkdir(path.join(fixture.workspace, "packages/mcp-common"), {
+        recursive: true,
+      }),
+      mkdir(path.join(fixture.cacheNodeModules, "@avg"), {
+        recursive: true,
+      }),
+    ]);
+    await writeFile(
+      path.join(fixture.workspace, "packages/mcp-common/package.json"),
+      '{"name":"@avg/mcp-common"}\n',
+    );
+    await symlink(
+      declaredTarget,
+      path.join(fixture.cacheNodeModules, "@avg/mcp-common"),
+    );
+
+    await expect(seedWorkspaceDependencies(
+      agentTaskFixture(),
+      fixture.workspace,
+      {
+        environment: {
+          HARNESS_DISPATCH_DEP_CACHE_DIR: fixture.cacheRoot,
+        },
+      },
+    )).resolves.toBe("seeded");
+
+    const seededLink = path.join(
+      fixture.workspace,
+      "node_modules/@avg/mcp-common",
+    );
+    expect((await lstat(seededLink)).isSymbolicLink()).toBe(true);
+    await expect(readlink(seededLink)).resolves.toBe(declaredTarget);
+    await expect(readFile(
+      path.join(seededLink, "package.json"),
+      "utf8",
+    )).resolves.toBe('{"name":"@avg/mcp-common"}\n');
+  });
+
   it("refuses a missing exact lockfile cache as stale without copying or networking", async () => {
     const { workspace, cacheRoot } = await emptySeedFixture();
     await writeFile(
@@ -374,12 +418,52 @@ describe("offline workspace dependency seeding", () => {
     expect(error.reason).toBe("dependency_cache_missing");
   });
 
-  it("rejects a cached symlink that resolves outside node_modules", async () => {
+  it("rejects a cached symlink with an absolute target outside both roots", async () => {
     const fixture = await populatedSeedFixture();
-    const external = path.join(fixture.root, "outside.js");
+    const externalRoot = await mkdtemp(
+      path.join(tmpdir(), "harness-dep-absolute-escape-"),
+    );
+    temporaryRoots.push(externalRoot);
+    const external = path.join(externalRoot, "outside.js");
     await writeFile(external, "do not copy\n");
     await symlink(
       external,
+      path.join(fixture.cacheNodeModules, "escape.js"),
+    );
+
+    const error = await capturedWorkspacePrepError(
+      seedWorkspaceDependencies(agentTaskFixture(), fixture.workspace, {
+        environment: {
+          HARNESS_DISPATCH_DEP_CACHE_DIR: fixture.cacheRoot,
+        },
+      }),
+    );
+
+    expect(error.reason).toBe("dependency_seed_failed");
+    await expect(
+      stat(path.join(fixture.workspace, "node_modules")),
+    ).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("rejects a cached symlink whose relative target escapes the workspace", async () => {
+    const fixture = await populatedSeedFixture();
+    const externalRoot = await mkdtemp(
+      path.join(tmpdir(), "harness-dep-relative-escape-"),
+    );
+    temporaryRoots.push(externalRoot);
+    const external = path.join(externalRoot, "outside.js");
+    await writeFile(external, "do not copy\n");
+    const destinationLink = path.join(
+      fixture.workspace,
+      "node_modules/escape.js",
+    );
+    const declaredTarget = path.relative(
+      path.dirname(destinationLink),
+      external,
+    );
+    expect(declaredTarget).toMatch(/^\.\.[/\\]/u);
+    await symlink(
+      declaredTarget,
       path.join(fixture.cacheNodeModules, "escape.js"),
     );
 


### PR DESCRIPTION
Closes the third wall on the task-family packet. The code is the implementer's, unmodified; **I committed and published it** because their run stopped at D4's environmental gate before committing anything.

## The fix

`dereference: true` → `dereference: false, verbatimSymlinks: true`, and the filter now classifies a symlink by its **declared target**, resolved against where the link will land in the prepared workspace rather than against the cache where it is merely stored. Regular files keep the original `realpath` containment check.

The detail I'd have got wrong: the destination is computed from `targetNodeModules` — the final path after the staging rename — not from the staging directory. Containment is therefore reasoned about where the link actually ends up.

## Verified independently

Applied to a clean `main` checkout, `npm ci`, typecheck 0, **19/19**.

### The guard bites — but not the way the handback implies

Removing **only** the destination-containment assertion:

```
× rejects a cached symlink whose relative target escapes the workspace
  Tests  1 failed | 18 passed (19)
```

Removing **only** the `path.isAbsolute` guard:

```
  Tests  19 passed (19)
```

So `isAbsolute` is **redundant** — `path.resolve` on an absolute target yields that absolute path, and the containment assertion refuses it regardless. There is **one** load-bearing guard with an early exit in front of it, not two independent ones.

Not a defect, and the redundancy is harmless. But the evidence should not be read as two separately-proven refusal mechanisms, and the containment assertion is the single point of failure for the relative-escape case.

### D4 — the load-bearing half, closed

Colima was down for the implementer at 18:13; it was up at 18:18. The question D4 exists to answer is whether a *preserved* link actually resolves where it lands, since a symlink that survives the copy but dangles in the container would fail silently:

```
$ docker run --rm -v "$WS:/w" -w /w node:22-bookworm-slim \
    node -e 'console.log(require.resolve("@avg/mcp-common"))'
/w/packages/mcp-common/dist/index.js
```

Resolves correctly inside the container. The premise the fix rests on holds.

**Still open:** the full dispatcher → seeded cache → container → `npm test` path. That is coupled to the task-family packet — the existing eleven cases skip seeding entirely — so it should be reported there rather than manufactured here.

## Protocol note

There was no SHA to verify against, because nothing was committed. The #696 rule expects the full head SHA in the handback before review; a stop that leaves work uncommitted has no SHA to state. Worth a line in the protocol so uncommitted work is either committed or explicitly flagged as unverifiable.
