### PR TITLE
feat(ops): the numbers explain themselves

### DIFF
--- a/packages/monitor-ui/src/components/ops/BankLane.tsx
+++ b/packages/monitor-ui/src/components/ops/BankLane.tsx
@@ -20,6 +20,7 @@
 // tiles nor complain about its own absence. Only `unavailable` — a configured
 // feed that failed — is worth a line.
 
+import { OPS_GLOSS } from "../../lib/monitor/ops-gloss.js";
 import type { BankBlock } from "../../lib/monitor/product-health.js";
 
 export interface BankLaneProps {
@@ -67,7 +68,10 @@ export function BankLane({ bank }: BankLaneProps) {
             never seen funds is not evidence of an empty position. */}
         <div className="ops-bank-row" data-testid="ops-bank-position">
           <dt>POSITION</dt>
-          <dd data-tone={positionTone(lane.position?.status)}>
+          <dd
+            data-tone={positionTone(lane.position?.status)}
+            title={lane.position?.status === "unverified" ? OPS_GLOSS.positionUnverified : undefined}
+          >
             {lane.position
               ? lane.position.status === "unverified"
                 ? `UNVERIFIED — ${lane.position.detail}`
@@ -76,16 +80,26 @@ export function BankLane({ bank }: BankLaneProps) {
           </dd>
         </div>
         <Row label="FLOAT" line={lane.float} testId="ops-bank-float" />
-        <Row label="POSTAGE" line={lane.postage} testId="ops-bank-postage" />
+        <Row label="POSTAGE" line={lane.postage} testId="ops-bank-postage" title={OPS_GLOSS.postage} />
         <Row label="REQUESTS" line={lane.requests} testId="ops-bank-requests" />
       </dl>
     </section>
   );
 }
 
-function Row({ label, line, testId }: { label: string; line: { text: string; tone: string }; testId: string }) {
+function Row({
+  label,
+  line,
+  testId,
+  title,
+}: {
+  label: string;
+  line: { text: string; tone: string };
+  testId: string;
+  title?: string;
+}) {
   return (
-    <div className="ops-bank-row" data-testid={testId}>
+    <div className="ops-bank-row" data-testid={testId} title={title}>
       <dt>{label}</dt>
       <dd data-tone={line.tone}>{line.text}</dd>
     </div>

--- a/packages/monitor-ui/src/components/ops/FlowPanel.tsx
+++ b/packages/monitor-ui/src/components/ops/FlowPanel.tsx
@@ -9,6 +9,7 @@
 // read a clean 9 → 9 → 9 while only 7 of those payouts ever landed on-chain,
 // and nothing else on this board can see the difference.
 
+import { OPS_GLOSS } from "../../lib/monitor/ops-gloss.js";
 import {
   EVIDENCE_KEY,
   flowFunnel,
@@ -73,13 +74,18 @@ export function FlowPanel({ flow, externalFunnel, lifecycle, nowMs }: FlowPanelP
           to anyone who does not already know better — including a future
           reader of a screenshot. */}
       {mix ? (
-        <p className="ops-volume-mix" data-tone={mix.tone} data-testid="ops-volume-mix">
+        <p
+          className="ops-volume-mix"
+          data-tone={mix.tone}
+          data-testid="ops-volume-mix"
+          title={mix.text.includes("beyond the ledger window") ? OPS_GLOSS.beyondWindow : undefined}
+        >
           {mix.text}
         </p>
       ) : null}
 
       {timing ? (
-        <p className="ops-lifecycle" data-tone={timing.tone} data-testid="ops-lifecycle">
+        <p className="ops-lifecycle" data-tone={timing.tone} data-testid="ops-lifecycle" title={OPS_GLOSS.selfPosted}>
           {timing.text}
         </p>
       ) : null}
@@ -111,7 +117,12 @@ export function FlowPanel({ flow, externalFunnel, lifecycle, nowMs }: FlowPanelP
                 present — this board once showed SHORTFALL −2 with no window
                 information at all, which is an accusation without the one
                 fact that decides whether to believe it. */}
-            <div className="ops-evidence-fit" data-tone={evidence.fit.tone} data-testid="ops-evidence-fit">
+            <div
+              className="ops-evidence-fit"
+              data-tone={evidence.fit.tone}
+              data-testid="ops-evidence-fit"
+              title={OPS_GLOSS.windowFit}
+            >
               {evidence.fit.text}
             </div>
           </div>
@@ -207,9 +218,9 @@ function Funnel({ funnel }: { funnel: FunnelView }) {
   return (
     <div className="ops-funnel">
       <Stage label="CLAIMED" value={funnel.claimed} />
-      <Gap label={`in-flight ${funnel.inflight} · normal WIP`} tone="awaiting" />
+      <Gap label={`in-flight ${funnel.inflight} · normal WIP`} tone="awaiting" title={OPS_GLOSS.inflight} />
       <Stage label="SUBMITTED" value={funnel.submitted} />
-      <Gap label={`backlog ${funnel.backlog} · real payout backlog`} tone={funnel.backlogTone} />
+      <Gap label={`backlog ${funnel.backlog} · real payout backlog`} tone={funnel.backlogTone} title={OPS_GLOSS.backlog} />
       <Stage label="SETTLED" value={funnel.settled} />
     </div>
   );
@@ -227,9 +238,9 @@ function Stage({ label, value }: { label: string; value: string }) {
   );
 }
 
-function Gap({ label, tone }: { label: string; tone: string }) {
+function Gap({ label, tone, title }: { label: string; tone: string; title?: string }) {
   return (
-    <div className="ops-funnel-gap">
+    <div className="ops-funnel-gap" title={title}>
       <span className="ops-funnel-arrow" aria-hidden>
         <i />▸
       </span>

--- a/packages/monitor-ui/src/components/ops/OpsBoard.test.tsx
+++ b/packages/monitor-ui/src/components/ops/OpsBoard.test.tsx
@@ -360,3 +360,34 @@ describe("NEXT — what to do about it", () => {
     expect(getByTestId("ops-next").querySelector("button")).toBeNull();
   });
 });
+
+// The glosses reach the DOM, where a hover can find them. jsdom cannot hover,
+// but it can prove the title is attached — absence here is the exact way this
+// feature silently dies in a refactor.
+describe("glosses — the numbers explain themselves", () => {
+  test("the margin, the meter and the window-fit line each carry their gloss", () => {
+    const { getByTestId, container } = render(
+      <OpsBoard health={OPS_FIXTURE_NOMINAL} nowMs={OPS_FIXTURE_NOMINAL.at! + 2000} />,
+    );
+    const margin = container.querySelector(".ops-pool-margin");
+    expect(margin?.getAttribute("title")).toContain("Balance ÷ floor");
+    const meter = container.querySelector(".ops-meter");
+    expect(meter?.getAttribute("title")).toContain("settlement halts");
+    expect(getByTestId("ops-evidence-fit").getAttribute("title")).toContain("same 24h");
+  });
+
+  test("every rendered note key explains itself; RUNWAY answers the pool's question", () => {
+    // No fixture carries gas data, so BURN never renders here — it only exists
+    // live. Asserting it from a fixture would test the fixture, not the board;
+    // its gloss text is held to standard by ops-gloss.test.ts and it shares
+    // this exact keyed-lookup path with RUNWAY.
+    const { container } = render(<OpsBoard health={OPS_FIXTURE_NOMINAL} nowMs={OPS_FIXTURE_NOMINAL.at! + 2000} />);
+    const keys = [...container.querySelectorAll(".ops-pool-note-key")];
+    expect(keys.length).toBeGreaterThan(0);
+    for (const k of keys) {
+      expect(k.getAttribute("title"), `${k.textContent} lost its gloss`).toBeTruthy();
+    }
+    const runway = keys.find((k) => k.textContent === "RUNWAY");
+    expect(runway?.getAttribute("title")).toContain("still fund");
+  });
+});

--- a/packages/monitor-ui/src/components/ops/SolvencyPanel.tsx
+++ b/packages/monitor-ui/src/components/ops/SolvencyPanel.tsx
@@ -13,6 +13,7 @@
 // Percentages never lead here. 5% of 2 TB is comfort; 20% of 20 GB is about to
 // fail — so the absolute number is the status.
 
+import { OPS_GLOSS } from "../../lib/monitor/ops-gloss.js";
 import type { GasSpendView, PayoutEvidence, SolvencySnapshot } from "../../lib/monitor/product-health.js";
 import { splitPools, type PoolView } from "../../lib/monitor/ops-spec.js";
 import { gasPoolNote, gasUnreadableNote, payoutRunwayNote } from "../../lib/monitor/ops-spec.js";
@@ -93,7 +94,14 @@ export function SolvencyPanel({ solvency, gas, payout }: SolvencyPanelProps) {
                 data-tone={note.tone}
                 data-testid={`ops-pool-note-${view.pool.key}`}
               >
-                {noteKey ? <span className="ops-pool-note-key">{noteKey}</span> : null}
+                {noteKey ? (
+                  <span
+                    className="ops-pool-note-key"
+                    title={noteKey === "BURN" ? OPS_GLOSS.burn : noteKey === "RUNWAY" ? OPS_GLOSS.runway : undefined}
+                  >
+                    {noteKey}
+                  </span>
+                ) : null}
                 <span className="ops-pool-note-val">{note.text}</span>
               </p>
             ) : null}
@@ -171,7 +179,7 @@ function FlooredPool({ view }: { view: PoolView }) {
     <div className="ops-pool" data-tone={view.tone} data-testid={`ops-pool-${view.pool.key}`}>
       <div className="ops-pool-id">
         <span className="ops-pool-name">{view.pool.label}</span>
-        <span className="ops-pool-margin" data-tone={view.marginTone}>
+        <span className="ops-pool-margin" data-tone={view.marginTone} title={OPS_GLOSS.margin}>
           {view.margin}
         </span>
       </div>
@@ -184,6 +192,7 @@ function FlooredPool({ view }: { view: PoolView }) {
           aria-valuenow={view.pool.amount ?? undefined}
           aria-valuemin={0}
           aria-valuetext={`${view.amountLabel} ${view.unit}, ${view.margin}`}
+          title={OPS_GLOSS.floor}
         >
           <i className="ops-meter-fill" data-tone={view.tone} style={{ width: `${meter.fillPct}%` }} />
           <i className="ops-meter-floor" style={{ left: `${meter.floorPct}%` }} aria-hidden />

--- a/packages/monitor-ui/src/lib/monitor/ops-gloss.test.ts
+++ b/packages/monitor-ui/src/lib/monitor/ops-gloss.test.ts
@@ -1,0 +1,31 @@
+// The glosses exist to be read by someone who did NOT build the board, so the
+// tests hold them to a reader's standard, not a compiler's.
+import { describe, expect, test } from "vitest";
+
+import { OPS_GLOSS } from "./ops-gloss.js";
+
+describe("every gloss is a real explanation", () => {
+  test("full sentences, not labels — a gloss shorter than the jargon is decoration", () => {
+    for (const [key, text] of Object.entries(OPS_GLOSS)) {
+      expect(text.length, `${key} is too short to explain anything`).toBeGreaterThan(60);
+      expect(text.endsWith("."), `${key} must end as a sentence`).toBe(true);
+    }
+  });
+
+  test("no gloss leans on another board term it does not explain", () => {
+    // "See RUNWAY" would send the reader on the hunt this file exists to end.
+    for (const [key, text] of Object.entries(OPS_GLOSS)) {
+      expect(text, `${key} must not cross-reference`).not.toMatch(/\bsee\s+[A-Z]/);
+    }
+  });
+
+  test("definitions carry no live numbers — those belong to the view models", () => {
+    // A number in a definition is a written fact that goes stale silently —
+    // the exact failure class the credential probe was built against. The one
+    // sanctioned exception is naming a window or a ratio bound (24h, ×1.0).
+    for (const [key, text] of Object.entries(OPS_GLOSS)) {
+      const numbers = (text.match(/\d+(\.\d+)?/g) ?? []).filter((n) => !["24", "1.0"].includes(n));
+      expect(numbers, `${key} carries live-looking numbers: ${numbers.join(", ")}`).toEqual([]);
+    }
+  });
+});

--- a/packages/monitor-ui/src/lib/monitor/ops-gloss.ts
+++ b/packages/monitor-ui/src/lib/monitor/ops-gloss.ts
@@ -1,0 +1,72 @@
+// What the numbers mean, for the reader who did not build them.
+//
+// The operator's verdict on 2026-08-04, reading the live board: "much of the
+// number just dont say much without context". He was right in a specific way:
+// every figure here is faithful, and half of them presume the reader already
+// knows what a floor is, what "window fit" protects against, or why one extra
+// on-chain payout is not a discrepancy. The board explained nothing because
+// its authors needed no explanation.
+//
+// ── DEFINITIONS, NOT DATA ─────────────────────────────────────────────────
+//
+// Everything in this file is a statement about the DESIGN — what a floor is,
+// what the funnel gaps mean. Nothing here is a claim about live state, which
+// is why a frontend constant is honest: a definition cannot go stale the way
+// a written expiry date does. Live facts (blocks read, endpoints, ages) stay
+// in the server-derived view models and are never restated here.
+//
+// ── ONE MAP, RENDERED AS `title` ──────────────────────────────────────────
+//
+// Attached where each term is rendered, as title + aria terms — the same
+// mechanism the by-hour bars already use. Hover carries it on the desk; the
+// phone board needs none of this because it already speaks in full sentences
+// (detail-only-when-not-ok is its explainer). Keyed and central so a gloss is
+// written once, tested for existence, and greppable when its wording ages.
+
+export const OPS_GLOSS = {
+  /** The ×N figure beside each floored pool's name. */
+  margin:
+    "Balance ÷ floor. ×1.0 is the floor itself — below that, the product stops settling until the pool is topped up.",
+
+  /** The tick and `floor N` label on a pool meter. */
+  floor:
+    "The balance below which settlement halts. Chosen per pool; the tick marks it on the meter so distance-to-trouble is visible at a glance.",
+
+  /** The BURN sub-fact under signer gas. */
+  burn:
+    "What is draining this pool: gas spent settling payouts over the window, with the average cost per settlement.",
+
+  /** The RUNWAY sub-fact under the reward bank. */
+  runway:
+    "How much longer this pool lasts: payouts it can still fund at the recent average, and the trend-projected time to its floor.",
+
+  /** The funnel's first gap. */
+  inflight:
+    "Claimed but not yet submitted — work in progress. Nonzero is the normal state of a busy board, not a queue.",
+
+  /** The funnel's second gap. */
+  backlog:
+    "Submitted but not settled — finished work awaiting payment. Zero is the healthy state; anything else is a real payout queue.",
+
+  /** The `N self-posted Xs, slowest Ys` timing line. */
+  selfPosted:
+    "Posting-to-settlement time for jobs Averray posted itself. External jobs are posted by outside posters and settle on their own clock.",
+
+  /** The `N beyond the ledger window` clause in the funnel header. */
+  beyondWindow:
+    "Confirmed on-chain right at the edge of the 24h comparison window, where the chain read and the settlement ledger can legitimately differ by a payout or two. A window-boundary artefact, not missing money.",
+
+  /** The `window fit` clause on the payout evidence. */
+  windowFit:
+    "Whether the chain was read over at least the same 24h the settlement ledger is counted over. A shorter read window could miss real payouts and report a false shortfall — this line is the guard against comparing unlike windows.",
+
+  /** The bank lane's POSTAGE row. */
+  postage:
+    "DOT committed to pay XCM delivery fees for the bank lane's transfers. Spendable only as postage — there is no withdraw path back to the treasury.",
+
+  /** The bank lane's POSITION row when it reads UNVERIFIED. */
+  positionUnverified:
+    "The read returned zero from a path that has never observed funds, so it cannot distinguish an empty position from a wrong address. Grey because the instrument is blind — not because money is missing.",
+} as const;
+
+export type OpsGlossKey = keyof typeof OPS_GLOSS;

--- a/services/slack-operator/src/credential-expiry.ts
+++ b/services/slack-operator/src/credential-expiry.ts
@@ -25,6 +25,14 @@ import { connect as tlsConnect } from "node:tls";
 export interface CredentialExpiry {
   /** Operator-facing name — what to go and rotate. */
   label: string;
+  /**
+   * What KIND of credential this is, so the verdict can say so. On 2026-08-05
+   * the board read "3 credentials, soonest expiry 37d" while the token list was
+   * entirely unconfigured — every one of the three was a TLS cert, and the line
+   * read as coverage of secrets nobody was watching. A count that does not name
+   * its kinds is a number that reads as more than it is.
+   */
+  kind: "tls" | "token";
   /** Where the reading came from, so a wrong answer is traceable. */
   source: string;
   /** Epoch ms of expiry, or null when the artefact does not declare one. */
@@ -172,7 +180,20 @@ export function credentialExpiryProbe(input: {
         .filter((c) => c.expiresAtMs !== null)
         .map((c) => daysUntil(c.expiresAtMs!, input.nowMs)),
     );
-    return { status, detail: `${input.credentials.length} credentials, soonest expiry ${soonest}d` };
+    // Name the KINDS, not just the count. "3 credentials" read as coverage of
+    // the secrets while the token list was entirely unconfigured — all three
+    // were TLS certs. "no tokens watched" is the honest gap, said out loud, so
+    // an operator can tell a green that covers their tokens from a green that
+    // never looked at them.
+    const certs = input.credentials.filter((c) => c.kind === "tls").length;
+    const tokens = input.credentials.length - certs;
+    const kinds = [
+      certs > 0 ? `${certs} TLS cert${certs === 1 ? "" : "s"}` : null,
+      tokens > 0 ? `${tokens} token${tokens === 1 ? "" : "s"}` : "no tokens watched",
+    ]
+      .filter(Boolean)
+      .join(" · ");
+    return { status, detail: `${kinds}, soonest expiry ${soonest}d` };
   }
   return { status, detail: headline.join(" · ") };
 }
@@ -238,6 +259,7 @@ export async function collectCredentialExpiries(input: {
     const r = await input.readCert(host);
     out.push({
       label: `TLS ${host}`,
+      kind: "tls",
       source: "leaf certificate notAfter",
       expiresAtMs: r.validToMs,
       ...(r.error ? { unreadable: r.error } : {}),
@@ -253,6 +275,7 @@ export async function collectCredentialExpiries(input: {
     const exp = jwtExpiryMs(raw);
     out.push({
       label: key,
+      kind: "token",
       source: "jwt exp claim",
       expiresAtMs: exp,
       // Non-JWT credentials (opaque GitHub PATs, webhook URLs) legitimately

--- a/services/slack-operator/test/unit/credential-expiry.test.ts
+++ b/services/slack-operator/test/unit/credential-expiry.test.ts
@@ -20,6 +20,7 @@ function jwt(claims: Record<string, unknown>): string {
 
 const cred = (over: Partial<CredentialExpiry> = {}): CredentialExpiry => ({
   label: "ADMIN_JWT",
+  kind: "token",
   source: "jwt exp claim",
   expiresAtMs: NOW + 30 * DAY,
   ...over,
@@ -202,5 +203,44 @@ describe("collecting from artefacts, not from a list of dates", () => {
       readCert: okCert,
     });
     expect(got[0]!.label).toBe("TLS a.example");
+  });
+});
+
+describe("the verdict names its kinds — a count is not coverage", () => {
+  test("certs-only says NO TOKENS WATCHED, out loud", () => {
+    // The live board read "3 credentials, soonest expiry 37d" while
+    // PRODUCT_HEALTH_EXPIRY_JWT_ENV_KEYS was entirely unset: every credential
+    // was a TLS cert, and the line read as coverage of secrets nobody was
+    // watching. The gap has to be in the sentence, not in the operator's
+    // memory of what they configured.
+    const p = credentialExpiryProbe({
+      credentials: [
+        cred({ label: "TLS a.example", kind: "tls", expiresAtMs: NOW + 37 * DAY }),
+        cred({ label: "TLS b.example", kind: "tls", expiresAtMs: NOW + 60 * DAY }),
+        cred({ label: "TLS c.example", kind: "tls", expiresAtMs: NOW + 90 * DAY }),
+      ],
+      nowMs: NOW,
+    });
+    expect(p.status).toBe("ok");
+    expect(p.detail).toBe("3 TLS certs · no tokens watched, soonest expiry 37d");
+  });
+
+  test("a mixed set counts each kind by name", () => {
+    const p = credentialExpiryProbe({
+      credentials: [
+        cred({ label: "TLS a.example", kind: "tls", expiresAtMs: NOW + 60 * DAY }),
+        cred({ expiresAtMs: NOW + 45 * DAY }),
+      ],
+      nowMs: NOW,
+    });
+    expect(p.detail).toBe("1 TLS cert · 1 token, soonest expiry 45d");
+  });
+
+  test("tokens-only does not invent a cert clause", () => {
+    const p = credentialExpiryProbe({
+      credentials: [cred({ expiresAtMs: NOW + 20 * DAY }), cred({ label: "GATEWAY_KEY", expiresAtMs: NOW + 50 * DAY })],
+      nowMs: NOW,
+    });
+    expect(p.detail).toBe("2 tokens, soonest expiry 20d");
   });
 });


### PR DESCRIPTION
## Why

The operator's verdict on the live board: *"much of the number just dont say much without context."* He was right in a specific way — every figure is faithful, and half of them presume the reader already knows what a floor is, what "window fit" protects against, or why one extra on-chain payout is not a discrepancy. The board explained nothing because its authors needed no explanation.

## One map — definitions, not data

`ops-gloss.ts` holds plain-language explanations, attached as `title` where each term renders (the mechanism the by-hour bars already use). Everything in it is a statement about the **design** — what a floor *is* — which is why a frontend constant is honest: a definition cannot go stale the way a written expiry date does. Live facts stay in the server-derived view models, and a test rejects any gloss that carries a live-looking number.

Glossed: the `×N` margin, the floor tick, `BURN`, `RUNWAY`, `in-flight`, `backlog`, the self-posted timing line, `beyond the ledger window`, `window fit`, and the bank lane's `POSTAGE` and unverified `POSITION`.

The phone board deliberately gets none of this — it already speaks in full sentences; detail-only-when-not-ok *is* its explainer.

## And the probe that read as more than it was

`credential_expiry` said **"3 credentials, soonest expiry 37d"** while `PRODUCT_HEALTH_EXPIRY_JWT_ENV_KEYS` was entirely unset — all three were TLS certs, and the line read as coverage of secrets nobody was watching (found live this morning). `CredentialExpiry` now carries `kind: "tls" | "token"` and the verdict names its kinds:

```
3 TLS certs · no tokens watched, soonest expiry 37d
```

The gap is in the sentence, not in the operator's memory of what they configured. Arming the token side stays one env line, documented in `ops/compose.yml`.

## Verification

- Every title confirmed present in a **real browser DOM**; solvency clipping re-measured at 0 (no layout shift).
- Gloss quality tests: full sentences, no cross-references, no live-looking numbers.
- New probe wording pinned exactly for certs-only / mixed / tokens-only.
- **`npx vitest run` — whole repo, 2,698 passed.**

One test premise of mine died on contact again: no fixture carries gas data, so `BURN` never renders from fixtures — asserting it there would have tested the fixture, not the board. The test says so and holds the shared lookup path via `RUNWAY`.

## Next

The morning digest — the channel is quiet enough now for it to mean something.

🤖 Generated with [Claude Code](https://claude.com/claude-code)