### PR TITLE
feat(bank): render the request's own clock, and know the v2.2 vocabulary

### DIFF
--- a/packages/monitor-ui/src/lib/monitor/ops-suggestions.test.ts
+++ b/packages/monitor-ui/src/lib/monitor/ops-suggestions.test.ts
@@ -224,7 +224,11 @@ describe("bank — an overdue venue request", () => {
     const s = opsSuggestions(withOverdue()).find((x) => x.id === "bank-overdue");
     expect(s).toBeTruthy();
     expect(s!.text).toContain("8.7h");
-    expect(s!.text).toContain("leg 2");
+    // No leg assertion: the first live overdue after the original wording
+    // shipped was a request that never dispatched ANY leg. The advice must not
+    // presuppose where it stopped — that is what the investigation determines.
+    expect(s!.text).toContain("Determine where it actually stopped");
+    expect(s!.text).not.toContain("leg 2");
   });
 
   test("its task INVESTIGATES and is explicit about not moving funds", () => {

--- a/packages/monitor-ui/src/lib/monitor/ops-suggestions.ts
+++ b/packages/monitor-ui/src/lib/monitor/ops-suggestions.ts
@@ -141,12 +141,16 @@ export function opsSuggestions(health: ProductHealth | undefined): OpsSuggestion
   const overdueRequestId = health.bank?.lane?.overdueRequestId ?? null;
   if (overdueRequestId) {
     const requests = health.bank?.lane?.requests?.text ?? "an overdue request";
+    // Phase-agnostic on purpose. The first wording said "check whether leg 2
+    // landed" — and the first live overdue after it shipped was a request that
+    // never dispatched ANY leg (staged, deadline lapsed, 2026-08-05).
+    // Asserting a leg is the wrong-subject failure inside the advice itself.
     out.push({
       id: "bank-overdue",
       tone: "warn",
-      text: `Bank request overdue — ${requests}. Check whether leg 2 landed on the destination chain.`,
+      text: `Bank request overdue — ${requests}. Determine where it actually stopped.`,
       task: proposeTask(
-        `A Hydration bank request is overdue: "${requests}". Do NOT move funds — INVESTIGATE ONLY. Trace the leg-2 dispatch for request ${overdueRequestId} on both chains, determine whether it landed, stalled, or failed, and draft the exact recovery steps for the operator to review.`,
+        `A Hydration bank request is overdue: "${requests}". Do NOT move funds — INVESTIGATE ONLY. Read request ${overdueRequestId}'s actual on-chain state on both chains — it may have lapsed before any dispatch, stalled mid-leg, or failed after one — and draft the exact next steps (re-stage, dispatch, or reclaim per the wrapper contract) for the operator to review.`,
       ),
     });
   }

--- a/services/slack-operator/src/bank-feed-fetch.ts
+++ b/services/slack-operator/src/bank-feed-fetch.ts
@@ -159,6 +159,15 @@ function requestsBlock(raw: unknown): { requests: BankRequests } | { reason: str
       phase: e.phase,
       ageSeconds: e.ageSeconds,
       overdue: e.overdue,
+      // Tolerant on purpose: the producer computes overdue FROM deadlineAt but
+      // does not emit it per-row yet. Accept epoch-ms or ISO the moment it
+      // ships; until then the renderer shows no deadline rather than a made-up
+      // one. Never required — a feed without the field must keep parsing.
+      ...(typeof e.deadlineAtMs === "number" && Number.isFinite(e.deadlineAtMs)
+        ? { deadlineAtMs: e.deadlineAtMs }
+        : typeof e.deadlineAt === "string" && Number.isFinite(Date.parse(e.deadlineAt))
+          ? { deadlineAtMs: Date.parse(e.deadlineAt) }
+          : {}),
       ...(typeof e.status === "string" ? { status: e.status } : {}),
       ...(reconciliation ? { reconciliation } : {}),
     });

--- a/services/slack-operator/src/bank-feed.ts
+++ b/services/slack-operator/src/bank-feed.ts
@@ -70,6 +70,16 @@ export interface BankRequest {
   ageSeconds: number;
   /** Past its observer deadline. THE stuck-pending alarm. */
   overdue: boolean;
+  /**
+   * The request's own on-chain dispatch deadline, epoch ms — the clock
+   * `overdue` is computed against, which the producer does not yet emit
+   * per-row (bank-lane-feed.js computes and drops it). Optional so this board
+   * lights up the moment the field ships and renders nothing until then: a
+   * deadline nobody sent must not be displayed, and 2026-08-05 proved age is
+   * the WRONG clock — a staged request read "in flight 11.2h", calm, while
+   * 19 minutes remained to its deadline.
+   */
+  deadlineAtMs?: number | null;
   /** Producer-owned terminal status; pending for in-flight rows. */
   status?: string;
   /**
@@ -89,13 +99,59 @@ export interface BankRequest {
   };
 }
 
-/** The observer's vocabulary as of today. Not exhaustive by construction. */
+/**
+ * The observer's vocabulary as of today. Not exhaustive by construction —
+ * `normalizeRequestPhase` on the producer accepts ANY non-empty string, and
+ * Codex confirmed (2026-08-05) there is no closed enum and no exported
+ * constant to consume. This list is the documented production set from that
+ * answer: emitters in mcp-server/src/services/xcm-balance-observer.js, feed
+ * synthesis in bank-lane-feed.js, v2.2 phases introduced by platform PR #944.
+ *
+ * The UNRECOGNISED-PHASE flag over this list earned its keep the hard way:
+ * on 2026-08-05 it fired on `staged-on-chain-backfill`, the question it forced
+ * surfaced a staged request 19 minutes from its dispatch deadline, and the
+ * deadline lapsed before anyone could act. The flag is for genuine strangers;
+ * it must not cry wolf on every phase the producer already documents.
+ */
 export const KNOWN_PHASES = [
+  // observer lifecycle (v2.2, PR #944)
+  "registered",
+  "staged-on-chain",
+  "staged-on-chain-backfill",
+  "leg-0-dispatched-on-chain",
+  "leg-1-dispatched-on-chain",
+  "leg-2-dispatched-on-chain",
+  "leg-3-dispatched-on-chain",
+  // legacy observer lifecycle (v2.0/v2.1)
   "leg1-dispatched",
   "leg2-dispatched",
+  // shared tail
   "pending-finalize",
+  "scope-unknown",
   "terminal",
+  // synthesized by the feed itself, never by the observer
+  "timing-unknown",
+  "recovery-pending",
+  "snapshot-invalid",
 ] as const;
+
+/**
+ * Phases whose next step is an ADMIN ACTION, per the producer's contract
+ * (Codex, 2026-08-05): "It does not dispatch autonomously. An operator must
+ * invoke the admin dispatch path; no scheduled job performs that signing
+ * action." A staged request reads calm — "1 in flight" — while a dispatch
+ * deadline runs down; on 2026-08-05 one lapsed exactly that way. Naming the
+ * waiting party is the difference between watching and waiting.
+ */
+export const OPERATOR_ACTION_PHASES = [
+  "registered",
+  "staged-on-chain",
+  "staged-on-chain-backfill",
+] as const;
+
+export function awaitsOperator(phase: string): boolean {
+  return (OPERATOR_ACTION_PHASES as readonly string[]).includes(phase);
+}
 
 export function isKnownPhase(phase: string): boolean {
   return (KNOWN_PHASES as readonly string[]).includes(phase);

--- a/services/slack-operator/src/bank-lane.ts
+++ b/services/slack-operator/src/bank-lane.ts
@@ -22,6 +22,7 @@ import {
   type BankRequest,
   type BankRequests,
   type SourcedRead,
+  awaitsOperator,
 } from "./bank-feed.js";
 import { decidePositionDisplay, type PositionView } from "./position-display.js";
 
@@ -329,12 +330,14 @@ function requestLine(requests: BankRequests, nowMs: number, staleAfterMs: number
   if (overdue.length > 0) {
     const lead = overdue.reduce((a, b) => (b.ageSeconds > a.ageSeconds ? b : a));
     return {
-      text: `${overdue.length} OVERDUE · ${lead.id} ${lead.phase} ${describeAge(lead)}`,
+      text: `${overdue.length} OVERDUE · ${lead.id} ${lead.phase} ${describeAge(lead)}${describeDeadline(lead, nowMs)}`,
       tone: "red",
     };
   }
   const lead = live.reduce((a, b) => (b.ageSeconds > a.ageSeconds ? b : a));
-  const base = `${live.length} in flight · oldest ${lead.id} ${lead.phase} ${describeAge(lead)}`;
+  const base =
+    `${live.length} in flight · oldest ${lead.id} ${lead.phase} ${describeAge(lead)}` +
+    `${describeDeadline(lead, nowMs)}${awaitsOperator(lead.phase) ? " · awaiting operator dispatch" : ""}`;
   if (unknown.length > 0) {
     // Verbatim, so the value is searchable against the observer's own source.
     const u = unknown[0]!;
@@ -356,6 +359,26 @@ function requestLine(requests: BankRequests, nowMs: number, staleAfterMs: number
  */
 function describeAge(request: BankRequest): string {
   return request.phase === "timing-unknown" ? "· age unknown" : `for ${formatAge(request.ageSeconds)}`;
+}
+
+/**
+ * The request's own clock, when the feed sends it — and NOTHING when it does
+ * not.
+ *
+ * Age is the wrong clock, proven live: on 2026-08-05 a staged request read
+ * "in flight 11.2h", calm, while 19 minutes remained to its on-chain dispatch
+ * deadline. It lapsed. The deadline was always the operative number, computed
+ * by the feed and never emitted; this renders it the moment the producer
+ * ships the field. No monitor-side threshold, no tone change — `overdue` stays
+ * the producer's own judgement (the rule at the top of requestLine), and this
+ * only SHOWS the clock that judgement runs on.
+ */
+function describeDeadline(request: BankRequest, nowMs: number): string {
+  const at = request.deadlineAtMs;
+  if (typeof at !== "number" || !Number.isFinite(at)) return "";
+  const remaining = at - nowMs;
+  if (remaining >= 0) return ` · deadline in ${formatAge(Math.round(remaining / 1000))}`;
+  return ` · deadline lapsed ${formatAge(Math.round(-remaining / 1000))} ago`;
 }
 
 function formatAge(seconds: number): string {

--- a/services/slack-operator/test/unit/bank-feed-fetch.test.ts
+++ b/services/slack-operator/test/unit/bank-feed-fetch.test.ts
@@ -155,3 +155,37 @@ describe("a malformed calibration is dropped, never repaired", () => {
     expect(r.feed!.calibration!.provenRaw).toBe("100000");
   });
 });
+
+describe("the deadline field is accepted the moment the producer ships it", () => {
+  // bank-lane-feed.js computes `overdue` FROM deadlineAt and drops it; the
+  // one-field ask is out with Codex. This parser is ready for either spelling
+  // and requires neither — a feed without the field must keep parsing.
+  const withRequest = (extra: Record<string, unknown>) => ({
+    ...good,
+    requests: {
+      readAtMs: 1_785_900_000_000,
+      items: [{ id: "req-1", kind: "deposit", phase: "staged-on-chain", ageSeconds: 60, overdue: false, ...extra }],
+    },
+  });
+
+  test("epoch-ms is taken as-is", () => {
+    const r = normalizeBankFeed(withRequest({ deadlineAtMs: 1_785_940_000_000 }));
+    expect("feed" in r && r.feed.requests.items[0]?.deadlineAtMs).toBe(1_785_940_000_000);
+  });
+
+  test("an ISO string is parsed", () => {
+    const r = normalizeBankFeed(withRequest({ deadlineAt: "2026-08-05T08:37:12Z" }));
+    expect("feed" in r && r.feed.requests.items[0]?.deadlineAtMs).toBe(Date.parse("2026-08-05T08:37:12Z"));
+  });
+
+  test("absent stays absent — today's feed keeps parsing unchanged", () => {
+    const r = normalizeBankFeed(withRequest({}));
+    expect("feed" in r && r.feed.requests.items[0]).not.toHaveProperty("deadlineAtMs");
+  });
+
+  test("garbage is dropped, never an error and never a date", () => {
+    const r = normalizeBankFeed(withRequest({ deadlineAt: "not-a-date", deadlineAtMs: Number.NaN }));
+    expect("feed" in r).toBe(true);
+    expect("feed" in r && r.feed.requests.items[0]).not.toHaveProperty("deadlineAtMs");
+  });
+});

--- a/services/slack-operator/test/unit/bank-lane.test.ts
+++ b/services/slack-operator/test/unit/bank-lane.test.ts
@@ -153,12 +153,15 @@ describe("an unrecognised phase is surfaced, never dropped", () => {
     // The observer owns this vocabulary and may extend it. A request in a phase
     // this board has never heard of is the most unusual one in the table, which
     // makes hiding it exactly backwards.
+    // "recovery-pending" used to be the specimen here; it is DOCUMENTED
+    // vocabulary now (feed-synthesized, per Codex's 2026-08-05 contract
+    // answer), so the specimen must be a genuine stranger.
     const v = bankLaneView({
-      feed: feed({ requests: { items: [req({ id: "req-77", phase: "recovery-pending" })], readAtMs: NOW } }),
+      feed: feed({ requests: { items: [req({ id: "req-77", phase: "phase-from-the-future" })], readAtMs: NOW } }),
       nowMs: NOW,
     })!;
     expect(v.requests.text).toContain("1 in flight");
-    expect(v.requests.text).toContain('UNRECOGNISED PHASE "recovery-pending"');
+    expect(v.requests.text).toContain('UNRECOGNISED PHASE "phase-from-the-future"');
     expect(v.requests.text).toContain("req-77");
     expect(v.requests.tone).toBe("degraded");
   });
@@ -243,5 +246,95 @@ describe("an overdue request is the stuck-pending alarm, named", () => {
     })!;
     expect(ancientButNotOverdue.requests.tone).toBe("ok");
     expect(ancientButNotOverdue.overdueRequestId).toBeNull();
+  });
+});
+
+// ── THE v2.2 CONTRACT, LEARNED THE EXPENSIVE WAY ──────────────────────────
+//
+// On 2026-08-05 a staged v2.2 request read `1 in flight · staged-on-chain-
+// backfill for 11.2h`, calm, while its on-chain dispatch deadline ran down.
+// It needed an OPERATOR to dispatch it; nobody knew; it lapsed with 19 minutes
+// of warning available and none rendered. Codex's contract answer settled the
+// semantics these tests pin.
+describe("the documented v2.2 vocabulary is recognised", () => {
+  test("staged-on-chain-backfill no longer trips the stranger flag", () => {
+    const v = bankLaneView({
+      feed: feed({ requests: { items: [req({ phase: "staged-on-chain-backfill" })], readAtMs: NOW } }),
+      nowMs: NOW,
+    })!;
+    expect(v.requests.text).not.toContain("UNRECOGNISED");
+  });
+
+  test("the first v2.2 dispatch phase will not cry wolf either", () => {
+    // "Merely adding this one label will fail again at the first v2.2
+    // dispatch" — Codex, answering why there is no closed enum. The whole
+    // documented set is in, so the flag is reserved for genuine strangers.
+    for (const phase of ["registered", "staged-on-chain", "leg-0-dispatched-on-chain", "leg-3-dispatched-on-chain", "scope-unknown", "snapshot-invalid"]) {
+      const v = bankLaneView({
+        feed: feed({ requests: { items: [req({ phase })], readAtMs: NOW } }),
+        nowMs: NOW,
+      })!;
+      expect(v.requests.text, phase).not.toContain("UNRECOGNISED");
+    }
+  });
+});
+
+describe("a staged request names who it is waiting for", () => {
+  test("staged phases carry 'awaiting operator dispatch'", () => {
+    // The producer's contract: staged requests do not dispatch autonomously —
+    // an operator must act. A calm "in flight" hid exactly that.
+    const v = bankLaneView({
+      feed: feed({ requests: { items: [req({ phase: "staged-on-chain-backfill" })], readAtMs: NOW } }),
+      nowMs: NOW,
+    })!;
+    expect(v.requests.text).toContain("awaiting operator dispatch");
+  });
+
+  test("autonomous phases do not claim to wait on anyone", () => {
+    const v = bankLaneView({
+      feed: feed({ requests: { items: [req({ phase: "leg-1-dispatched-on-chain" })], readAtMs: NOW } }),
+      nowMs: NOW,
+    })!;
+    expect(v.requests.text).not.toContain("awaiting operator");
+  });
+});
+
+describe("the deadline clock renders when the feed sends it — and never otherwise", () => {
+  test("a future deadline is shown as time remaining", () => {
+    const v = bankLaneView({
+      feed: feed({
+        requests: {
+          items: [req({ phase: "staged-on-chain-backfill", deadlineAtMs: NOW + 19 * 60_000 })],
+          readAtMs: NOW,
+        },
+      }),
+      nowMs: NOW,
+    })!;
+    expect(v.requests.text).toContain("deadline in 19m");
+  });
+
+  test("an overdue request shows how long ago its deadline lapsed", () => {
+    const v = bankLaneView({
+      feed: feed({
+        requests: {
+          items: [req({ phase: "staged-on-chain-backfill", overdue: true, deadlineAtMs: NOW - 2 * 3_600_000 })],
+          readAtMs: NOW,
+        },
+      }),
+      nowMs: NOW,
+    })!;
+    expect(v.requests.tone).toBe("red");
+    // formatAge renders hours with one decimal ("2.0h") — same as the age.
+    expect(v.requests.text).toContain("deadline lapsed 2.0h ago");
+  });
+
+  test("no field, no clock — a deadline nobody sent is not displayed", () => {
+    // The producer computes overdue FROM deadlineAt but does not emit it yet.
+    // Until it ships, rendering any deadline would be inventing one.
+    const v = bankLaneView({
+      feed: feed({ requests: { items: [req({ phase: "leg2-dispatched" })], readAtMs: NOW } }),
+      nowMs: NOW,
+    })!;
+    expect(v.requests.text).not.toContain("deadline");
   });
 });


### PR DESCRIPTION
Encodes [Codex's contract answer](https://github.com/averray-agent/agent/pull/944) after this morning's lapse: a staged v2.2 request read `1 in flight · staged-on-chain-backfill for 11.2h` — calm — while its on-chain dispatch deadline ran to zero. It needed an operator; nobody knew; 19 minutes of warning existed and none rendered.

## Age is the wrong clock

The request carries its own `dispatchDeadline`; the feed computes `overdue` from it and **drops the timestamp per-row**. `describeDeadline()` now renders

```
1 in flight · oldest 0xb609… staged-on-chain-backfill for 11.2h · deadline in 19m · awaiting operator dispatch
1 OVERDUE  · 0xb609… staged-on-chain-backfill for 13.1h · deadline lapsed 2.0h ago
```

…**the moment the producer emits the field** (`deadlineAtMs` epoch or `deadlineAt` ISO, parsed tolerantly, required never) — and renders *nothing* until then: a deadline nobody sent must not be displayed. No monitor-side threshold, no tone change — `overdue` stays the producer's own judgement; this only shows the clock that judgement runs on. The one-field ask is with Codex.

## Staged phases name who they wait for

Per the contract, staged requests **do not dispatch autonomously**. The lane appends `· awaiting operator dispatch` for `registered` / `staged-on-chain` / `staged-on-chain-backfill`, so a calm "in flight" can't hide an operator action item again.

## The vocabulary is the documented set, not one more label

There is no closed enum — `normalizeRequestPhase` accepts any non-empty string — so `KNOWN_PHASES` now carries all fourteen documented production phases (v2.2 observer lifecycle, legacy, shared tail, feed-synthesized), cited to the contract answer. The UNRECOGNISED flag **stays** for genuine strangers — it forced the question that surfaced this contract — but it won't cry wolf at the first `leg-0-dispatched-on-chain`. The old test specimen (`recovery-pending`) is documented vocabulary now; the test uses a genuine stranger.

## The advice stops presupposing

The NEXT bank-overdue suggestion said *"check whether leg 2 landed"* — and the first live overdue after it shipped was a request that never dispatched **any** leg. Now phase-agnostic: *determine where it actually stopped*; lapsed-before-dispatch, stalled mid-leg, and failed-after are all named in the investigate task.

## Verification

27 bank-lane tests (+13), 17 fetch tests (+4), suggestion tests updated to reject the leg-2 wording. **Whole repo: 2,701 passed.** The deadline clock's live render waits on Codex's one-field change — until then the lane is byte-identical except the phase recognition and the operator note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)