### PR TITLE
feat(ops): say what to do about it

### DIFF
--- a/packages/monitor-ui/src/components/ops/OpsBoard.test.tsx
+++ b/packages/monitor-ui/src/components/ops/OpsBoard.test.tsx
@@ -332,3 +332,31 @@ describe("OpsBoard — pillars and footer", () => {
     expect(getAllByTestId(/^ops-pool-[a-z_]+$/).length).toBe(6);
   });
 });
+
+// The board named what was wrong in eleven places and never said what to do.
+describe("NEXT — what to do about it", () => {
+  test("a board with something wrong says what to do next", () => {
+    const { getByTestId } = render(<OpsBoard health={OPS_FIXTURE_STRESS} nowMs={OPS_FIXTURE_STRESS.at! + 2000} />);
+    expect(getByTestId("ops-next").textContent).toContain("NEXT");
+  });
+
+  test("an all-clear board shows NO strip — not a reassuring empty box", () => {
+    // NOMINAL is not all-clear — it carries a degraded capability, so the
+    // strip correctly appears for it. A genuinely clean board has to be built.
+    const health = {
+      ...OPS_FIXTURE_NOMINAL,
+      bank: undefined,
+      probes: OPS_FIXTURE_NOMINAL.probes.map((p) => ({ ...p, status: "ok" as const })),
+      solvency: { ...OPS_FIXTURE_NOMINAL.solvency, runway: [] },
+    };
+    const { queryByTestId } = render(<OpsBoard health={health} nowMs={health.at! + 2000} />);
+    expect(queryByTestId("ops-next")).toBeNull();
+  });
+
+  test("it TELLS, it does not ACT — no button reaches this read-only board", () => {
+    // Every suggestion carries an approvable task. Rendering it here would
+    // break the promise one line below: "refresh is the only control".
+    const { getByTestId } = render(<OpsBoard health={OPS_FIXTURE_STRESS} nowMs={OPS_FIXTURE_STRESS.at! + 2000} />);
+    expect(getByTestId("ops-next").querySelector("button")).toBeNull();
+  });
+});

--- a/packages/monitor-ui/src/components/ops/OpsBoard.tsx
+++ b/packages/monitor-ui/src/components/ops/OpsBoard.tsx
@@ -15,6 +15,7 @@
 // There are no controls here beyond Refresh. Commands and discussion live in
 // Buzz (docs/OPS_ONLY_PIVOT.md).
 
+import { opsSuggestions } from "../../lib/monitor/ops-suggestions.js";
 import type { MonitorBoard } from "../../lib/monitor/board-cache.js";
 import type { ProductHealth } from "../../lib/monitor/product-health.js";
 import { formatAgo, incidentRows } from "../../lib/monitor/ops-model.js";
@@ -136,6 +137,39 @@ export function OpsBoard({
               {e.text}
             </div>
           ) : null;
+        })()}
+
+        {/* ── NEXT ────────────────────────────────────────────────────────
+            The board says WHAT is wrong in eleven places and never once said
+            what to DO. `opsSuggestions` has derived probe-cited, pre-drafted
+            remediations for eight incident types since 2026-07; until now it
+            was imported by NOTHING — it was wired to the co-pilot board the
+            ops-only pivot replaced, and the content simply stopped reaching a
+            person. The fourth instance in one day of this system discarding
+            words it had already written.
+
+            TEXT ONLY. Each suggestion carries a `task` the operator could
+            approve, and this board is read-only by design — "refresh is the
+            only control" is one line below. Rendering the button here would
+            break that promise; the sentence is the whole value anyway.
+
+            NOTHING WHEN THERE IS NOTHING. An all-clear board shows no NEXT
+            strip rather than a reassuring empty box. */}
+        {(() => {
+          const next = opsSuggestions(health).slice(0, 3);
+          if (next.length === 0) return null;
+          return (
+            <div className="ops-next" data-testid="ops-next">
+              <span className="ops-next-key">NEXT</span>
+              <ul>
+                {next.map((s) => (
+                  <li key={s.id} data-tone={s.tone} data-testid={`ops-next-${s.id}`}>
+                    {s.text}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          );
         })()}
 
         <div className="ops-foot">

--- a/packages/monitor-ui/src/lib/monitor/ops-suggestions.test.ts
+++ b/packages/monitor-ui/src/lib/monitor/ops-suggestions.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "vitest";
 import type { ProductHealth } from "./product-health.js";
 import { opsSuggestions } from "./ops-suggestions.js";
-import { OPS_FIXTURE_LIVE, OPS_FIXTURE_RED } from "./ops-fixtures.js";
+import { OPS_FIXTURE_LIVE, OPS_FIXTURE_NOMINAL, OPS_FIXTURE_RED } from "./ops-fixtures.js";
 
 describe("opsSuggestions", () => {
   test("red board → signer-below-floor (PREPARE task) + money-path (investigate task)", () => {
@@ -197,5 +197,45 @@ describe("opsSuggestions", () => {
       ],
     };
     expect(opsSuggestions(health)).toEqual([]);
+  });
+});
+
+// ── THE BANK LANE, AND THE STRIP THAT FINALLY RENDERS ANY OF THIS ─────────
+//
+// On 2026-08-04 the desk board carried `1 OVERDUE · leg2-dispatched for 8.7h`,
+// still aging, and nothing anywhere told the operator what to do about it —
+// because this module, which has derived probe-cited remediations for eight
+// incident types since 2026-07, was imported by NOTHING. It was wired to the
+// co-pilot board the ops-only pivot replaced.
+describe("bank — an overdue venue request", () => {
+  const withOverdue = (over: Partial<{ overdueRequestId: string | null; text: string }> = {}) =>
+    ({
+      ...OPS_FIXTURE_NOMINAL,
+      bank: {
+        lane: {
+          ...OPS_FIXTURE_NOMINAL.bank!.lane!,
+          overdueRequestId: over.overdueRequestId === undefined ? "0xb609f4d8…f57ecaac" : over.overdueRequestId,
+          requests: { text: over.text ?? "1 OVERDUE · 0xb609f4d8…f57ecaac leg2-dispatched for 8.7h", tone: "red" as const },
+        },
+      },
+    }) as ProductHealth;
+
+  test("an overdue request produces a suggestion carrying the probe's own words", () => {
+    const s = opsSuggestions(withOverdue()).find((x) => x.id === "bank-overdue");
+    expect(s).toBeTruthy();
+    expect(s!.text).toContain("8.7h");
+    expect(s!.text).toContain("leg 2");
+  });
+
+  test("its task INVESTIGATES and is explicit about not moving funds", () => {
+    // Money is operator-only. A worker traces and drafts; it never transfers.
+    const s = opsSuggestions(withOverdue()).find((x) => x.id === "bank-overdue")!;
+    expect(s.task?.prompt).toMatch(/do NOT move funds/i);
+    expect(s.task?.prompt).toMatch(/INVESTIGATE ONLY/i);
+  });
+
+  test("no overdue request, no suggestion — a healthy lane says nothing", () => {
+    const s = opsSuggestions(withOverdue({ overdueRequestId: null })).find((x) => x.id === "bank-overdue");
+    expect(s).toBeUndefined();
   });
 });

--- a/packages/monitor-ui/src/lib/monitor/ops-suggestions.ts
+++ b/packages/monitor-ui/src/lib/monitor/ops-suggestions.ts
@@ -130,6 +130,27 @@ export function opsSuggestions(health: ProductHealth | undefined): OpsSuggestion
     });
   }
 
+  // 5b. BANK — an overdue venue request. Money-adjacent and time-based: leg 2
+  //     was dispatched and has not landed, and the longer it sits the more
+  //     likely it needs a human rather than patience. Not a fund movement, so
+  //     this INVESTIGATES; the recovery ceremony itself stays operator-only.
+  //
+  //     Added 2026-08-04, when the desk board carried `1 OVERDUE …
+  //     leg2-dispatched for 8.7h`, still aging, and nothing anywhere told the
+  //     operator what to do about it.
+  const overdueRequestId = health.bank?.lane?.overdueRequestId ?? null;
+  if (overdueRequestId) {
+    const requests = health.bank?.lane?.requests?.text ?? "an overdue request";
+    out.push({
+      id: "bank-overdue",
+      tone: "warn",
+      text: `Bank request overdue — ${requests}. Check whether leg 2 landed on the destination chain.`,
+      task: proposeTask(
+        `A Hydration bank request is overdue: "${requests}". Do NOT move funds — INVESTIGATE ONLY. Trace the leg-2 dispatch for request ${overdueRequestId} on both chains, determine whether it landed, stalled, or failed, and draft the exact recovery steps for the operator to review.`,
+      ),
+    });
+  }
+
   // 6. Capability degraded — name the capability + why it dropped.
   const caps = live("capabilities");
   if (caps && caps.status === "degraded") {

--- a/packages/monitor-ui/src/styles/hermes4-ops.css
+++ b/packages/monitor-ui/src/styles/hermes4-ops.css
@@ -1085,3 +1085,38 @@ body,
   .ops-pillar:nth-child(3) { border-left: 0; }
   .ops-foot { flex-wrap: wrap; }
 }
+
+/* ---- NEXT — what to do about it ----------------------------------------
+   The board named eleven things that were wrong and never once said what to
+   do. This strip is the answer, and it sits directly above the footer that
+   promises "refresh is the only control" — deliberately: it TELLS, it does not
+   ACT. The suggestions carry an approvable task; this surface renders only
+   their sentence. */
+.ops-next {
+  display: flex;
+  align-items: baseline;
+  gap: calc(14 * var(--ops-u));
+  padding-top: calc(8 * var(--ops-u));
+  border-top: 1px solid var(--ops-hair);
+  font-family: var(--h4-font-mono);
+  font-size: calc(11 * var(--ops-u));
+  line-height: 1.5;
+}
+.ops-next-key {
+  flex: none;
+  letter-spacing: 0.14em;
+  color: var(--h4-muted);
+}
+.ops-next ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: calc(3 * var(--ops-u));
+}
+/* Tone follows the suggestion's own urgency — `act` is the one that costs
+   money if ignored. Never louder than the fact it refers to. */
+.ops-next li { color: var(--h4-ink); }
+.ops-next li[data-tone="warn"] { color: var(--h4-warn); }
+.ops-next li[data-tone="act"] { color: var(--h4-act); }
+.ops-next li[data-tone="tel"] { color: var(--h4-muted); }


### PR DESCRIPTION
The board names what is wrong in eleven places and never once says what to **do**.

`opsSuggestions()` has derived probe-cited, pre-drafted remediations for eight incident types since 2026-07 — *"Reward bank below floor — top up before the next payout"*, and so on. It was imported by **nothing**: wired to the co-pilot board the ops-only pivot replaced, so the content stopped reaching a person and nobody noticed.

That is the fourth instance in one day of this system discarding words it had already written — after the clipped payout evidence, the desktop-only bank lane, and the product's own warning `message` field.

## The strip

```
NEXT   Bank request overdue — 1 OVERDUE · 0xb609f4d8… leg2-dispatched for 8.7h.
       Check whether leg 2 landed on the destination chain.
       Capabilities — External posting is staged. Check config.
```

Directly above the footer that promises *"refresh is the only control"* — deliberately. **It tells, it does not act.** Every suggestion carries an approvable `task`; this surface renders only the sentence, and a test asserts no button reaches the read-only board.

**Nothing when there is nothing.** An all-clear board shows no strip rather than a reassuring empty box.

## Bank coverage

Your board carried `1 OVERDUE · leg2-dispatched for 8.7h`, still aging, and no suggestion covered it. `bank-overdue` cites the lane's own words and drafts an **INVESTIGATE-ONLY** task — trace leg 2 on both chains, determine whether it landed, draft the recovery steps. Money stays operator-only; the prompt says so twice and a test asserts it.

## Verification

- 16 suggestion tests, 29 board tests.
- **`npx vitest run` — whole repo, 2,690 passed.** Two unrelated failures persist locally from missing `services/harness-dispatcher/dist/*`; CI builds first.

Two of my own test premises were wrong and the run said so: a missing fixture import, and the assumption that `OPS_FIXTURE_NOMINAL` is all-clear — it carries a degraded capability, so the strip correctly appears for it and a genuinely clean board had to be constructed.

## Next

The explainers on individual numbers (hover/gloss), then the morning digest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)