### PR TITLE
feat(buzz): the morning digest — one message, then quiet

### DIFF
--- a/ops/compose.yml
+++ b/ops/compose.yml
@@ -472,6 +472,13 @@ services:
       BUZZ_AGENT_SECRET_KEY: ${BUZZ_AGENT_SECRET_KEY:-}
       BUZZ_OWNER_AUTH_TAG: ${BUZZ_OWNER_AUTH_TAG:-}
       BUZZ_OPS_CHANNEL_ID: ${BUZZ_OPS_CHANNEL_ID:-}
+      # ── Morning digest ── one scheduled #Ops message at a LOCAL time, then
+      # quiet. Off by default; armed deliberately like every flag here. An
+      # invalid time or zone DISABLES it with a named problem in the logs —
+      # never a guessed hour.
+      BUZZ_MORNING_DIGEST: ${BUZZ_MORNING_DIGEST:-}
+      BUZZ_DIGEST_TIME: ${BUZZ_DIGEST_TIME:-08:00}
+      BUZZ_DIGEST_TZ: ${BUZZ_DIGEST_TZ:-Europe/Zurich}
       # Buzz INBOUND — answering questions in #Ops. Default OFF, and separate
       # from the four above on purpose: publishing narration is safe, while
       # listening hands an LLM turn to whatever is typed in the channel.

--- a/services/slack-operator/src/index.ts
+++ b/services/slack-operator/src/index.ts
@@ -1,6 +1,7 @@
 import http from "node:http";
 import { setTimeout as delay } from "node:timers/promises";
 import path from "node:path";
+import fs from "node:fs";
 import { fileURLToPath } from "node:url";
 import { readFile } from "node:fs/promises";
 import { addressFromPrivateKey, logger, optionalEnv, query } from "@avg/mcp-common";
@@ -155,6 +156,7 @@ import { decideOpsNarration, type OpsStatus } from "./ops-narration.js";
 import { publishNarration, readBuzzConfig } from "./buzz-client.js";
 import { startBuzzInbound } from "./buzz-inbound-start.js";
 import { decideProbeTransitions } from "./probe-transitions.js";
+import { buildMorningDigest, digestDue, readDigestSchedule } from "./morning-digest.js";
 import { describeBuzzDelivery, recordBuzzDelivery, type BuzzDeliveryState } from "./buzz-delivery.js";
 import type { ProbeResult } from "./product-health.js";
 import { isBurnUnmeasurable, measuredGasBurn } from "./gas-burn-rate.js";
@@ -309,6 +311,38 @@ const PRODUCT_HEALTH_INCIDENT_MAX = 200;
 let productHealthChainAdvance: ChainAdvance | undefined;
 // Structured snapshot blocks (chain id / network / solvency / flow) for the Ops board.
 let productHealthSnapshotBlocks: ProductHealthSnapshotBlocks | undefined;
+
+// ── MORNING DIGEST state ──────────────────────────────────────────────────
+// The persisted fact is the local DATE of the last digest — "today's digest
+// exists" — so restarts around the send window neither double-post nor skip.
+// Same /data convention as autonomy-mode.
+const morningDigestSchedule = readDigestSchedule();
+let morningDigestProblemLogged = false;
+const MORNING_DIGEST_STATE_PATH =
+  process.env.BUZZ_DIGEST_STATE_PATH ?? "/data/morning-digest.json";
+function readMorningDigestState(): string | null {
+  try {
+    const raw = JSON.parse(fs.readFileSync(MORNING_DIGEST_STATE_PATH, "utf8")) as {
+      lastSentLocalDate?: string;
+    };
+    return typeof raw.lastSentLocalDate === "string" ? raw.lastSentLocalDate : null;
+  } catch {
+    // Missing or unreadable state reads as "never sent" — the worst outcome is
+    // one extra digest, which beats a machinery failure silencing it forever.
+    return null;
+  }
+}
+function writeMorningDigestState(lastSentLocalDate: string): void {
+  try {
+    fs.mkdirSync(path.dirname(MORNING_DIGEST_STATE_PATH), { recursive: true });
+    fs.writeFileSync(MORNING_DIGEST_STATE_PATH, `${JSON.stringify({ lastSentLocalDate }, null, 2)}\n`);
+  } catch (err) {
+    // A failed write means tomorrow's dedupe rests on process memory alone;
+    // say so rather than discover it as a duplicate.
+    logger.warn({ err, path: MORNING_DIGEST_STATE_PATH }, "morning_digest_state_write_failed");
+  }
+}
+let morningDigestSentLocalDate: string | null = null;
 // Buzz delivery outcomes. Module scope so the endpoint can report it without
 // the heartbeat having to thread it through — and in memory on purpose: after a
 // restart the honest answer is "nothing delivered yet", not a stale success.
@@ -3865,6 +3899,75 @@ function startOperatorRoutines() {
               { probe: alert.probe, kind: alert.kind, reason: delivery.reason, detail: delivery.detail },
               "probe_transition_publish_failed",
             );
+          }
+        }
+      }
+      // ── THE MORNING DIGEST ──────────────────────────────────────────────
+      // One message at the operator's chosen local time: the same verdict the
+      // board renders, the probes' own detail lines, and everything currently
+      // not-ok — which the alert hold may have (correctly) never announced.
+      // Muted skips WITHOUT marking sent, so the day's digest arrives on
+      // unmute rather than silently not existing.
+      if (morningDigestSchedule.problem && !morningDigestProblemLogged) {
+        morningDigestProblemLogged = true;
+        logger.warn({ problem: morningDigestSchedule.problem }, "morning_digest_misconfigured");
+      }
+      const digestNowMs = Date.now();
+      const digestCheck = digestDue({
+        nowMs: digestNowMs,
+        schedule: morningDigestSchedule,
+        lastSentLocalDate: morningDigestSentLocalDate ?? readMorningDigestState(),
+      });
+      if (digestCheck.due && !(getServerAlertMuteUntilMs() > digestNowMs)) {
+        const digestText = buildMorningDigest({
+          localDate: digestCheck.localDate,
+          localTime: digestCheck.localTime,
+          timeZone: morningDigestSchedule.timeZone,
+          network:
+            (process.env.WALLET_NETWORK ?? "").trim().toLowerCase() === "mainnet" ? "mainnet" : "testnet",
+          // The SAME verdict inputs the /monitor/product-health endpoint uses —
+          // one verdict system, quoted rather than re-derived.
+          verdictHeadline: deriveOpsVerdict({
+            enabled: routineConfig.productHealth.enabled,
+            checks: productHealthHistory.length,
+            probes: result.evaluation.probes,
+            pools: productHealthSnapshotBlocks?.solvency?.pools ?? [],
+            runway: productHealthSnapshotBlocks?.solvency?.runway ?? [],
+            ...(productHealthSnapshotBlocks?.flow?.payout
+              ? { payout: productHealthSnapshotBlocks.flow.payout }
+              : {}),
+          }).headline,
+          probes: result.evaluation.probes,
+          bankRequests: productHealthSnapshotBlocks?.bank?.lane?.requests ?? null,
+        });
+        const digestBuzz = readBuzzConfig();
+        if (!digestBuzz.config) {
+          // No relay configured: the local collaboration record IS the digest.
+          recordCollaborationMessage({ author: "hermes", text: digestText, kind: "chat" });
+          morningDigestSentLocalDate = digestCheck.localDate;
+          writeMorningDigestState(digestCheck.localDate);
+          logger.info({ localDate: digestCheck.localDate }, "morning_digest_recorded_undelivered");
+        } else {
+          const delivery = await publishNarration(digestBuzz.config, digestText);
+          buzzDeliveryState = recordBuzzDelivery(buzzDeliveryState, {
+            ok: delivery.ok,
+            reason: delivery.reason,
+            detail: delivery.detail,
+            atMs: Date.now(),
+          });
+          if (delivery.ok) {
+            recordCollaborationMessage({ author: "hermes", text: digestText, kind: "chat" });
+            morningDigestSentLocalDate = digestCheck.localDate;
+            writeMorningDigestState(digestCheck.localDate);
+            logger.info(
+              { localDate: digestCheck.localDate, eventId: delivery.eventId },
+              "morning_digest_published",
+            );
+          } else {
+            // NOT marked sent: retried on the next tick until the relay
+            // answers. A Buzz outage at 08:00 delays the digest; it does not
+            // delete it.
+            logger.warn({ reason: delivery.reason, detail: delivery.detail }, "morning_digest_publish_failed");
           }
         }
       }

--- a/services/slack-operator/src/morning-digest.ts
+++ b/services/slack-operator/src/morning-digest.ts
@@ -1,0 +1,178 @@
+// The morning digest — one message at a chosen local time, then silence.
+//
+// The #Ops channel had taught the operator to ignore it: eight flapping
+// capability alerts in a day, speaking in enum values. The alert hold fixed the
+// noise; this is the other half. A channel that only ever speaks when something
+// crosses a threshold leaves the operator to PULL the daily picture from the
+// board. One scheduled message carries it to them: verdict, flow, floors,
+// credentials, the bank lane, and anything currently not-ok — then the channel
+// goes quiet again until something real happens.
+//
+// ── WHY THIS LIVES HERE AND NOT IN HERMES CRON ────────────────────────────
+//
+// Decided when Buzz went live: Hermes cron's `--deliver` has no Buzz target,
+// and Hermes v0.20.0's bundled Buzz platform was deliberately declined (second
+// inbound path, weaker gates). slack-operator already owns the only sanctioned
+// Buzz publisher, so the schedule lives beside it.
+//
+// ── ONE VERDICT SYSTEM ────────────────────────────────────────────────────
+//
+// The digest quotes the SAME strings the board renders — probe details decided
+// server-side, the shared deriveOpsVerdict headline — and composes zero
+// opinions of its own. Two verdict systems disagree eventually, and the first
+// disagreement is the last time the operator believes either.
+//
+// ── TIME IS LOCAL, AND FAIL-CLOSED ────────────────────────────────────────
+//
+// "08:00" means the operator's morning, not the server's UTC. The timezone is
+// config; an invalid one DISABLES the digest with a named problem rather than
+// guessing — a digest at a wrong-guessed hour is the wrong-subject failure
+// wearing a clock. Late is honest: if the process was down at 08:00, the
+// digest fires on the first tick after it comes back, stamped with the time it
+// actually ran.
+//
+// Kept pure — no clock, no I/O — so every rule is testable without a relay.
+
+export interface DigestSchedule {
+  enabled: boolean;
+  /** Local wall-clock target. */
+  hour: number;
+  minute: number;
+  /** IANA zone the wall clock is read in. */
+  timeZone: string;
+  /** Why the digest is disabled despite the env asking for it. */
+  problem?: string;
+}
+
+/**
+ * Parse the schedule from env. Disabled by default — a scheduled message is
+ * armed deliberately, like every other feature flag here.
+ */
+export function readDigestSchedule(env: NodeJS.ProcessEnv = process.env): DigestSchedule {
+  const off: DigestSchedule = { enabled: false, hour: 8, minute: 0, timeZone: "Europe/Zurich" };
+  const flag = (env.BUZZ_MORNING_DIGEST ?? "").trim();
+  if (!["1", "true", "yes", "on"].includes(flag.toLowerCase())) return off;
+
+  const time = (env.BUZZ_DIGEST_TIME ?? "08:00").trim();
+  const m = /^([01]?\d|2[0-3]):([0-5]\d)$/.exec(time);
+  if (!m) {
+    return { ...off, problem: `BUZZ_DIGEST_TIME "${time}" is not HH:MM — digest disabled rather than guessed` };
+  }
+
+  const timeZone = (env.BUZZ_DIGEST_TZ ?? "Europe/Zurich").trim();
+  try {
+    // The only reliable IANA-zone validator Node ships. Throws on garbage.
+    new Intl.DateTimeFormat("en-CA", { timeZone });
+  } catch {
+    return { ...off, problem: `BUZZ_DIGEST_TZ "${timeZone}" is not an IANA zone — digest disabled rather than guessed` };
+  }
+
+  return { enabled: true, hour: Number(m[1]), minute: Number(m[2]), timeZone };
+}
+
+/** The local calendar date and minutes-since-midnight at `nowMs` in `timeZone`. */
+export function localStamp(nowMs: number, timeZone: string): { date: string; minutes: number; hhmm: string } {
+  const fmt = new Intl.DateTimeFormat("en-CA", {
+    timeZone,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: false,
+  });
+  const parts = Object.fromEntries(fmt.formatToParts(new Date(nowMs)).map((p) => [p.type, p.value]));
+  // Intl emits "24" for midnight in some ICU versions; normalise.
+  const hour = Number(parts.hour) % 24;
+  const minute = Number(parts.minute);
+  return {
+    date: `${parts.year}-${parts.month}-${parts.day}`,
+    minutes: hour * 60 + minute,
+    hhmm: `${String(hour).padStart(2, "0")}:${String(minute).padStart(2, "0")}`,
+  };
+}
+
+/**
+ * Once per local day, at or after the target time.
+ *
+ * Down at 08:00 → fires when the process returns (late beats absent, and the
+ * message is stamped with its real time). Already sent today → never again,
+ * whatever restarts happen — which is why the caller persists the local DATE
+ * rather than a timestamp: the date is the fact "today's digest exists".
+ */
+export function digestDue(input: {
+  nowMs: number;
+  schedule: DigestSchedule;
+  lastSentLocalDate: string | null;
+}): { due: boolean; localDate: string; localTime: string } {
+  const { schedule } = input;
+  const stamp = localStamp(input.nowMs, schedule.timeZone);
+  const due =
+    schedule.enabled &&
+    stamp.minutes >= schedule.hour * 60 + schedule.minute &&
+    input.lastSentLocalDate !== stamp.date;
+  return { due, localDate: stamp.date, localTime: stamp.hhmm };
+}
+
+/** The probe shape the digest reads — the same one the board renders. */
+export interface DigestProbe {
+  name: string;
+  status: string;
+  detail: string;
+}
+
+export interface MorningDigestInput {
+  localDate: string;
+  localTime: string;
+  timeZone: string;
+  network: string;
+  /** deriveOpsVerdict output — headline is prose FOR humans; that is this. */
+  verdictHeadline: string;
+  probes: readonly DigestProbe[];
+  /** The bank lane's server-decided requests line, when a lane exists at all. */
+  bankRequests?: { text: string; tone: string } | null;
+}
+
+const DIGEST_LINE_PROBES: readonly { key: string; name: string }[] = [
+  { key: "FLOW", name: "money_path" },
+  { key: "FLOORS", name: "signer_liquidity" },
+  { key: "CREDS", name: "credential_expiry" },
+];
+
+/**
+ * Compose the message. Every content string is a probe's own detail or the
+ * shared verdict headline — this function chooses layout and nothing else.
+ *
+ *  · A probe that is absent contributes NO line. Absence is not zero, and a
+ *    "FLOW —" placeholder would claim a measurement nobody took.
+ *  · Probes that are not ok get quoted in full under ATTENTION, because the
+ *    alert hold may have (correctly) never announced a flapping one — the
+ *    digest is the once-a-day complete picture.
+ *  · The bank line appears only when a lane exists — the same absent-is-
+ *    nothing rule the board and the phone follow.
+ */
+export function buildMorningDigest(input: MorningDigestInput): string {
+  const byName = new Map(input.probes.map((p) => [p.name, p] as const));
+  const ok = input.probes.filter((p) => p.status === "ok").length;
+  const red = input.probes.filter((p) => p.status === "red").length;
+
+  const lines: string[] = [];
+  lines.push(`MORNING DIGEST · ${input.localDate} ${input.localTime} ${input.timeZone} · AVERRAY ${input.network.toUpperCase()}`);
+  lines.push(input.verdictHeadline);
+  lines.push(`PROBES ${ok} ok / ${red} red of ${input.probes.length}`);
+
+  for (const { key, name } of DIGEST_LINE_PROBES) {
+    const probe = byName.get(name);
+    if (probe) lines.push(`${key} ${probe.detail}`);
+  }
+
+  if (input.bankRequests) lines.push(`BANK ${input.bankRequests.text}`);
+
+  const attention = input.probes.filter((p) => p.status !== "ok");
+  if (attention.length > 0) {
+    lines.push("ATTENTION");
+    for (const p of attention) lines.push(`  ${p.status === "red" ? "✗" : "⚠"} ${p.name}: ${p.detail}`);
+  }
+
+  return lines.join("\n");
+}

--- a/services/slack-operator/test/unit/morning-digest.test.ts
+++ b/services/slack-operator/test/unit/morning-digest.test.ts
@@ -1,0 +1,133 @@
+// The digest's contract: once per LOCAL day, at or after the chosen time,
+// quoting only strings other systems decided.
+import { describe, expect, test } from "vitest";
+
+import {
+  buildMorningDigest,
+  digestDue,
+  localStamp,
+  readDigestSchedule,
+  type DigestProbe,
+} from "../../src/morning-digest.js";
+
+const ZURICH = "Europe/Zurich";
+// 2026-08-05T22:30Z. Zurich is UTC+2 in August, so LOCALLY this is already
+// 2026-08-06 00:30 — the date-boundary case a UTC-naive implementation gets
+// wrong in exactly the direction that double-sends.
+const LATE_EVENING_UTC = Date.parse("2026-08-05T22:30:00Z");
+const MORNING = Date.parse("2026-08-06T06:30:00Z"); // 08:30 in Zurich
+
+const enabled = { enabled: true, hour: 8, minute: 0, timeZone: ZURICH };
+
+describe("the schedule is config, and fail-closed", () => {
+  test("off by default — a scheduled message is armed deliberately", () => {
+    expect(readDigestSchedule({}).enabled).toBe(false);
+  });
+
+  test("armed with defaults: 08:00 Europe/Zurich", () => {
+    const s = readDigestSchedule({ BUZZ_MORNING_DIGEST: "1" });
+    expect(s).toMatchObject({ enabled: true, hour: 8, minute: 0, timeZone: ZURICH });
+  });
+
+  test("an invalid time DISABLES with a named problem — never a guessed hour", () => {
+    const s = readDigestSchedule({ BUZZ_MORNING_DIGEST: "1", BUZZ_DIGEST_TIME: "8am" });
+    expect(s.enabled).toBe(false);
+    expect(s.problem).toContain('"8am"');
+  });
+
+  test("an invalid zone DISABLES with a named problem — never a guessed clock", () => {
+    const s = readDigestSchedule({ BUZZ_MORNING_DIGEST: "1", BUZZ_DIGEST_TZ: "Mars/Olympus" });
+    expect(s.enabled).toBe(false);
+    expect(s.problem).toContain("Mars/Olympus");
+  });
+});
+
+describe("once per local day, at or after the time", () => {
+  test("before the hour: not due", () => {
+    const d = digestDue({ nowMs: LATE_EVENING_UTC, schedule: enabled, lastSentLocalDate: "2026-08-05" });
+    // 00:30 local on the 6th — a new day, but hours before 08:00.
+    expect(d.due).toBe(false);
+    expect(d.localDate).toBe("2026-08-06");
+  });
+
+  test("after the hour on a fresh day: due, stamped with the real local time", () => {
+    const d = digestDue({ nowMs: MORNING, schedule: enabled, lastSentLocalDate: "2026-08-05" });
+    expect(d).toMatchObject({ due: true, localDate: "2026-08-06", localTime: "08:30" });
+  });
+
+  test("already sent today: never again, whatever restarts happen", () => {
+    const d = digestDue({ nowMs: MORNING, schedule: enabled, lastSentLocalDate: "2026-08-06" });
+    expect(d.due).toBe(false);
+  });
+
+  test("down at 08:00 → fires late rather than not at all", () => {
+    const lateAfternoon = Date.parse("2026-08-06T14:07:00Z"); // 16:07 local
+    const d = digestDue({ nowMs: lateAfternoon, schedule: enabled, lastSentLocalDate: "2026-08-05" });
+    expect(d).toMatchObject({ due: true, localTime: "16:07" });
+  });
+
+  test("disabled never fires, even past the hour", () => {
+    const d = digestDue({ nowMs: MORNING, schedule: { ...enabled, enabled: false }, lastSentLocalDate: null });
+    expect(d.due).toBe(false);
+  });
+
+  test("the UTC/local date boundary is decided in the LOCAL zone", () => {
+    // At 22:30Z it is already tomorrow in Zurich. A UTC-date dedupe would call
+    // this "still 2026-08-05" and then send twice on the 6th.
+    expect(localStamp(LATE_EVENING_UTC, ZURICH).date).toBe("2026-08-06");
+    expect(localStamp(LATE_EVENING_UTC, "UTC").date).toBe("2026-08-05");
+  });
+});
+
+describe("the message quotes; it does not opine", () => {
+  const probes: DigestProbe[] = [
+    { name: "money_path", status: "ok", detail: "settled24h 16 (0 stuck, 0 failed)" },
+    { name: "signer_liquidity", status: "ok", detail: "gas 7.2018 DOT, reward bank 10.20 USDC" },
+    { name: "credential_expiry", status: "ok", detail: "3 TLS certs · no tokens watched, soonest expiry 37d" },
+    { name: "chain_height", status: "ok", detail: "block #19,083,248" },
+  ];
+  const base = {
+    localDate: "2026-08-06",
+    localTime: "08:00",
+    timeZone: ZURICH,
+    network: "mainnet",
+    verdictHeadline: "money is moving and proven on-chain",
+    probes,
+  };
+
+  test("a clean morning: header, verdict, counts, and the probes' own words", () => {
+    const text = buildMorningDigest({ ...base, bankRequests: { text: "no requests in flight", tone: "ok" } });
+    expect(text).toContain("MORNING DIGEST · 2026-08-06 08:00 Europe/Zurich · AVERRAY MAINNET");
+    expect(text).toContain("money is moving and proven on-chain");
+    expect(text).toContain("PROBES 4 ok / 0 red of 4");
+    expect(text).toContain("FLOW settled24h 16 (0 stuck, 0 failed)");
+    expect(text).toContain("CREDS 3 TLS certs · no tokens watched");
+    expect(text).toContain("BANK no requests in flight");
+    expect(text).not.toContain("ATTENTION");
+  });
+
+  test("an absent probe contributes NO line — absence is not zero", () => {
+    const text = buildMorningDigest({ ...base, probes: probes.filter((p) => p.name !== "money_path") });
+    expect(text).not.toContain("FLOW");
+  });
+
+  test("no bank lane, no BANK line — the rule every surface follows", () => {
+    const text = buildMorningDigest({ ...base, bankRequests: null });
+    expect(text).not.toContain("BANK");
+  });
+
+  test("everything not-ok is quoted under ATTENTION — the hold may never have announced it", () => {
+    const text = buildMorningDigest({
+      ...base,
+      probes: [
+        ...probes,
+        { name: "capabilities", status: "degraded", detail: "External posting is staged. (external_posting_staged)" },
+        { name: "api_latency", status: "red", detail: "/health 4100ms" },
+      ],
+    });
+    expect(text).toContain("ATTENTION");
+    expect(text).toContain("⚠ capabilities: External posting is staged.");
+    expect(text).toContain("✗ api_latency: /health 4100ms");
+    expect(text).toContain("PROBES 4 ok / 1 red of 6");
+  });
+});


### PR DESCRIPTION
The channel had two modes: event-driven alerts (now held to a standard by #734/#735) and answers when asked. Nothing carried the daily picture **to** the operator. One scheduled message now does — then the channel goes quiet again until something real happens.

## What it sends

```
MORNING DIGEST · 2026-08-06 08:00 Europe/Zurich · AVERRAY MAINNET
money is moving and proven on-chain · all floors clear
PROBES 10 ok / 0 red of 10
FLOW settled24h 16 (0 stuck, 0 failed)
FLOORS gas 7.2018 DOT, reward bank 10.20 USDC
CREDS 3 TLS certs · no tokens watched, soonest expiry 37d
BANK 1 in flight · oldest 0xb609f4d8… staged-on-chain-backfill for 11.2h
ATTENTION            ← only when something is not ok
  ⚠ capabilities: External posting is staged. (external_posting_staged)
```

## The rules, each a house rule restated

- **One verdict system.** It calls `deriveOpsVerdict` with the *same inputs* the `/monitor/product-health` endpoint uses and prints its headline; every other string is a probe's own detail or the bank lane's server-decided line. The composer chooses layout and nothing else.
- **Absence is not zero.** An absent probe contributes no line — a `FLOW —` placeholder would claim a measurement nobody took. No bank lane → no BANK line.
- **ATTENTION quotes everything not-ok in full** — the alert hold may have (correctly) never announced a flapping condition; the digest is the once-a-day complete picture.

## Time is local, and fail-closed

`BUZZ_DIGEST_TIME` / `BUZZ_DIGEST_TZ` (default 08:00 Europe/Zurich). An invalid time or zone **disables** the digest with a named problem in the logs — a digest at a wrong-guessed hour is the wrong-subject failure wearing a clock. The persisted dedupe fact is the local *date* ("today's digest exists"), so restarts around the window neither double-post nor skip; the 22:30Z-is-already-tomorrow-in-Zurich boundary is pinned by test. Down at 08:00 → fires on return, stamped with its real time. Buzz outage → retried every tick, never marked sent — delayed, not deleted. Muted → skipped *without* marking, so the day's digest arrives on unmute.

## Why slack-operator and not Hermes cron

Decided when Buzz went live: cron's `--deliver` has no Buzz target, and v0.20.0's bundled Buzz platform was deliberately declined (second inbound path, weaker gates). This service owns the only sanctioned Buzz publisher, so the schedule lives beside it.

## Arming

Off by default. In `.env.prod` (same convention as the other `BUZZ_` flags):

```
BUZZ_MORNING_DIGEST=1
```

## Verification

14 new tests (schedule parsing, once-per-local-day, TZ boundary, late-fire, mute, absent-probe/bank omission, ATTENTION). **`npx vitest run` — whole repo, 2,704 passed.** The first live render is tomorrow 08:00 — that's the acceptance test, and I'll want to see it before calling this verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)