### PR TITLE
ceremony(int3): let the first send target a repository of the operator's choosing

### DIFF
--- a/scripts/ceremony/int2-bringup.sh
+++ b/scripts/ceremony/int2-bringup.sh
@@ -20,7 +20,7 @@ _int2_bringup() {
 
   [ -d "$CEREMONY_ROOT" ] \
     || { die "ceremony root is absent: $CEREMONY_ROOT"; return 1; }
-  [ -d "$REFERENCE_CHECKOUT/.git" ] \
+  [ -e "$REFERENCE_CHECKOUT/.git" ] \
     || { die "reference checkout is not a Git checkout"; return 1; }
   [ -x "$HARNESS_BIN" ] \
     || { die "Harness executable is absent: $HARNESS_BIN"; return 1; }

--- a/scripts/ops/harness-pilot.mjs
+++ b/scripts/ops/harness-pilot.mjs
@@ -5,6 +5,7 @@ import path from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 
 const FIXTURES = new Set([
+  "first-send",
   "docs-fix",
   "add-unit-test",
   "small-refactor",

--- a/test/fixtures/agent-integration/ceremony/first-send.json
+++ b/test/fixtures/agent-integration/ceremony/first-send.json
@@ -1,0 +1,41 @@
+{
+  "workItemId": "firstsend-20260804-001",
+  "correlationId": "firstsend-20260804-001",
+  "taskKind": "lint_format",
+  "title": "Record that this repository received the first supervised send",
+  "objective": "Append one concise line to docs/NOTES.md stating that this repository is the target of the first supervised pull-request send, preserving the surrounding text and clean formatting.",
+  "whyNow": "The INT-3 gate requires one verified handoff to open exactly one pull request against a real repository.",
+  "requestedBy": {
+    "type": "operator",
+    "id": "pilot-operator"
+  },
+  "repository": {
+    "nameWithOwner": "depre-dev/averray-send-test",
+    "baseRevision": "f649d3c442d552d0a7ea7b31af566c2b7071353e",
+    "allowedPaths": [
+      "docs/**"
+    ],
+    "forbiddenPaths": [
+      ".github/**",
+      "scripts/**"
+    ]
+  },
+  "profile": "coding-change-pilot",
+  "acceptanceCriteria": [
+    {
+      "id": "format-command",
+      "type": "command",
+      "command": "test -n \"$(git diff --numstat)\" && git diff --check",
+      "required": true
+    }
+  ],
+  "budget": {
+    "elapsedSeconds": 60,
+    "modelTokens": 8000,
+    "toolCalls": 30,
+    "estimatedUsdMicros": null
+  },
+  "deadline": "2027-12-31T23:59:59.000Z",
+  "riskTier": "low",
+  "selectionReason": "One appended line in a tracked allowlisted file is bounded, reversible, and produces a verifier-visible diff without requiring node_modules."
+}

--- a/test/fixtures/agent-integration/ceremony/first-send.jsonl
+++ b/test/fixtures/agent-integration/ceremony/first-send.jsonl
@@ -1,0 +1,2 @@
+{"tool_calls":[{"id":"firstsend-append","name":"shell_run","arguments":{"command":"printf '%b' '\\nThis repository received the first supervised pull-request send.\\n' >> docs/NOTES.md"}}],"usage":{"input_tokens":2,"output_tokens":1,"requests":1},"finish_reason":"tool_call"}
+{"text":"Appended one line recording the first supervised send.","usage":{"input_tokens":2,"output_tokens":2,"requests":1},"finish_reason":"stop"}


### PR DESCRIPTION
Two things found by running the ceremony end to end, not by reading it. Both blocked the first send; both are small.

## The pilot CLI cannot dispatch against a chosen repository

`--fixture` resolves against a hardcoded `FIXTURES` set. There is no way to supply an operator-chosen fixture, so there is no way to target a repository other than the ones already committed — and every committed fixture pins `depre-dev/averray-reference-agent`, which is exactly what the first-send ceremony says not to use.

Adds `first-send`, pinned to a disposable target. Its criterion is `git diff --check` **deliberately**: it needs no `node_modules`, so the unresolved `.bin` seeding defect (#728) cannot reach it. The boring family is the right one to send first.

## The bring-up script rejects git worktrees

```sh
[ -d "$REFERENCE_CHECKOUT/.git" ]
```

In a git worktree `.git` is a *file*, not a directory. The script refused a perfectly valid checkout with "reference checkout is not a Git checkout". `-e` accepts both.

Cost me a clone to work around, and would cost the same to anyone running the ceremony from a worktree — which is the repo's own default workflow.

## Correcting something I said earlier

I also reported that the ceremony docs omit building the pilot image, after a run failed `environment_provisioning_failed`. **That was wrong.** Runbook §1.3 covers it — "build or select a locally available, immutable pilot image", with `docker image inspect "$PILOT_IMAGE"` and an explicit pin. I skipped it by reusing a stale profile from the July ceremony whose pinned image ID no longer existed on the machine. The doc is fine; I didn't follow it.

## Proven by use

With these two changes the ceremony reached a verified handoff against a real external repository:

```
work item    firstsend-20260804-003 v1   lifecycle = handoff_ready
harness run  fbc500f3-cb91-59d4-…        outcome = completed
decision     handoff
egress       deny_all []
patch        docs/NOTES.md +2, digest verified
```

Two behaviours worth recording as correct: cloning a private target failed **before** any run was created, and a blocked task did **not** silently retry — each attempt needed a fresh work item.

🤖 Generated with [Claude Code](https://claude.com/claude-code)