### PR TITLE
fix(buzz): the hold must not silence a de-escalation or an all-clear

### DIFF
--- a/services/slack-operator/src/probe-transitions.ts
+++ b/services/slack-operator/src/probe-transitions.ts
@@ -101,8 +101,18 @@ export interface ProbeTransitionDecision {
  * that do not. Red says it the moment it sees it; degraded has to prove it
  * meant it.
  */
-export function holdRequired(status: ProbeStatus, minDegradedTicks: number): number {
-  return status === "red" ? 1 : Math.max(1, minDegradedTicks);
+export function holdRequired(status: ProbeStatus, minDegradedTicks: number, from?: ProbeStatus): number {
+  // Anything arriving at red is immediate — see above.
+  if (status === "red") return 1;
+  // LEAVING RED IS ALSO IMMEDIATE. red→degraded is a material de-escalation:
+  // the situation changed and is not over, and an operator watching a money
+  // alarm needs that now, not in three heartbeats. The first version of this
+  // held it, and the pre-existing suite caught it — which I had not run,
+  // because I searched services/slack-operator/test/ and the file lives in the
+  // repo-root test/unit/. Asserting "this module has no tests" from one
+  // directory was the actual mistake; the regression was its consequence.
+  if (from === "red") return 1;
+  return Math.max(1, minDegradedTicks);
 }
 
 const DEFAULT_MIN_DEGRADED_TICKS = 3;
@@ -216,7 +226,7 @@ export function decideProbeTransitions(input: DecideProbeTransitionsInput): Prob
         keys.add(key);
         continue;
       }
-      if (held < holdRequired(probe.status, minDegradedTicks)) continue;
+      if (held < holdRequired(probe.status, minDegradedTicks, before.status)) continue;
 
       // Muted burns the announcement without making it. The alternative —
       // announcing on unmute — would replay an edge that happened hours ago,
@@ -240,8 +250,20 @@ export function decideProbeTransitions(input: DecideProbeTransitionsInput): Prob
       // "opened", so an unconditional recovery would be the ONLY thing in the
       // channel — all-clears for alarms nobody was ever given. Silence about a
       // problem you were never told about is correct.
-      const wasAnnounced = input.posted.has(reasonClass(before));
-      if (wasAnnounced && !input.posted.has(key) && !input.muted) {
+      // ONLY ANNOUNCE THE END OF SOMETHING THAT WAS ANNOUNCED — but "was it
+      // announced" has to be decided from EVIDENCE OF SUPPRESSION, not from
+      // membership of `posted`. A caller that hands us a prior alarm without its
+      // key (every standalone call in the suite, and any state rebuilt from a
+      // partial source) is not telling us the alarm was silent; it is telling us
+      // nothing. Defaulting to silence there swallowed every recovery in the
+      // pre-existing tests.
+      //
+      // A class we actively held below its threshold IS evidence: we know we
+      // suppressed it, so its all-clear would be about a problem nobody heard.
+      const beforeClass = reasonClass(before);
+      const heldBack = (input.streaks?.get(beforeClass) ?? Number.MAX_SAFE_INTEGER)
+        < holdRequired(before.status, minDegradedTicks);
+      if (!heldBack && !input.posted.has(key) && !input.muted) {
         alerts.push({ probe: probe.name, kind: "recovered", from: before.status, to: probe.status, text: alertText(probe, "recovered"), key });
       }
       // Recovery keys are NOT retained: the next time this probe breaks and


### PR DESCRIPTION
Fixes main, red since #734 — **my regression**.

## The mistake behind the mistake

I wrote in #734's commit message and PR body that `probe-transitions` had **no tests**. It had 17. I searched `services/slack-operator/test/`, found nothing, and asserted a negative from one directory — the file lives in the repo-root `test/unit/`.

I also verified #734 with `vitest run services/slack-operator/test`, a path I chose, instead of `npx vitest run`, which is the command that would have told me. Everything below is the consequence of never running it.

## Two real regressions it caught

**1. `red → degraded` waited three ticks.** A de-escalation off red is material: the situation changed and is not over, and someone watching a money alarm needs that now, not in three heartbeats. `holdRequired` now takes the *from* status — arriving at red is immediate, and so is leaving it.

**2. Every recovery vanished.** I gated the all-clear on `posted.has(beforeClass)`, but a caller that hands us a prior alarm without its key isn't saying the alarm was silent — it's saying nothing, and defaulting to silence there swallowed all of them.

The gate now keys on **evidence of suppression**: a class we actively held below its threshold is one we know we silenced, so its all-clear would be about a problem nobody heard. Absent evidence, the recovery is announced. That is the same absence-is-not-zero rule this repo applies everywhere else, and I had inverted it.

## Verification

- Both files, 29 tests: `test/unit/probe-transitions.test.ts` (pre-existing, 17) and `services/slack-operator/test/unit/probe-transitions.test.ts` (mine, 12).
- **`npx vitest run` — the whole repo: 2,684 passed.** Two unrelated failures remain locally from missing `services/harness-dispatcher/dist/*` in an unbuilt worktree; CI builds first and neither touches this module.

The 1:25 PM burst still produces zero messages, and a condition that holds is still said exactly once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)