### PR TITLE
feat(mobile): put the bank lane on the phone

### DIFF
--- a/packages/monitor-ui/src/components/mobile/MobileBoard.test.tsx
+++ b/packages/monitor-ui/src/components/mobile/MobileBoard.test.tsx
@@ -340,3 +340,93 @@ describe("phone board — what you can act on, and what you would not be told", 
     expect(queryByTestId("mobile-pool-addr-reward_bank")).toBeNull();
   });
 });
+
+// ─────────────────────────────────────────────────────────────────────────
+// THE BANK LANE ON THE PHONE
+//
+// The regression these guard: on 2026-08-04 the desk board carried this lane
+// red — `1 OVERDUE · leg2-dispatched for 8.7h`, still aging — while the phone
+// reported the same system NOMINAL and never named it. Searching the rendered
+// mobile text for "OVERDUE" returned nothing. The screen read away from the
+// desk was the one omitting the only thing that was wrong.
+describe("phone board — the bank lane", () => {
+  const laneOf = (over: Partial<NonNullable<NonNullable<ProductHealth["bank"]>["lane"]>> = {}) => {
+    const base = OPS_FIXTURE_NOMINAL.bank!.lane!;
+    return { ...OPS_FIXTURE_NOMINAL, bank: { lane: { ...base, ...over } } } as ProductHealth;
+  };
+
+  test("the lane reaches the phone at all", () => {
+    const { getByTestId } = render(
+      <MobileBoard health={OPS_FIXTURE_NOMINAL} nowMs={fresh(OPS_FIXTURE_NOMINAL)} />,
+    );
+    expect(getByTestId("mobile-bank")).toBeTruthy();
+  });
+
+  test("an overdue request is named on the phone, not only on the desk", () => {
+    // The whole point. Doing nothing here costs money, and this is the screen
+    // you are holding when you could still act.
+    const health = laneOf({
+      overdueRequestId: "0xb609f4d8…f57ecaac",
+      requests: { text: "1 OVERDUE · 0xb609f4d8…f57ecaac leg2-dispatched for 8.7h", tone: "red" },
+      tone: "red",
+    });
+    const { getByTestId } = render(<MobileBoard health={health} nowMs={fresh(health)} />);
+    expect(getByTestId("mobile-bank").getAttribute("data-tone")).toBe("red");
+    expect(getByTestId("mobile-bank-alarm").textContent).toContain("OVERDUE");
+    expect(getByTestId("mobile-bank-requests").textContent).toContain("8.7h");
+  });
+
+  test("the subject warning rides ABOVE the numbers it qualifies", () => {
+    // A reader who takes in the float and stops must not have read the wrong
+    // wrapper generation — the defect this lane exists to detect.
+    const { getByTestId } = render(
+      <MobileBoard health={OPS_FIXTURE_NOMINAL} nowMs={fresh(OPS_FIXTURE_NOMINAL)} />,
+    );
+    const lane = getByTestId("mobile-bank");
+    const subject = getByTestId("mobile-bank-subject");
+    expect(subject.textContent).toContain("cannot confirm which wrapper generation");
+    const order = [...lane.querySelectorAll("[data-testid]")].map((el) => el.getAttribute("data-testid"));
+    expect(order.indexOf("mobile-bank-subject")).toBeLessThan(order.indexOf("mobile-bank-requests"));
+  });
+
+  test("a healthy lane stays one quiet line — detail only when not ok", () => {
+    // The rule the probe rollups already follow. Vertical space on a 500px
+    // screen is spent on what is wrong.
+    const health = laneOf({ tone: "ok", subject: { text: "reading v2.1", tone: "ok" } });
+    const { queryByTestId } = render(<MobileBoard health={health} nowMs={fresh(health)} />);
+    expect(queryByTestId("mobile-bank-rows")).toBeNull();
+  });
+
+  test("a lane that is NOT ok opens its rows", () => {
+    const { getByTestId } = render(
+      <MobileBoard health={OPS_FIXTURE_NOMINAL} nowMs={fresh(OPS_FIXTURE_NOMINAL)} />,
+    );
+    // The fixture lane is `degraded` — an undeclared subject.
+    expect(getByTestId("mobile-bank-rows").textContent).toContain("UNVERIFIED");
+  });
+
+  test("an unverified position is warm grey, never coral", () => {
+    // It means the instrument cannot vouch for itself, not that money is gone.
+    // A false red here is what teaches an operator to ignore the real one.
+    const { getByTestId } = render(
+      <MobileBoard health={OPS_FIXTURE_NOMINAL} nowMs={fresh(OPS_FIXTURE_NOMINAL)} />,
+    );
+    const position = getByTestId("mobile-bank-rows").querySelector("dd");
+    expect(position?.getAttribute("data-tone")).toBe("awaiting");
+  });
+
+  test("a lane nobody wired renders NOTHING — absent is not broken", () => {
+    // A feed that was never configured must not occupy a phone screen to
+    // announce its own absence.
+    const health: ProductHealth = { ...OPS_FIXTURE_NOMINAL, bank: undefined };
+    const { queryByTestId } = render(<MobileBoard health={health} nowMs={fresh(health)} />);
+    expect(queryByTestId("mobile-bank")).toBeNull();
+    expect(queryByTestId("mobile-bank-absent")).toBeNull();
+  });
+
+  test("a CONFIGURED feed that failed gets one line, and says why", () => {
+    const health: ProductHealth = { ...OPS_FIXTURE_NOMINAL, bank: { unavailable: "hydration read timed out" } };
+    const { getByTestId } = render(<MobileBoard health={health} nowMs={fresh(health)} />);
+    expect(getByTestId("mobile-bank-absent").textContent).toContain("hydration read timed out");
+  });
+});

--- a/packages/monitor-ui/src/components/mobile/MobileBoard.tsx
+++ b/packages/monitor-ui/src/components/mobile/MobileBoard.tsx
@@ -108,6 +108,7 @@ export function MobileBoard({
       <div className="hm-ph-body">
         {breach ? <BreachPanel breach={breach} /> : <SolvencyPanel health={health} />}
         <FlowPanel health={health} emphasise={Boolean(breach)} nowMs={nowMs} />
+        <BankPanel bank={health.bank} />
       </div>
 
       <p className="hm-ph-scroll" aria-hidden>
@@ -370,6 +371,104 @@ function FlowPanel({ health, emphasise, nowMs }: { health: ProductHealth; emphas
       </div>
     </section>
   );
+}
+
+/**
+ * BANK — the second money path, on the screen you read when you are not at the
+ * desk.
+ *
+ * WHY THIS EXISTS. The phone board shipped without it. On 2026-08-04 the desk
+ * board showed this lane red with `1 OVERDUE · leg2-dispatched for 8.7h` and
+ * still aging, while the phone showed the same system as NOMINAL — "floors
+ * clear · money moving · proven on-chain" — and never mentioned the lane at
+ * all. Verified by searching the rendered text, not by looking: `OVERDUE` did
+ * not appear anywhere on the mobile surface. The one screen you check while
+ * away from the desk was the one that omitted the only thing that was wrong.
+ *
+ * EVERY STRING HERE IS DECIDED SERVER-SIDE, exactly as in the desktop lane.
+ * This picks layout and tone and nothing else. Re-deriving any of it would be
+ * a second opinion on money, and two opinions is how an operator learns to
+ * trust neither.
+ *
+ * ABSENT IS NOT BROKEN. No `bank` block means no feed was ever configured, and
+ * that renders nothing — a lane nobody wired must not occupy a phone screen to
+ * announce its own absence. Only a CONFIGURED feed that failed
+ * (`unavailable`) is worth a line.
+ *
+ * DETAIL ONLY WHEN NOT OK, which is the rule the probe rollups below already
+ * follow. A healthy lane is one quiet line; a lane that is degraded, red or
+ * unreadable opens its rows, because that is when the numbers are worth the
+ * vertical space on a 500px screen.
+ */
+function BankPanel({ bank }: { bank: ProductHealth["bank"] }) {
+  if (!bank) return null;
+  if (!bank.lane) {
+    return (
+      <p className="hm-ph-bank-absent" data-tone="awaiting" data-testid="mobile-bank-absent">
+        BANK — {bank.unavailable ?? "lane unavailable"}
+      </p>
+    );
+  }
+
+  const { lane } = bank;
+  const open = lane.tone !== "ok";
+  return (
+    <section className="hm-ph-bank" data-tone={lane.tone} data-testid="mobile-bank" aria-label="Bank — venue position">
+      <div className="hm-ph-sec">
+        <h2>BANK — HYDRATION USDC</h2>
+        {/* Hoisted above every row: an overdue request is the one state in this
+            lane where doing nothing costs money. */}
+        {lane.overdueRequestId ? (
+          <span className="hm-ph-bank-alarm" data-tone="red" data-testid="mobile-bank-alarm">
+            ⏳ OVERDUE
+          </span>
+        ) : null}
+      </div>
+
+      {/* WHAT the numbers are about, above the numbers. This lane once showed
+          four fresh, correctly-sourced, green tiles describing a wrapper
+          retired that morning — a reader who took in the float and stopped had
+          still read the wrong thing. */}
+      {lane.subject ? (
+        <p className="hm-ph-bank-subject" data-tone={lane.subject.tone} data-testid="mobile-bank-subject">
+          {lane.subject.text}
+        </p>
+      ) : null}
+
+      <p className="hm-ph-bank-requests" data-tone={lane.requests.tone} data-testid="mobile-bank-requests">
+        {lane.requests.text}
+      </p>
+
+      {open ? (
+        <dl className="hm-ph-facts" data-testid="mobile-bank-rows">
+          <dt>POSITION</dt>
+          <dd data-tone={bankPositionTone(lane.position?.status)}>
+            {lane.position
+              ? lane.position.status === "unverified"
+                ? `UNVERIFIED — ${lane.position.detail}`
+                : `${lane.position.raw} raw · ${lane.position.detail}`
+              : "not reported"}
+          </dd>
+          <dt>FLOAT</dt>
+          <dd data-tone={lane.float.tone}>{lane.float.text}</dd>
+          <dt>POSTAGE</dt>
+          <dd data-tone={lane.postage.tone}>{lane.postage.text}</dd>
+        </dl>
+      ) : null}
+    </section>
+  );
+}
+
+/**
+ * `unverified` is warm grey, never coral — identical to the desktop lane.
+ *
+ * It means the instrument cannot vouch for itself, not that the money is gone.
+ * Paging on a blind instrument is the false red that teaches an operator to
+ * ignore the real one.
+ */
+function bankPositionTone(status: string | undefined): string {
+  if (status === "funded" || status === "empty") return "ok";
+  return "awaiting";
 }
 
 function incidentLine(health: ProductHealth, untrusted: boolean): string {

--- a/packages/monitor-ui/src/styles/hermes4-mobile.css
+++ b/packages/monitor-ui/src/styles/hermes4-mobile.css
@@ -519,3 +519,51 @@
   font-size: 12px;
   color: var(--h4-tel);
 }
+
+/* ---- the bank lane ------------------------------------------------------
+   The phone board shipped without this lane. On 2026-08-04 the desk board
+   showed it red — `1 OVERDUE · leg2-dispatched for 8.7h`, still aging — while
+   the phone reported the same system NOMINAL and never named it. The screen you
+   read when you are away from the desk was the one omitting the only thing that
+   was wrong.
+
+   Bordered like the breach card rather than laid out like a probe row, because
+   this lane is a second money path and not a fifth pillar. Tone comes from the
+   server's own verdict; nothing here re-derives it. */
+.hm-ph-bank {
+  border: 1px solid var(--ph-rule);
+  padding: 10px 14px 12px;
+  display: grid;
+  gap: 7px;
+}
+.hm-ph-bank[data-tone="red"] { border-color: var(--h4-act); }
+.hm-ph-bank[data-tone="degraded"] { border-color: var(--h4-warn); }
+
+/* The alarm rides in the section header's right slot, so it is legible before
+   any row is read — the same placement the desktop lane uses. */
+.hm-ph-bank-alarm {
+  margin-left: auto;
+  font-family: var(--h4-font-mono);
+  font-size: 10px;
+  letter-spacing: 0.08em;
+  color: var(--h4-act);
+}
+
+/* WHAT the numbers describe, above the numbers. Never dimmed below the body
+   text it qualifies: a subject warning that is harder to read than the value it
+   warns about is decoration. */
+.hm-ph-bank-subject,
+.hm-ph-bank-requests,
+.hm-ph-bank-absent {
+  margin: 0;
+  font-family: var(--h4-font-mono);
+  font-size: 11.5px;
+  line-height: 1.45;
+  overflow-wrap: anywhere;
+  color: var(--h4-muted);
+}
+.hm-ph-bank-subject[data-tone="degraded"],
+.hm-ph-bank-requests[data-tone="degraded"] { color: var(--h4-warn); }
+.hm-ph-bank-subject[data-tone="red"],
+.hm-ph-bank-requests[data-tone="red"] { color: var(--h4-act); }
+.hm-ph-bank-absent { padding: 0 16px; }


### PR DESCRIPTION
## The gap

Today the desk board carried the bank lane **red** — `1 OVERDUE · leg2-dispatched for 8.7h`, still aging — while the phone reported the same system:

> **NOMINAL** · floors clear · money moving · proven on-chain

…and never named the lane. Confirmed by searching the rendered mobile text rather than by looking: `OVERDUE` appeared **nowhere** on that surface, and the only `BANK` hit was the "REWARD BANK" solvency row.

The screen you read when you're away from the desk was the one omitting the only thing that was wrong — and it's also the screen where you could still have acted on it.

## What it renders

In the primary body, above the `SCROLL FOR PROBES` marker:

```
BANK — HYDRATION USDC                        ⏳ OVERDUE
subject not declared by the feed — cannot confirm which wrapper generation these read
1 OVERDUE · 0xb609f4d8…f57ecaac leg2-dispatched for 8.7h
POSITION   UNVERIFIED — zero from erc20:0x2ec48840…, and this read
           path has never observed funds — not yet evidence of an
           empty position
FLOAT      0.149475 USDC · 149,475 raw
POSTAGE    0.2697 DOT · committed postage, no withdraw path
```

**Every string is the server's**, exactly as in the desktop lane. This component picks layout and tone and nothing else — re-deriving any of it would be a second opinion on money, and two opinions is how an operator learns to trust neither.

## Three rules carried across, not reinvented

- **Absent is not broken.** No `bank` block means no feed was ever configured → renders **nothing**. A lane nobody wired must not occupy a phone screen to announce its own absence. Only a *configured* feed that failed gets a line, and it says why.
- **Detail only when not ok** — the rule the probe rollups already follow. A healthy lane is one quiet line; vertical space on a 390px screen goes to what's wrong.
- **Unverified is warm grey, never coral.** It means the instrument can't vouch for itself, not that the money is gone. A false red here is what teaches an operator to ignore the real one.

## Verification

- Preview's **390×844 phone frame**, both fixtures: correct amber border for the degraded tone, subject above the numbers, rows open because the fixture lane is degraded, `scrollHeight - clientHeight = 0`.
- **406 tests** green (+8 here), typecheck clean.
- The new tests were verified by **deleting the panel and watching 3 go red** — a test that only passes on working code proves nothing.

**Not visually verified: the ⏳ OVERDUE alarm.** Neither fixture produces an overdue request, so that path is covered by unit test only. The live board has one right now, so it's checkable on the phone straight after deploy.

## Still open, deliberately not in here

The desktop verdict still reads `10 ok / 0 red` above a red bank lane. Whether the lane belongs in the top-line verdict is a product decision, not a layout one — flagged separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)