### PR TITLE
fix(hermes): advertise a real model, not the virtual name that 404s

### DIFF
--- a/docs/HERMES_UPGRADE_v020.md
+++ b/docs/HERMES_UPGRADE_v020.md
@@ -10,7 +10,7 @@ shape — upstream diffed against **what we actually use**, not a feature tour.
 | Running | **v0.20.0** (`v2026.8.3`) since 2026-08-04 — was v0.18.0 (`v2026.7.1`) for a month |
 | Released | v0.20.0 shipped 2026-08-03; taken the next day |
 | Skipped | v0.19.1 — NO-GO on 2026-07-31, **on a diagnosis that was wrong** (§1) |
-| Verdict | **DONE — upgraded and verified 2026-08-04.** See §6 |
+| Verdict | **Upgraded 2026-08-04. Declared verified, WAS NOT** — it broke every answer for six hours (§7) |
 
 
 It is **v0.20.0**, not "2.0" — the project is still on a 0.x line.
@@ -138,7 +138,7 @@ ops/upgrade-hermes.sh --check-only  # run the checks against what is live now
 3. **Recreate only `hermes` + `hermes-gateway`**, with `--no-deps` — pulling
    deps would re-run `hermes-permissions` and its `chmod -R 0777 /opt/data`,
    re-opening the volume Hermes secures to 0700.
-4. **Two checks**, deliberately narrow because a check that tests everything is
+4. **Three checks**, deliberately narrow because a check that tests everything is
    a check nobody runs:
    - **Session API binds and answers** — `POST /api/sessions` returns 201.
      `/health` is *not* sufficient: on v0.19.1 the gateway reported healthy
@@ -148,6 +148,10 @@ ops/upgrade-hermes.sh --check-only  # run the checks against what is live now
      `averray_board_health`. Not a log grep: under lazy startup the boot log is
      silent on MCP whether the surface is healthy or dead (§6). Not `mcp list`
      either: that reports what is configured, and configured is not working.
+   - **A turn actually completes** — post to `/v1/chat/completions` using the
+     model id read from `GET /v1/models`, and assert non-empty content. Added
+     after v0.20.0 shipped six hours of 404s past the first two (§7). The first
+     check proves the API *accepts* work; only this one proves it *does* any.
 
 It does **not** roll back on its own. A failed check prints the exact revert
 commands and stops — humans own deploy, and auto-restoring a data volume is not
@@ -217,3 +221,83 @@ mitigation. **A real decision, not upgrade cleanup — tracked separately.**
 "you already have a local skill by this name — yours was kept", so the agent
 runs v0.18-era bundled skills under a v0.20.0 binary. `ops/averray-ops` is
 unaffected (bind-mounted from the repo, synced by `deploy-monitor.sh`).
+
+## 7. The regression this upgrade shipped, and the check that missed it
+
+**Symptom.** From 12:48 on 2026-08-04, every question asked in the Buzz `#Ops`
+channel came back:
+
+```
+API call failed after 3 retries: HTTP 404: model "hermes-agent" not found
+```
+
+Roughly six hours, on the control plane, while §6 recorded the upgrade as
+verified.
+
+**Root cause.** The `api_server` platform is OpenAI-compatible, so it advertises
+a model in `GET /v1/models` and clients send that id back on every request. With
+`model_name` unset it advertises the string `hermes-agent` — a **virtual** name
+Hermes is meant to recognise as its own and swap for the configured model before
+calling the provider. `gateway/platforms/api_server.py` still carries the intent:
+`_request_agent_overrides(body, virtual_model=self._model_name)`, and it only
+treats a request as a route when `model != self._model_name`.
+
+On v0.20.0 the swap stopped happening. The virtual name reached Ollama Cloud
+verbatim, and Ollama answered correctly — it has no such model.
+
+Everything else was healthy, which is why this took so long to find:
+
+| Suspected | Actual |
+|---|---|
+| Config wrong | `hermes config get model` → `glm-5.2:cloud`. Correct. |
+| `:cloud` suffix retired | All four names tested → **200**. Suffix is fine. |
+| `hermes-agent` a catalog fallback | 0 occurrences in `models_dev_cache.json`. |
+| api_server dead | `gateway_state.json` said `fatal` — **a stale corpse**; live `POST /api/sessions` → 201. |
+| The bundled `hermes-agent` skill | Name collision only. Unrelated. |
+
+The only wrong value in the entire system was the name on the wire.
+
+**Fix.** `hermes/config/hermes.yaml` now sets
+`platforms.api_server.model_name: glm-5.2:cloud`. This does not depend on
+upstream restoring the swap: whether or not the virtual name is resolved, the
+string clients send is now one the provider honours. The pass-through stops
+being a failure mode rather than merely being avoided.
+
+`test/unit/hermes-config.test.ts` reads the file and fails if `model_name` is
+absent, is `hermes-agent`, or drifts from `model.default`. Verified by breaking
+the config both ways and watching it go red — the config is a mounted artefact,
+so a test that reads it is the only thing that can guard it.
+
+### The check was wrong, and it was wrong in a way we had already been warned about
+
+CHECK 1 does `POST /api/sessions` → 201 and calls that proof. **Creating a
+session is not completing one.** It proved the API binds, which is genuinely the
+v0.19.1 failure it was written for, and then that pass got read as "the upgrade
+works". The answer path was never exercised. §6's own lesson about CHECK 2 —
+that a check has to *do the thing* rather than observe a proxy for it — applied
+here too and was not carried across.
+
+CHECK 3 now completes a real turn and asserts on content. Two properties matter:
+
+- **It sends the model id read from `GET /v1/models`, not a hardcoded name.**
+  That is the exact string a client sends. Hardcoding `glm-5.2:cloud` would have
+  passed green straight through this outage, because the *configured* model was
+  never the broken one.
+- **It asserts non-empty content**, because a 200 with empty `choices` is the
+  same class of false pass as a 201 that never completed.
+
+Both of its JSON extractions normalise `\"` first. Without that the failure line
+for this very incident renders as `model \` — a check that names nothing. Found
+by running the real payload through it, not by reading it.
+
+### Still open after this fix
+
+- **The auxiliary lane leaks to a paid fallback.** The gateway logs
+  `PAID lane engaged — OpenRouter fallback model 'google/gemini-3.6-flash' is
+  not a :free SKU and may incur real spend`, despite `auxiliary.background_review`
+  being pinned to ollama-cloud. Real money; needs its own pass.
+- **`terminal.backend: local` on a `0.0.0.0` listener.** The warning is real and
+  the docker backend is not the answer (no socket is mounted; granting one is
+  worse). Firewalling 8642 is. Unowned.
+- **Whether upstream intends the virtual-name swap to still work.** Worth an
+  issue; our fix is deliberately independent of the answer.

--- a/hermes/config/hermes.yaml
+++ b/hermes/config/hermes.yaml
@@ -54,9 +54,32 @@ paths:
 #
 # Key, port and bind address stay in the environment (ops/compose.command-center.yml);
 # only the opt-in lives here.
+#
+# ── model_name: WHY THIS IS A REAL MODEL AND NOT A LABEL ──────────────────
+#
+# The api_server is an OpenAI-compatible endpoint, so it advertises a model in
+# GET /v1/models and clients send that id back on every request. Left unset it
+# advertises the string `hermes-agent` — a VIRTUAL name that Hermes is supposed
+# to recognise as its own and swap for the configured model before calling the
+# provider (gateway/platforms/api_server.py passes it as `virtual_model=` and
+# only treats a request as a route when `model != self._model_name`).
+#
+# On v0.20.0 that swap stopped happening. The virtual name reached the provider
+# verbatim and Ollama Cloud answered, correctly, `model "hermes-agent" not
+# found` — so every question asked in Buzz #Ops failed with a 404 for six
+# hours on 2026-08-04 while the gateway, the Session API and the MCP surface
+# were all healthy. Config was right; env was right; only the name on the wire
+# was wrong.
+#
+# Naming a REAL model here fixes it in a way that does not depend on upstream:
+# whether or not the virtual-model swap works, the string clients send is now
+# one the provider will honour. The pass-through stops being a failure mode
+# instead of merely being avoided. Keep it equal to `model.default` above —
+# test/unit/hermes-config.test.ts fails if the two drift apart.
 platforms:
   api_server:
     enabled: true
+    model_name: glm-5.2:cloud
 
 # ── THE TOOL SURFACE THIS DEPLOYMENT ACTUALLY NEEDS ───────────────────────
 #

--- a/ops/upgrade-hermes.sh
+++ b/ops/upgrade-hermes.sh
@@ -155,12 +155,86 @@ check_mcp_tools() {
   echo "  CHECK 2 PASS: averray MCP connected, ${count} tools, averray_board_health present"
 }
 
+# CHECK 3 — can it COMPLETE a turn, not just accept one?
+#
+# CHECK 1 proves the Session API binds. It does not prove Hermes can answer,
+# and on 2026-08-04 that gap cost a day: the v0.20.0 upgrade passed CHECK 1 and
+# CHECK 2 at 09:20, was declared verified, and every question asked in Buzz
+# #Ops from 12:48 onward failed with `model "hermes-agent" not found`. Creating
+# a session is not completing one, and nothing here looked at the answer.
+#
+# THE MODEL NAME IS READ FROM THE SERVER, NOT HARDCODED. That is the whole
+# point. The regression was that the api_server's advertised VIRTUAL model name
+# stopped resolving to the configured model, so the exact string a client sends
+# is the string this check must send. Hardcoding `glm-5.2:cloud` here would
+# have sailed through the outage green, because the configured model was fine —
+# it was the advertised one that was broken.
+check_completion() {
+  local port key models advertised body content
+  port="$(grep '^HERMES_GATEWAY_PORT=' "$ENV_FILE" | tail -1 | sed 's/^HERMES_GATEWAY_PORT=//')"
+  port="${port:-8642}"
+  key="$(grep '^HERMES_GATEWAY_API_KEY=' "$ENV_FILE" | tail -1 | sed 's/^HERMES_GATEWAY_API_KEY=//')"
+  if [ -z "$key" ]; then
+    echo "  CHECK 3 SKIPPED: HERMES_GATEWAY_API_KEY is unset — cannot authenticate." >&2
+    return 1
+  fi
+
+  models="$(curl -s --max-time 10 "http://127.0.0.1:${port}/v1/models" \
+    -H "Authorization: Bearer ${key}" 2>/dev/null)" || true
+  advertised="$(printf '%s' "$models" \
+    | sed -n 's/.*"id"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -1)"
+  if [ -z "$advertised" ]; then
+    echo "  CHECK 3 FAIL: GET /v1/models advertised no model id." >&2
+    return 1
+  fi
+
+  # A real turn against a real provider. 120s because this is a live model call
+  # with our full MCP tool surface in context, not a health ping.
+  body="$(curl -s --max-time 120 \
+    -X POST "http://127.0.0.1:${port}/v1/chat/completions" \
+    -H "Authorization: Bearer ${key}" \
+    -H 'Content-Type: application/json' \
+    -d "{\"model\":\"${advertised}\",\"messages\":[{\"role\":\"user\",\"content\":\"Reply with the single word: pong\"}],\"stream\":false}" \
+    2>/dev/null)" || true
+
+  # `\"` inside a JSON string value has to become something else BEFORE the
+  # extraction below, because `[^"]*` stops dead at the backslash-escaped quote.
+  # The message that matters here is literally `model \"hermes-agent\" not
+  # found`, so without this the check prints `model \` — a failure that names
+  # nothing, which is the exact trap CHECK 1's comment warns about. Caught by
+  # running the real 2026-08-04 payload through it.
+  unescape() { sed "s/\\\\\"/'/g"; }
+
+  # The provider's own error, surfaced verbatim. `model "X" not found` is the
+  # 2026-08-04 signature and naming it beats a bare status code.
+  if printf '%s' "$body" | grep -q '"error"'; then
+    echo "  CHECK 3 FAIL: completion with the advertised model '${advertised}' was rejected:" >&2
+    printf '%s' "$body" | unescape \
+      | sed -n 's/.*"message"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/    \1/p' | head -1 >&2
+    return 1
+  fi
+
+  # Assert on CONTENT. A 200 carrying an empty choices array is the same class
+  # of false pass as a 201 that never completed — it looks like an answer and
+  # is not one.
+  content="$(printf '%s' "$body" | unescape \
+    | sed -n 's/.*"content"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -1)"
+  if [ -z "$content" ]; then
+    echo "  CHECK 3 FAIL: completion with '${advertised}' returned no content." >&2
+    printf '%s' "$body" | head -c 300 | sed 's/^/    /' >&2
+    echo >&2
+    return 1
+  fi
+  echo "  CHECK 3 PASS: completed a turn as '${advertised}' -> $(printf '%s' "$content" | head -c 40)"
+}
+
 run_checks() {
   echo
   echo "── checks ──────────────────────────────────────────────────────────"
   local failed=false
   check_session_api || failed=true
   check_mcp_tools || failed=true
+  check_completion || failed=true
   echo
   [ "$failed" = false ]
 }

--- a/services/slack-operator/test/unit/hermes-config.test.ts
+++ b/services/slack-operator/test/unit/hermes-config.test.ts
@@ -1,0 +1,76 @@
+// The Hermes config is a MOUNTED ARTEFACT, not code — nothing typechecks it,
+// nothing imports it, and CI has no opinion about it. It is bind-mounted into
+// the gateway at /opt/data/config.yaml and read once at boot, so a wrong value
+// here surfaces as a live control-plane outage and nowhere earlier.
+//
+// That is exactly what happened on 2026-08-04. Every question asked in Buzz
+// #Ops failed for six hours with `model "hermes-agent" not found` while the
+// gateway, the Session API and all 37 MCP tools were healthy — because the
+// api_server was advertising a VIRTUAL model name that upstream had stopped
+// resolving. No test read the file, so nothing could have caught it.
+//
+// This is the lesson from the mainnet bank-lane template, restated: an artefact
+// is guarded by a test that READS it. A CI step that never opens the file is
+// not a guard.
+
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { describe, expect, test } from "vitest";
+import { parse } from "yaml";
+
+const CONFIG_PATH = join(__dirname, "../../../../hermes/config/hermes.yaml");
+
+interface HermesConfig {
+  model?: { default?: string; provider?: string };
+  auxiliary?: { background_review?: { model?: string; provider?: string } };
+  platforms?: { api_server?: { enabled?: boolean; model_name?: string } };
+}
+
+const config = parse(readFileSync(CONFIG_PATH, "utf8")) as HermesConfig;
+
+describe("the api_server advertises a model the provider will actually honour", () => {
+  test("model_name is set at all — unset means it advertises `hermes-agent`", () => {
+    // Left unset, Hermes advertises its own virtual name in GET /v1/models,
+    // clients send that string back, and whether it works depends on upstream
+    // still swapping it for the configured model. v0.20.0 stopped doing that.
+    expect(config.platforms?.api_server?.model_name).toBeTruthy();
+  });
+
+  test("model_name is NOT the virtual name that broke", () => {
+    expect(config.platforms?.api_server?.model_name).not.toBe("hermes-agent");
+  });
+
+  test("model_name matches model.default — one model, named once", () => {
+    // Drift here is silent and asymmetric: the agent answers on model.default
+    // while every API client is told to ask for something else. They must be
+    // the same string, so that whichever one a code path happens to use, the
+    // provider recognises it.
+    expect(config.platforms?.api_server?.model_name).toBe(config.model?.default);
+  });
+
+  test("the advertised model carries a provider-qualified tag", () => {
+    // `glm-5.2:cloud` resolves at ollama.com; a bare product name like
+    // `hermes-agent` is what a 404 looks like before it happens. This does not
+    // prove the model exists — only a live call does that, which is CHECK 3 in
+    // ops/upgrade-hermes.sh — but it catches a name that is obviously not one.
+    expect(config.platforms?.api_server?.model_name).toMatch(/:/);
+  });
+});
+
+describe("the pieces that must not silently diverge", () => {
+  test("the api_server platform is still opted in", () => {
+    // v0.19.1 needs this opt-in to exist before any API_SERVER_* env var can
+    // override it; with no `platforms:` key the gateway binds nothing and
+    // reports healthy. Documented at length in the config itself.
+    expect(config.platforms?.api_server?.enabled).toBe(true);
+  });
+
+  test("the auxiliary lane points at our own provider, not a paid fallback", () => {
+    // Unset, this falls through the auxiliary chain to OpenRouter — the gateway
+    // logs "PAID lane engaged ... may incur real spend" — and then to Nous
+    // Portal, which has no credit. This pin is a spend control.
+    expect(config.auxiliary?.background_review?.provider).toBe(config.model?.provider);
+    expect(config.auxiliary?.background_review?.model).toBe(config.model?.default);
+  });
+});


### PR DESCRIPTION
## The outage

From **12:48 on 2026-08-04**, every question asked in Buzz `#Ops` came back:

```
API call failed after 3 retries: HTTP 404: model "hermes-agent" not found
```

Six hours, on the control plane, while `HERMES_UPGRADE_v020.md` recorded the morning's v0.20.0 upgrade as verified.

## Root cause

The `api_server` platform is OpenAI-compatible, so it advertises a model in `GET /v1/models` and clients send that id back on every request. With `model_name` unset it advertises **`hermes-agent`** — a *virtual* name Hermes is meant to recognise as its own and swap for the configured model before calling the provider. The intent is still visible in the shipped source:

```python
agent_overrides = _request_agent_overrides(body, virtual_model=self._model_name)
if not route and model and model != self._model_name:   # only route when it DIFFERS
```

On v0.20.0 the swap stopped happening. The virtual name reached Ollama Cloud verbatim, and Ollama answered correctly — it has no such model.

## Everything else was healthy, which is why it took so long

| Suspected | Actual |
|---|---|
| Config wrong | `hermes config get model` → `glm-5.2:cloud`. Correct. |
| `:cloud` suffix retired | All four names POSTed to the provider → **200**. Fine. |
| `hermes-agent` a catalog fallback | **0** occurrences in `models_dev_cache.json`. |
| api_server dead | `gateway_state.json` said `fatal` — a **stale corpse** from a superseded process. Live `POST /api/sessions` → 201. |
| The bundled `hermes-agent` skill | Name collision only. Unrelated. |

The only wrong value in the entire system was the name on the wire.

## The fix

`hermes/config/hermes.yaml` sets `platforms.api_server.model_name: glm-5.2:cloud`.

This deliberately does **not** depend on upstream restoring the swap. Whether or not the virtual name resolves, the string clients send is now one the provider honours — the pass-through stops being a failure mode rather than merely being avoided.

## The check that missed it

`CHECK 1` does `POST /api/sessions` → 201, and that pass got read as "the upgrade works". **Creating a session is not completing one.** It proved the API binds — genuinely the v0.19.1 failure it was written for — and never exercised the answer path.

`CHECK 3` completes a real turn and asserts on content. Two properties matter:

- **It sends the model id read from `GET /v1/models`**, not a hardcoded name. That is the exact string a client sends. Hardcoding `glm-5.2:cloud` would have passed green straight through this outage, because the *configured* model was never the broken one.
- **It asserts non-empty content**, because a 200 with empty `choices` is the same class of false pass as a 201 that never completed.

Both JSON extractions normalise `\"` first. Without that, the failure line for *this very incident* renders as `model \` — a check that names nothing, which is the trap `CHECK 1`'s own comment warns about. Found by running the real payload through it, not by reading it.

## Verification

- `services/slack-operator/test/unit/hermes-config.test.ts` reads the config and fails if `model_name` is absent, is `hermes-agent`, or drifts from `model.default`. **Verified by breaking the config both ways and watching it go red** — a mounted artefact is only guarded by a test that opens it.
- Full slack-operator unit suite: **125 passed**.
- `bash -n ops/upgrade-hermes.sh` clean; all four CHECK 3 parse paths exercised against the real payloads captured from the box (advertised-id extraction, the 404 error body, a good completion, empty `choices`).

CHECK 3 itself has **not** run live yet — it needs this merged and deployed. That is the acceptance test.

## Still open (recorded in §7, not fixed here)

- **The auxiliary lane leaks to a paid fallback.** The gateway logs `PAID lane engaged — OpenRouter fallback model 'google/gemini-3.6-flash' is not a :free SKU and may incur real spend`, despite `auxiliary.background_review` being pinned to ollama-cloud. Real money.
- **`terminal.backend: local` on a `0.0.0.0` listener.** The warning is real; the docker backend is not the answer (no socket mounted, granting one is worse). Firewalling 8642 is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)