### PR TITLE
fix(ops-board): stop the board deleting the evidence it was given

### DIFF
--- a/packages/monitor-ui/index.html
+++ b/packages/monitor-ui/index.html
@@ -7,12 +7,20 @@
     <!-- Full-viewport host chain: .hm-board is width/height:100% and
          collapses to a sliver unless #root/body/html give it a sized
          parent. The page canvas color matches --avy-bg so there is no
-         flash before the stylesheet loads. -->
+         flash before the stylesheet loads.
+
+         `min-height`, NOT `height`. A fixed `height: 100%` pinned the document
+         to the viewport, so when the board was taller than the window the
+         excess had nowhere to go AND could not be scrolled to — measured
+         2026-08-04 on a 923px screen, the footer sat at y=1206, unreachable.
+         That is why the payout-evidence panel rendered empty on a laptop.
+         This inline rule outranks the stylesheets, so fixing hermes4-ops.css
+         alone changed nothing; the two must agree. -->
     <style>
       html,
       body,
       #root {
-        height: 100%;
+        min-height: 100%;
       }
       body {
         margin: 0;

--- a/packages/monitor-ui/ops-preview.html
+++ b/packages/monitor-ui/ops-preview.html
@@ -6,12 +6,17 @@
     <title>Ops board — preview</title>
     <!-- Dev-only harness for iterating the Ops surface against fixtures. Not a
          Vite build input, so it never ships in the prod bundle. Canvas bg matches
-         --h4-canvas so there's no flash before the stylesheet loads. -->
+         --h4-canvas so there's no flash before the stylesheet loads.
+
+         Kept byte-identical to index.html's host chain ON PURPOSE — including
+         `min-height` rather than `height` (see the note there). A preview that
+         sizes its document differently from production is a preview that lies
+         about the layout, which is the one thing it exists not to do. -->
     <style>
       html,
       body,
       #root {
-        height: 100%;
+        min-height: 100%;
       }
       body {
         margin: 0;

--- a/packages/monitor-ui/src/styles/hermes4-ops.css
+++ b/packages/monitor-ui/src/styles/hermes4-ops.css
@@ -26,14 +26,39 @@
 html,
 body,
 #root {
-  height: 100%;
+  min-height: 100%;
 }
+
+/* ---- WHEN THE BOARD DOES NOT FIT, IT SCROLLS. IT DOES NOT HIDE. ----
+   This was `height: 100dvh; overflow: hidden`, which is right for the wall
+   display this board is designed for and silently destructive anywhere else.
+   The money band is the only `flex: 1` child, so it absorbed the entire
+   shortfall while its fixed siblings took what they liked. MEASURED on a
+   1512x923 laptop, 2026-08-04:
+
+     natural content   ~1089px      available   835px
+     .ops-solvency     needs 503    had 250     ← three balance rows gone
+     .ops-flow         needs 398    had 250     ← ALL payout evidence gone
+
+   So the board rendered a panel titled PAYOUT EVIDENCE — INDEPENDENT ON-CHAIN
+   PROOF containing no evidence, under a headline reading "money is moving and
+   proven on-chain". The proof was fetched, derived, tested and thrown away one
+   layer before an eye.
+
+   SCALING DOWN CANNOT FIX THIS, which is what the measurement settled: every
+   size is expressed in `--ops-u`, so shrinking it shrinks the container and the
+   contents together and the ratio never improves. Closing a 1089→835 gap needs
+   `--ops-u` near 0.77px — 10px labels at 7.7px. Illegible is not visible.
+
+   `min-height` + `overflow-y: auto` keeps the fixed canvas EXACTLY as designed
+   wherever the content fits (the wall display, where the footer still lands on
+   the bottom edge), and lets it scroll where it does not. Scrolling is honest;
+   clipping is not. */
 .hm-shell {
   display: flex;
   flex-direction: column;
-  height: 100dvh;
-  min-height: 0;
-  overflow: hidden;
+  min-height: 100dvh;
+  overflow-y: auto;
 }
 
 .ops-board {
@@ -227,10 +252,16 @@ body,
 }
 .ops-dot--sm { width: calc(7 * var(--ops-u)); height: calc(7 * var(--ops-u)); }
 
-/* ---- the money band ------------------------------------------- */
+/* ---- the money band -------------------------------------------
+   `flex: 1` alone made this the ONLY child that could give, so it took the
+   entire shortfall on any viewport shorter than the design: 250px of space for
+   503px of solvency rows and 398px of payout evidence. `flex-basis: auto` +
+   `flex-shrink: 0` means it asks for its content height first and the board
+   grows (and scrolls) instead of this band eating itself. It still GROWS to
+   fill a tall screen — that is the `flex-grow: 1`, and the reason the wall
+   display looks unchanged. */
 .ops-money {
-  flex: 1;
-  min-height: 0;
+  flex: 1 0 auto;
   display: flex;
   border: 1px solid var(--ops-rule);
 }
@@ -241,7 +272,6 @@ body,
   flex-direction: column;
   padding: calc(10 * var(--ops-u)) calc(16 * var(--ops-u));
   border-right: 1px solid var(--ops-rule);
-  overflow: hidden;
 }
 .ops-flow {
   flex: 1;
@@ -249,7 +279,6 @@ body,
   display: flex;
   flex-direction: column;
   padding: calc(10 * var(--ops-u)) calc(16 * var(--ops-u));
-  overflow: hidden;
 }
 
 .ops-panel-head {

--- a/packages/monitor-ui/src/styles/ops-overflow.test.ts
+++ b/packages/monitor-ui/src/styles/ops-overflow.test.ts
@@ -1,0 +1,94 @@
+// The board must never hide a fact it was given.
+//
+// On 2026-08-04 the live board rendered a panel headed PAYOUT EVIDENCE —
+// INDEPENDENT ON-CHAIN PROOF containing no evidence at all, under a verdict
+// reading "money is moving and proven on-chain". Three solvency rows (treasury
+// reserve, escrow, protocol revenue) never rendered either. Nothing was broken
+// upstream: the proof was fetched, derived, unit-tested and then thrown away by
+// a `height: 100dvh; overflow: hidden` canvas one layer before an eye.
+//
+// MEASURED on the live board at 1512x923, which is the machine it is read on:
+//
+//   natural content  ~1089px        available  835px
+//   .ops-solvency    needs 503px    had 250px
+//   .ops-flow        needs 398px    had 250px
+//
+// `.ops-money` was the only `flex: 1` child, so it absorbed the entire
+// shortfall while its fixed siblings took what they liked.
+//
+// WHY THESE ARE TEXT ASSERTIONS AND NOT RENDER ASSERTIONS: jsdom does no
+// layout — every height it reports is 0 — so a rendering test in this suite
+// cannot see clipping at all. It would have passed happily throughout the
+// outage. The stylesheet is the artefact that decides, so the stylesheet is
+// what gets read. Confirmed against the real board in a browser before landing;
+// that check is CHECK-worthy but not automatable here, so it is written down
+// rather than pretended at.
+
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, expect, test } from "vitest";
+
+const CSS = readFileSync(fileURLToPath(new URL("./hermes4-ops.css", import.meta.url)), "utf8");
+const RULES = CSS.replace(/\/\*[\s\S]*?\*\//g, "");
+
+const HTML_ENTRIES = ["../../index.html", "../../ops-preview.html"] as const;
+
+/** The body of a rule, by selector, comments already stripped. */
+function ruleBody(selector: string): string {
+  const escaped = selector.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const m = new RegExp(`(?:^|[},])\\s*${escaped}\\s*\\{([^}]*)\\}`, "m").exec(RULES);
+  expect(m, `expected a \`${selector}\` rule in hermes4-ops.css`).not.toBeNull();
+  return m![1]!;
+}
+
+describe("the shell grows and scrolls; it does not clip", () => {
+  test(".hm-shell is min-height, never a fixed height", () => {
+    // `height: 100dvh` is the whole bug: content taller than the window has
+    // nowhere to go, and `overflow: hidden` then deletes it silently.
+    const body = ruleBody(".hm-shell");
+    expect(body).toMatch(/min-height:\s*100dvh/);
+    expect(body, "a fixed height re-introduces the clip").not.toMatch(/(^|[;\s])height:\s*100dvh/);
+  });
+
+  test(".hm-shell never hides its overflow", () => {
+    const body = ruleBody(".hm-shell");
+    expect(body).not.toMatch(/overflow(-y)?:\s*hidden/);
+  });
+
+  test("the host chain is min-height in BOTH html entries", () => {
+    // The inline <style> in index.html outranks every stylesheet, so fixing
+    // hermes4-ops.css alone changed nothing at all — the document stayed pinned
+    // to the viewport and the footer sat at y=1206 on a 923px screen,
+    // unreachable. The preview must match production or it lies about layout.
+    for (const rel of HTML_ENTRIES) {
+      const html = readFileSync(fileURLToPath(new URL(rel, import.meta.url)), "utf8");
+      const style = /<style>([\s\S]*?)<\/style>/.exec(html)?.[1] ?? "";
+      expect(style, `${rel}: host chain must be min-height`).toMatch(/#root\s*\{\s*min-height:\s*100%/);
+      expect(style, `${rel}: a fixed height pins the document to the viewport`)
+        .not.toMatch(/#root\s*\{\s*height:\s*100%/);
+    }
+  });
+});
+
+describe("the money band asks for its content before it gives anything up", () => {
+  test(".ops-money does not shrink below its content", () => {
+    // flex-shrink 0 is the load-bearing digit. With the default 1 this band is
+    // the only flexible child and therefore eats the entire shortfall — 250px
+    // of space for 503px of solvency rows.
+    const body = ruleBody(".ops-money");
+    const flex = /(?:^|[;\s])flex:\s*([^;]+)/.exec(body)?.[1]?.trim();
+    expect(flex, ".ops-money needs an explicit flex").toBeTruthy();
+    const [grow, shrink, basis] = flex!.split(/\s+/);
+    expect(grow, "must still grow to fill a wall display").toBe("1");
+    expect(shrink, "must NOT shrink below its content").toBe("0");
+    expect(basis, "basis auto = ask for the content height").toBe("auto");
+  });
+
+  test("neither money panel hides its own overflow", () => {
+    // Belt and braces: even correctly sized, an `overflow: hidden` here would
+    // clip the moment a row is added.
+    for (const sel of [".ops-solvency", ".ops-flow"]) {
+      expect(ruleBody(sel), `${sel} must not clip`).not.toMatch(/overflow(-y)?:\s*hidden/);
+    }
+  });
+});


### PR DESCRIPTION
## What you see today

On a 1512×923 laptop the live board renders a panel headed **PAYOUT EVIDENCE — INDEPENDENT ON-CHAIN PROOF** containing *no evidence*, directly under a verdict reading "money is moving and **proven on-chain**". Treasury reserve, escrow and protocol revenue never render either.

Nothing upstream is broken. The proof is fetched, derived, unit-tested — and then thrown away one layer before an eye.

## Measured, not guessed

| element | has | needs | outcome |
|---|---|---|---|
| `.ops-solvency` | 250px | **503px** | three balance rows gone |
| `.ops-flow` | 250px | **398px** | all payout evidence gone |
| natural content | — | ~1089px | available 835px |

`.ops-money` was the only `flex: 1` child of a `height: 100dvh; overflow: hidden` canvas, so it absorbed the entire shortfall while its fixed siblings took what they liked.

## Scaling down cannot fix this

My first instinct was a height term in `--ops-u`. **Measuring killed it.** Every size on this board is expressed in `--ops-u`, so shrinking it shrinks container *and* contents together and the ratio never improves. Closing 1089→835 needs `--ops-u` near **0.77px** — 10px labels at 7.7px. Illegible is not visible.

## The fix

`min-height` + `overflow-y: auto`, and `flex: 1 0 auto` on the money band.

The fixed canvas is **unchanged wherever the content fits** — the wall display this board is designed for, where the footer still lands on the bottom edge. It scrolls where it doesn't. Scrolling is honest; clipping is not.

**The inline `<style>` in `index.html` outranks every stylesheet**, so fixing `hermes4-ops.css` alone changed *nothing* — the document stayed pinned to the viewport and the footer sat at y=1206 on a 923px screen, unreachable. Both HTML entries move to `min-height`, and `ops-preview.html` is kept byte-identical to `index.html`: a preview that sizes its document differently is a preview that lies about layout.

## Verification

Real browser, both fixtures, before → after:

- **NOMINAL** — now shows all six solvency rows and the full evidence block including its four-state legend (CONFIRMED / SHORTFALL / UNVERIFIED / ENDPOINTS DISAGREE).
- **STRESS** — now shows `SHORTFALL -2` and "2 settled jobs have no on-chain proof — money did not move".
- Re-measured clipping afterwards: **0 on every panel**. Real wheel-scroll reaches the footer.
- 398 tests pass, typecheck clean.

`ops-overflow.test.ts` guards the **stylesheet**, not a render. jsdom does no layout — every height it reports is 0 — so a render test in this suite would have passed happily throughout the outage. Verified by restoring the original declarations and watching 4 of 5 go red.

## Not in this PR

Follow-up, and the thing that prompted the review: much of the board states a number without saying what it means, and when something is red it never says what to do next. `opsSuggestions()` already derives pre-drafted, probe-cited remediations for 8 incident types — and is imported by **nothing**. It was wired to the board the ops-only pivot replaced. Next PR renders it (read-only, no task buttons) and extends it to cover `credential_expiry`, `disk_headroom` and the bank lane.

Also unfixed here: the top-right rail still ellipsises `nothing delive…` and `services.polkadothub-rp…`, hiding *which* RPC is primary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)