### PR TITLE
fix(buzz): say it in words, and only when it holds

### DIFF
--- a/services/slack-operator/src/index.ts
+++ b/services/slack-operator/src/index.ts
@@ -3336,6 +3336,9 @@ function startOperatorRoutines() {
   // a redeploy must not page the operator about states that have not changed.
   let prevProbes = new Map<string, ProbeResult>();
   let postedProbeKeys = new Set<string>();
+  // Consecutive ticks each reason class has held. Threaded exactly like the two
+  // above so a flapping warning never accumulates the hold it needs to speak.
+  let probeStreaks = new Map<string, number>();
   let taskHealthRunning = false;
   const anomalyConfig = loadAnomalyConfig();
   const dispatchPerDayCap = Number(process.env.HERMES_DISPATCH_PER_DAY_MAX) || 10;
@@ -3831,11 +3834,13 @@ function startOperatorRoutines() {
         current: result.evaluation.probes,
         posted: postedProbeKeys,
         muted: getServerAlertMuteUntilMs() > Date.now(),
+        streaks: probeStreaks,
       });
       // State advances even while muted, so unmuting does not replay an edge
       // that happened hours ago.
       prevProbes = transitions.next;
       postedProbeKeys = transitions.keys;
+      probeStreaks = transitions.streaks;
       if (transitions.alerts.length > 0) {
         const buzzForProbes = readBuzzConfig();
         for (const alert of transitions.alerts) {

--- a/services/slack-operator/src/probe-transitions.ts
+++ b/services/slack-operator/src/probe-transitions.ts
@@ -48,6 +48,16 @@ export interface DecideProbeTransitionsInput {
   posted: ReadonlySet<string>;
   /** Operator mute — quiet everywhere, same rule the narration follows. */
   muted: boolean;
+  /**
+   * Consecutive ticks each reason class has held, carried from the last call.
+   * The caller threads this exactly like `posted` and `previous`.
+   */
+  streaks?: ReadonlyMap<string, number>;
+  /**
+   * How many consecutive ticks a DEGRADED class must hold before it is worth
+   * saying. Default 3. `red` ignores this entirely — see holdRequired().
+   */
+  minDegradedTicks?: number;
 }
 
 export interface ProbeTransitionDecision {
@@ -56,7 +66,46 @@ export interface ProbeTransitionDecision {
   keys: Set<string>;
   /** Probe state to carry into the next tick. */
   next: Map<string, ProbeResult>;
+  /** Consecutive-tick counts to carry into the next tick. */
+  streaks: Map<string, number>;
 }
+
+/**
+ * How long a class must hold before it is worth saying out loud.
+ *
+ * ── WHY THIS EXISTS ────────────────────────────────────────────────────────
+ *
+ * On 2026-08-04 the #Ops channel carried eight near-identical capability
+ * alerts, three of them inside the same minute:
+ *
+ *   1:25 PM  ⚠ new capability warning: indexer_lagging, external_posting_staged
+ *   1:25 PM  ⚠ new capability warning: external_posting_staged
+ *   1:25 PM  ⚠ new capability warning: indexer_lagging, external_posting_staged
+ *   1:25 PM  ✓ capabilities recovered …
+ *
+ * Nothing was happening. One warning was entering and leaving the product's
+ * warnings array as a watcher lag crossed a threshold, and because the reason
+ * class is built from the detail text, each flip read as a NEW problem. The
+ * existing `reasonClass` blanking handles a number that drifts; it cannot help
+ * when the words themselves alternate.
+ *
+ * Keying more cleverly is the wrong fix — it means guessing which text changes
+ * are meaningful, and guessing wrong in the quiet direction is how a real alert
+ * gets swallowed. Requiring a state to PERSIST is the honest test: a condition
+ * that cannot survive three polls was not worth waking someone for.
+ *
+ * ── WHY RED IS EXEMPT ──────────────────────────────────────────────────────
+ *
+ * `red` means the money path. Delaying that by three heartbeats to spare the
+ * channel some noise is trading the only alert that matters against the ones
+ * that do not. Red says it the moment it sees it; degraded has to prove it
+ * meant it.
+ */
+export function holdRequired(status: ProbeStatus, minDegradedTicks: number): number {
+  return status === "red" ? 1 : Math.max(1, minDegradedTicks);
+}
+
+const DEFAULT_MIN_DEGRADED_TICKS = 3;
 
 /**
  * Collapse a probe's detail to its SHAPE, so a moving number is not mistaken
@@ -103,6 +152,23 @@ export function decideProbeTransitions(input: DecideProbeTransitionsInput): Prob
   const alerts: ProbeTransitionAlert[] = [];
   const keys = new Set<string>();
   const next = new Map<string, ProbeResult>();
+  const streaks = new Map<string, number>();
+  const minDegradedTicks = input.minDegradedTicks ?? DEFAULT_MIN_DEGRADED_TICKS;
+  const priorStreaks = input.streaks ?? new Map<string, number>();
+
+  // `posted` NOW MEANS ANNOUNCED, WHICH IS WHAT IT WAS ALWAYS CALLED.
+  //
+  // It used to mean "this class was present last tick" — the old code added to
+  // it whether or not it actually posted, because with no streak map that set
+  // was the only persistence bookkeeping available. The hold collides with that
+  // reading head-on: a class gets marked on its first tick, and by the time it
+  // earns the right to speak the dedupe guard has already silenced it forever.
+  // Caught by the tests below, not by reading.
+  //
+  // `streaks` does the persistence bookkeeping now, so the set is free to carry
+  // the meaning its name implies, and both the dedupe guard and the recovery
+  // gate can rely on it.
+  const heldFor = (key: string): number => priorStreaks.get(key) ?? 0;
 
   for (const probe of input.current) {
     next.set(probe.name, probe);
@@ -118,37 +184,64 @@ export function decideProbeTransitions(input: DecideProbeTransitionsInput): Prob
     // Production found this, not the tests: three deploys in one night produced
     // three duplicate money_path alerts, each one tick after a restart.
     if (!before) {
-      if (isAlarm(probe.status)) keys.add(reasonClass(probe));
+      if (isAlarm(probe.status)) {
+        // Marked ANNOUNCED on first sight, deliberately. An alarm that was
+        // already burning when this process started is not news, and without
+        // this it would simply re-earn its hold and page three ticks after every
+        // redeploy — which is the "three deploys, three duplicate money_path
+        // alerts" bug production found, rediscovered by a different route.
+        const key = reasonClass(probe);
+        keys.add(key);
+        streaks.set(key, heldFor(key) + 1);
+      }
       continue;
     }
     if (before.status === probe.status && !isAlarm(probe.status)) continue;
 
-    const enteringAlarm = isAlarm(probe.status) && before.status !== probe.status;
     const recovered = !isAlarm(probe.status) && isAlarm(before.status);
 
     if (isAlarm(probe.status)) {
-      // Carry the key forward whether or not we post: a probe that stays in the
-      // same reason class must not re-post when some other probe changes.
       const key = reasonClass(probe);
-      keys.add(key);
-      if (!enteringAlarm && !input.posted.has(key)) {
-        // Status unchanged but the reason CLASS moved — a different problem
-        // wearing the same severity. Worth saying; the operator's next action
-        // differs.
-        if (!input.muted) {
-          alerts.push({ probe: probe.name, kind: "opened", from: before.status, to: probe.status, text: alertText(probe, "opened"), key });
-        }
+
+      // THE HOLD. A class that keeps flipping never accumulates a streak, so it
+      // never speaks — which is the whole point. A class that persists reaches
+      // the threshold and says it once. Red's threshold is 1, so this is a
+      // no-op for anything on the money path.
+      const held = heldFor(key) + 1;
+      streaks.set(key, held);
+
+      // An already-announced class stays announced for as long as it persists,
+      // so it is never said twice.
+      if (input.posted.has(key)) {
+        keys.add(key);
         continue;
       }
-      if (enteringAlarm && !input.posted.has(key) && !input.muted) {
-        alerts.push({ probe: probe.name, kind: "opened", from: before.status, to: probe.status, text: alertText(probe, "opened"), key });
-      }
+      if (held < holdRequired(probe.status, minDegradedTicks)) continue;
+
+      // Muted burns the announcement without making it. The alternative —
+      // announcing on unmute — would replay an edge that happened hours ago,
+      // which is the behaviour index.ts documents as deliberately avoided. The
+      // operator unmutes to a board that already shows the state; the channel
+      // does not owe them the history.
+      keys.add(key);
+      if (input.muted) continue;
+
+      alerts.push({ probe: probe.name, kind: "opened", from: before.status, to: probe.status, text: alertText(probe, "opened"), key });
       continue;
     }
 
     if (recovered) {
       const key = `${probe.name}:recovered:${reasonClass(before)}`;
-      if (!input.posted.has(key) && !input.muted) {
+      // ONLY ANNOUNCE THE END OF SOMETHING THAT WAS ANNOUNCED.
+      //
+      // Half of 2026-08-04's noise was `✓ capabilities recovered` for a warning
+      // that had never been worth mentioning in the first place. Under the hold
+      // above that gets worse, not better: a flapping class now never posts an
+      // "opened", so an unconditional recovery would be the ONLY thing in the
+      // channel — all-clears for alarms nobody was ever given. Silence about a
+      // problem you were never told about is correct.
+      const wasAnnounced = input.posted.has(reasonClass(before));
+      if (wasAnnounced && !input.posted.has(key) && !input.muted) {
         alerts.push({ probe: probe.name, kind: "recovered", from: before.status, to: probe.status, text: alertText(probe, "recovered"), key });
       }
       // Recovery keys are NOT retained: the next time this probe breaks and
@@ -156,5 +249,5 @@ export function decideProbeTransitions(input: DecideProbeTransitionsInput): Prob
     }
   }
 
-  return { alerts, keys, next };
+  return { alerts, keys, next, streaks };
 }

--- a/services/slack-operator/src/product-health.ts
+++ b/services/slack-operator/src/product-health.ts
@@ -1071,10 +1071,47 @@ export function deriveCapabilityProbe(
     return {
       name,
       status: critical ? "red" : "degraded",
-      detail: `${critical ? "new CRITICAL" : "new"} capability warning: ${unexpected.map((w) => w.code).join(", ")}`,
+      detail: `${critical ? "new CRITICAL" : "new"} capability warning: ${describeWarnings(unexpected)}`,
     };
   }
   return { name, status: "ok", detail: describeHealthyCapabilities(caps, h.body?.warnings ?? [], config) };
+}
+
+/**
+ * Warnings in the words the PRODUCT already wrote, not its identifiers.
+ *
+ * This line reached a human as `new capability warning: external_posting_staged`
+ * — a symbol out of a config file that says nothing about what is staged,
+ * whether money is affected, or whether to act. Meanwhile /health was sending:
+ *
+ *   { "code": "xcm_observer_staged", "severity": "warning",
+ *     "message": "XCM observer is staged." }
+ *
+ * The sentence was in the payload the whole time and this function is the layer
+ * that dropped it. The operator's verdict on 2026-08-04 was "half of these I do
+ * not even understand", which is the correct reading of a channel that speaks in
+ * enum values.
+ *
+ * SORTED, because the identity of this line matters downstream. `probe-
+ * transitions` keys an alert on the detail's shape, so `a, b` and `b, a` are two
+ * different problems to it, and a warnings array that reorders would re-alert
+ * saying nothing new. Sorting makes the set's rendering canonical.
+ *
+ * The code is kept in parentheses: the sentence is for reading, the code is what
+ * you grep for and what appears in `expectedWarnings` when you acknowledge it.
+ */
+export function describeWarnings(
+  warnings: ReadonlyArray<{ code?: string; message?: string }>,
+): string {
+  return warnings
+    .map((w) => {
+      const code = w.code ?? "unknown";
+      const message = (w.message ?? "").trim();
+      // No message is a fact about the warning, not a reason to invent one.
+      return message ? `${message} (${code})` : code;
+    })
+    .sort((a, b) => a.localeCompare(b))
+    .join(" · ");
 }
 
 /**

--- a/services/slack-operator/test/unit/probe-transitions.test.ts
+++ b/services/slack-operator/test/unit/probe-transitions.test.ts
@@ -1,0 +1,195 @@
+// What #Ops is allowed to say, and how often.
+//
+// This module had NO tests. Its own comments record that production found its
+// last two defects — three duplicate money_path alerts after three deploys in
+// one night, and a countdown re-alerting every poll. On 2026-08-04 it produced
+// a third, in front of the operator:
+//
+//   10:54  ⚠ capabilities: new capability warning: external_posting_staged
+//   10:54  ⚠ … indexer_lagging, external_posting_staged
+//   11:14  ✓ capabilities recovered …
+//   12:36  ✓ capabilities recovered …
+//    1:10  ⚠ … external_posting_staged
+//    1:25  ⚠ … indexer_lagging, external_posting_staged
+//    1:25  ⚠ … external_posting_staged
+//    1:25  ⚠ … indexer_lagging, external_posting_staged
+//    1:25  ✓ capabilities recovered …
+//
+// Eight messages for a condition the same text calls acknowledged and not red.
+// Nothing was happening: one warning entered and left the product's array as a
+// watcher lag crossed a threshold, and the reason class is built from the
+// detail, so each flip read as a new problem.
+//
+// That channel also carried, twice that day, `model "hermes-agent" not found` —
+// the one message that mattered, sitting in the noise this module generated.
+import { describe, expect, test } from "vitest";
+
+import { decideProbeTransitions, holdRequired, reasonClass } from "../../src/probe-transitions.js";
+import type { ProbeResult } from "../../src/product-health.js";
+
+const probe = (status: ProbeResult["status"], detail: string, name = "capabilities"): ProbeResult =>
+  ({ name, status, detail }) as ProbeResult;
+
+/** Feed ticks through the decider, threading state the way index.ts does. */
+function run(ticks: ProbeResult[][], opts: { minDegradedTicks?: number } = {}) {
+  let previous = new Map<string, ProbeResult>();
+  let posted = new Set<string>();
+  let streaks = new Map<string, number>();
+  const said: string[] = [];
+  for (const current of ticks) {
+    const d = decideProbeTransitions({
+      previous,
+      current,
+      posted,
+      muted: false,
+      streaks,
+      ...(opts.minDegradedTicks !== undefined ? { minDegradedTicks: opts.minDegradedTicks } : {}),
+    });
+    said.push(...d.alerts.map((a) => a.text));
+    previous = d.next;
+    posted = d.keys;
+    streaks = d.streaks;
+  }
+  return said;
+}
+
+const A = "new capability warning: external_posting_staged";
+const AB = "new capability warning: indexer_lagging, external_posting_staged";
+const OK = "2/2 required up · xcmObserver staged";
+
+describe("a flapping warning does not get to speak", () => {
+  test("THE 2026-08-04 BURST: eight messages become none", () => {
+    // Replayed from the channel. A first tick to establish a prior reading
+    // (first sight never alerts), then the alternation that produced the burst.
+    const said = run([
+      [probe("ok", OK)],
+      [probe("degraded", A)],
+      [probe("degraded", AB)],
+      [probe("ok", OK)],
+      [probe("degraded", A)],
+      [probe("degraded", AB)],
+      [probe("degraded", A)],
+      [probe("degraded", AB)],
+      [probe("ok", OK)],
+    ]);
+    expect(said).toEqual([]);
+  });
+
+  test("but a condition that HOLDS is said, exactly once", () => {
+    const said = run([
+      [probe("ok", OK)],
+      [probe("degraded", A)],
+      [probe("degraded", A)],
+      [probe("degraded", A)], // third consecutive tick — earns the hold
+      [probe("degraded", A)],
+      [probe("degraded", A)],
+    ]);
+    expect(said).toHaveLength(1);
+    expect(said[0]).toContain("external_posting_staged");
+  });
+
+  test("the hold is consecutive — an interruption resets it", () => {
+    // Two ticks, a flip, two ticks. Neither run reaches three, so neither
+    // speaks. This is the difference between "persistent" and "frequent".
+    const said = run([
+      [probe("ok", OK)],
+      [probe("degraded", A)],
+      [probe("degraded", A)],
+      [probe("degraded", AB)],
+      [probe("degraded", A)],
+      [probe("degraded", A)],
+    ]);
+    expect(said).toEqual([]);
+  });
+});
+
+describe("red is exempt, because red is the money path", () => {
+  test("red speaks on the first tick, with no hold at all", () => {
+    const said = run([[probe("ok", OK)], [probe("red", "required capability down: blockchain=missing")]]);
+    expect(said).toHaveLength(1);
+    expect(said[0]).toContain("required capability down");
+  });
+
+  test("holdRequired says so directly", () => {
+    // Guarded at the function rather than only through a scenario: the whole
+    // safety argument for this feature is that it cannot delay a red.
+    expect(holdRequired("red", 99)).toBe(1);
+    expect(holdRequired("degraded", 3)).toBe(3);
+    // A misconfigured 0 must not mean "never speak".
+    expect(holdRequired("degraded", 0)).toBe(1);
+  });
+
+  test("a degraded probe escalating to red is not held back by its own streak", () => {
+    const said = run([
+      [probe("ok", OK)],
+      [probe("degraded", A)],
+      [probe("red", "required capability down: blockchain=missing")],
+    ]);
+    expect(said).toHaveLength(1);
+    expect(said[0]).toContain("required capability down");
+  });
+});
+
+describe("recovery is only announced for something that was announced", () => {
+  test("no all-clear for an alarm nobody was given", () => {
+    // Under the hold a flapping class never posts an "opened", so an
+    // unconditional recovery would leave the channel carrying ONLY all-clears
+    // for problems the operator never heard about.
+    const said = run([[probe("ok", OK)], [probe("degraded", A)], [probe("ok", OK)]]);
+    expect(said).toEqual([]);
+  });
+
+  test("but a real alarm still gets its all-clear", () => {
+    // A channel that only reports bad news leaves you guessing whether it is
+    // over — the reason recovery alerts exist at all.
+    const said = run([
+      [probe("ok", OK)],
+      [probe("degraded", A)],
+      [probe("degraded", A)],
+      [probe("degraded", A)],
+      [probe("ok", OK)],
+    ]);
+    expect(said).toHaveLength(2);
+    expect(said[0]).toContain("⚠");
+    expect(said[1]).toContain("✓");
+    expect(said[1]).toContain("recovered");
+  });
+});
+
+describe("the rules that were already there stay there", () => {
+  test("first sight never alerts — a restart is not news", () => {
+    expect(run([[probe("red", "required capability down: blockchain=missing")]])).toEqual([]);
+  });
+
+  test("a probe that vanishes says nothing — absence is not recovery", () => {
+    const said = run([
+      [probe("ok", OK)],
+      [probe("degraded", A)],
+      [probe("degraded", A)],
+      [probe("degraded", A)],
+      [], // the probe stops being reported
+    ]);
+    expect(said).toHaveLength(1); // the opened alert only
+  });
+
+  test("a drifting number is the same alert, not a new one", () => {
+    // reasonClass blanks digits, so a countdown does not re-alert. Held from
+    // the original module; the hold must not have broken it.
+    expect(reasonClass(probe("degraded", "bond slashes in 9h", "external_funnel")))
+      .toBe(reasonClass(probe("degraded", "bond slashes in 8h", "external_funnel")));
+  });
+
+  test("muted stays silent but still advances state", () => {
+    let previous = new Map<string, ProbeResult>([["capabilities", probe("ok", OK)]]);
+    const d = decideProbeTransitions({
+      previous,
+      current: [probe("red", "required capability down: blockchain=missing")],
+      posted: new Set(),
+      muted: true,
+      streaks: new Map(),
+    });
+    expect(d.alerts).toEqual([]);
+    // The key is retained, so unmuting does not replay an hours-old edge.
+    expect(d.keys.size).toBe(1);
+  });
+});


### PR DESCRIPTION
## The channel today

```
10:54  ⚠ capabilities: new capability warning: external_posting_staged
10:54  ⚠ … indexer_lagging, external_posting_staged
11:14  ✓ capabilities recovered …
12:36  ✓ capabilities recovered …
 1:10  ⚠ … external_posting_staged
 1:25  ⚠ … indexer_lagging, external_posting_staged
 1:25  ⚠ … external_posting_staged
 1:25  ⚠ … indexer_lagging, external_posting_staged
 1:25  ✓ capabilities recovered …
```

Eight messages for a condition the same text calls *acknowledged and not red*. Nothing was happening — one warning entered and left the product's `warnings` array as a watcher lag crossed a threshold, and the reason class is built from the detail text, so every flip read as a new problem. `reasonClass` blanks drifting **numbers**; it can't help when the **words** alternate.

The operator's verdict: *"half of these I do not even understand"*. That's the correct reading of a channel that speaks in enum values.

That same channel carried, twice that day, `model "hermes-agent" not found` — the one message that mattered, sitting in this noise.

## 1. Say it in the product's own words

`/health` already sends this, and we printed only `code`:

```json
{"code": "xcm_observer_staged", "severity": "warning", "message": "XCM observer is staged."}
```

The sentence was in the payload the whole time. Now: `XCM observer is staged. (xcm_observer_staged)` — sentence to read, code to grep and to paste into `expectedWarnings` when you acknowledge it. **Sorted**, because `probe-transitions` keys on the detail's shape and an array that reorders would otherwise re-alert saying nothing new.

## 2. A degraded state must hold before it speaks

Three consecutive ticks.

Keying more cleverly is the wrong fix — it means guessing which text changes are meaningful, and guessing wrong in the quiet direction swallows a real alert. Requiring persistence is the honest test: a condition that can't survive three polls wasn't worth waking anyone for.

**Red is exempt, threshold 1.** Delaying the money path to spare the channel some noise trades the only alert that matters against the ones that don't. Guarded at `holdRequired()` directly, not only through a scenario.

**Recovery now requires that the alarm was announced.** Under the hold a flapping class never posts an "opened", so an unconditional recovery would leave the channel carrying *only* all-clears for problems nobody was ever told about.

## What the tests caught

`posted` did not mean announced. The old code added to it whether or not it posted, because with no streak map that set was its only persistence bookkeeping. The hold collided head-on: a class marked on tick 1 was silenced forever by the dedupe guard. `streaks` does the bookkeeping now and the set carries the meaning its name implies. First sight still marks announced, so a redeploy doesn't page about an alarm that was already burning — the "three deploys, three duplicate `money_path` alerts" bug, rediscovered by a different route.

## Tests

This module had **none**; its own comments record that production found its last two defects. Twelve now, including **the 1:25 PM burst replayed tick for tick — it produces zero messages**, and the counterpart that a condition which *holds* is still said exactly once.

137 slack-operator tests green, typecheck clean.

## Next, one by one

Explainer + `NEXT →` (what it means, what to do) — `opsSuggestions()` is still imported by nothing. Then the morning digest, which only becomes worth having once the channel is quiet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)