### PR TITLE
fix(int2): size the two suite-running fixtures' elapsed ceiling from CI measurement

### DIFF
--- a/scripts/ceremony/int2-evidence.mjs
+++ b/scripts/ceremony/int2-evidence.mjs
@@ -372,7 +372,7 @@ const CASE_EXPECTATIONS = Object.freeze({
       }),
     ]),
     expectedBudget: Object.freeze({
-      elapsedSeconds: 120,
+      elapsedSeconds: 300,
       modelTokens: 12000,
       toolCalls: 50,
       estimatedUsdMicros: null,
@@ -440,7 +440,7 @@ const CASE_EXPECTATIONS = Object.freeze({
       }),
     ]),
     expectedBudget: Object.freeze({
-      elapsedSeconds: 120,
+      elapsedSeconds: 300,
       modelTokens: 14000,
       toolCalls: 60,
       estimatedUsdMicros: null,

--- a/test/fixtures/agent-integration/ceremony/add-unit-test.json
+++ b/test/fixtures/agent-integration/ceremony/add-unit-test.json
@@ -44,7 +44,7 @@
     }
   ],
   "budget": {
-    "elapsedSeconds": 120,
+    "elapsedSeconds": 300,
     "modelTokens": 12000,
     "toolCalls": 50,
     "estimatedUsdMicros": null

--- a/test/fixtures/agent-integration/ceremony/small-refactor.json
+++ b/test/fixtures/agent-integration/ceremony/small-refactor.json
@@ -50,7 +50,7 @@
     }
   ],
   "budget": {
-    "elapsedSeconds": 120,
+    "elapsedSeconds": 300,
     "modelTokens": 14000,
     "toolCalls": 60,
     "estimatedUsdMicros": null


### PR DESCRIPTION
Main went intermittently red on the first post-merge run of #737 — [run 30980968234](https://github.com/depre-dev/averray-reference-agent/actions/runs/30980968234), `add-unit-test` only.

## What the diagnostics show

From the uploaded evidence artifact:

```
harness run:   outcome=completed, VerificationCompleted passed=true, required_failed=[]
agent task:    lifecycle=failed
```

A verified, completed run with a failed task — the live-budget signature. The run's elapsed crossed the fixture's **120s** ceiling while still executing; the dispatcher force-cancelled (correct #653 live-runaway behaviour); the cancel raced the finish and lost.

The same run measured, on its own runner:

```
verification alone   93–95s   (npm test -- --no-cache, 2,600 tests, in-container)
case wall time       143s
same case, locally   53s      ← how 120 ever looked safe
```

`small-refactor` passed this run at **95.4s of verification against the same 120s ceiling** — one slow runner from the same red.

## The fix

`elapsedSeconds: 120 → 300` on the two fixtures whose criteria run the full suite. Sized from measurement: ~2× the worst observed honest cost, and equal to the kernel's own `command_timeout_seconds` schema bound.

This is not raising-a-budget-to-green. 120 was a per-task *estimate* made on fast hardware — the thing the 2026-08-01 operator decision says budgets must never be. A ceiling exists to catch runaways, and a task that legitimately takes 143s on CI hardware is not a runaway.

## Considered and rejected

Making reconciliation revisit a failed task whose cancelled run later completed+verified. That would make cancellation non-final, and HALT rides on cancellation being final. The discarded verified run is the accepted cost of live cancellation; the decision record documents the overrun.

Guard suite: 22/22. Docs-fix (3.5s verification) keeps its ceiling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)