### PR TITLE
feat(int4a): add the independent Slack watchdog

### DIFF
--- a/docs/HARNESS_INT4A_WATCHDOG_RUNBOOK.md
+++ b/docs/HARNESS_INT4A_WATCHDOG_RUNBOOK.md
@@ -1,0 +1,74 @@
+# INT-4a standalone watchdog runbook
+
+The watchdog is a default Compose service, independent of the dispatcher,
+Hermes, and slack-operator. It never dispatches, mutates a task, or performs
+remediation. It reads both Postgres boundaries, reads the dispatcher heartbeat,
+tails the dispatcher alert JSONL, writes its own observability files, and posts
+redacted alerts to a direct Slack incoming webhook when configured.
+
+Buzz/Nostr is deliberately not part of INT-4a. It is the separate INT-4a.1
+packet described in the work order.
+
+## Configuration
+
+The only credential-like value is `WATCHDOG_SLACK_WEBHOOK_URL`. The operator
+adds it to the watchdog's production environment after merge. Never commit,
+print, or pass the URL as a command-line argument. With the variable absent or
+empty, the service remains live and reports the Slack sink as `disabled`.
+
+Defaults:
+
+| Variable | Default | Purpose |
+|---|---:|---|
+| `WATCHDOG_POLL_INTERVAL_MS` | `15000` | Watch interval. |
+| `WATCHDOG_DISPATCHER_STALE_MS` | `90000` | Maximum dispatcher-heartbeat age. |
+| `WATCHDOG_HARNESS_SOURCE_STALE_MS` | `900000` | Maximum source-event age while a Harness run is live. Idle systems do not alert on source age. |
+| `WATCHDOG_DATABASE_TIMEOUT_MS` | `5000` | Bound on each read-only database probe. |
+| `WATCHDOG_HEARTBEAT_PATH` | `/data/harness-watchdog-heartbeat.json` | Watchdog heartbeat. |
+| `WATCHDOG_STATUS_PATH` | `/data/harness-watchdog-status.json` | One-line operator status. |
+
+The service shares `HARNESS_DISPATCH_HEARTBEAT_PATH`,
+`HARNESS_DISPATCH_ALERTS_PATH`, `DATABASE_URL`, and `HARNESS_DATABASE_URL` with
+the watched boundaries. It does not log those values.
+
+## Operator check
+
+After the normal image deployment, recreate only the watchdog through the
+repository's normal production Compose invocation. Then verify the container
+is running and read these two local files from the container:
+
+```sh
+cat /data/harness-watchdog-heartbeat.json
+cat /data/harness-watchdog-status.json
+```
+
+The status must name Slack as `configured` after provisioning, or `disabled`
+when the webhook variable is absent. `updatedAt` must advance. An active issue
+names the affected boundary; it never contains a database driver error or DSN.
+
+The recursion ends here: there is no watchdog-for-the-watchdog. The service has
+Compose `restart: unless-stopped`; the operator checks its container state and
+heartbeat during routine health checks.
+
+## Local drills
+
+Build first, then run the disposable Compose drill:
+
+```sh
+npm run typecheck
+node scripts/ceremony/run-int4a-watchdog-drills.mjs
+```
+
+The runner creates a unique `codex-int4a-*` Compose project, uses sentinel-only
+Postgres credentials and a local fake Slack listener, and always removes its
+containers, volumes, and network. It never addresses the production `avg`
+project.
+
+## Sink outage and rollback
+
+Slack delivery is forward-only and best-effort. The JSONL alert is written
+first, so a webhook outage does not erase evidence or stop another future sink.
+Clear `WATCHDOG_SLACK_WEBHOOK_URL` and recreate only the watchdog to disable
+external delivery; status will say `disabled`. Stopping the watchdog does not
+change dispatcher authority or task state, but it removes external detection
+until the service is restored.

--- a/docs/HARNESS_INT4_DRILL_LEDGER.md
+++ b/docs/HARNESS_INT4_DRILL_LEDGER.md
@@ -1,0 +1,56 @@
+# INT-4 failure-drill ledger
+
+This is the acceptance ledger defined by
+`docs/HARNESS_INT4_CHARTER.md`. A mechanism is not treated as proven until a
+disposable-environment drill has been observed red without it and green with
+it. Rows are amended with dated evidence; an implementation alone never
+silently upgrades a row.
+
+Status vocabulary is exactly the charter's: `proven`, `mechanism-only`, and
+`absent`.
+
+## The 22 §11 drills
+
+| §11 drill | Initial status on 2026-08-05 | Current status | Mechanism and evidence | Owner |
+|---|---|---|---|---|
+| Dispatcher crash before submit | `absent` | `absent` | Lease column exists but expiry semantics do not. INT-4c. | Dispatcher operator |
+| Dispatcher crash after submit before binding write | `proven` | `proven` | **Restart suite case (exactly-once held).** | Dispatcher operator |
+| Duplicate webhook/event | `mechanism-only` | `mechanism-only` | Projection dedupe exists; no disposable drill is cited yet. | INT-4d operator |
+| Harness/DBOS unavailable | `absent` | `proven` | Amended 2026-08-05: Harness Postgres stop produced a file alert and direct Slack delivery while the watchdog stayed live. [INT-4a drill evidence](evidence/INT4A_WATCHDOG_DRILLS_2026-08-05.md). | Watchdog operator |
+| Harness worker killed mid-run | `mechanism-only` | `mechanism-only` | DBOS durability exists; worker-orphan detection remains agent-harness#33 and no worker-kill drill is cited. | INT-4b operator |
+| Board unavailable | `mechanism-only` | `mechanism-only` | Harness execution is separated from the board; replay under board outage has not been drilled. | INT-4d operator |
+| Policy changes after approval | `mechanism-only` | `mechanism-only` | Pre-submit policy/hash checks exist; no policy-change drill is cited. | Dispatcher operator |
+| Approval/task hash mismatch | `proven` | `proven` | **Suite case.** | Dispatcher operator |
+| Capability expansion | `proven` | `proven` | **Narrow/over-broad + memory.propose cases.** | Dispatcher operator |
+| Budget/deadline exhaustion | `proven` | `proven` | **Budget-overrun case; live-cancel additionally proven by CI run 30980968234.** | Dispatcher operator |
+| Global HALT during run | `proven` | `proven` | **HALT suite case.** | Operator |
+| Verifier outage | `mechanism-only` | `mechanism-only` | Ineligible-handoff handling exists; no verifier-outage drill is cited. | Verification operator |
+| Verification timeout | `proven` | `proven` | **Kernel #35 bounded `command_timeout_seconds` + suite.** | Verification operator |
+| Verifier rejects output | `proven` | `proven` | **Negative fixture case.** | Verification operator |
+| Malicious/oversized event | `absent` | `absent` | No dispatcher-side poison-event quarantine. INT-4b. | INT-4b operator |
+| Conflicting run binding | `mechanism-only` | `mechanism-only` | Refusal exists at claim time; no detector for divergence after the fact. INT-4b. | INT-4b operator |
+| PR head changes after handoff | `proven` | `proven` | **Identity-mismatch + head_conflict (#740).** | Actuation operator |
+| PR API failure | `proven` | `proven` | **Crash-after-create convergence case.** | Actuation operator |
+| Averray control-plane outage | `absent` | `absent` | No disposable outage drill is cited. | Economic operator |
+| Settlement replay | `mechanism-only` | `mechanism-only` | Idempotency mechanisms exist; no settlement-replay drill is cited. | Economic operator |
+| Direct fallback after Harness failure | `absent` | `absent` | No explicit fallback-decision drill is cited. | Operator |
+| Hermes unavailable | `absent` | `proven` | Amended 2026-08-05: with every local Hermes/slack-operator container stopped, both dispatcher-stale and Harness-DB-down alerts reached direct Slack. [INT-4a drill evidence](evidence/INT4A_WATCHDOG_DRILLS_2026-08-05.md). | Watchdog operator |
+
+The nine rows that began `proven` above retain the charter's citations
+faithfully. INT-4a adds two proven rows; it does not reinterpret any other
+mechanism as a completed drill.
+
+## Charter §2 mechanism inventory
+
+This preserves the charter's separate, grep-verified inventory. The baseline
+wording remains visible; INT-4a amendments are dated rather than replacing it.
+
+| Mechanism | 2026-08-05 charter baseline | Current status and dated evidence |
+|---|---|---|
+| Durable lease expiry | **Column exists, written `null` — `dispatch-claim.ts:155`. Schema-present, semantics-absent.** | `absent`; unchanged, owned by INT-4c. |
+| Alert channel | **JSONL file sink only (`alerts.ts:8`); no consumer, no off-device path.** | `proven` on 2026-08-05: file-first consumer plus direct Slack delivery in [INT-4a evidence](evidence/INT4A_WATCHDOG_DRILLS_2026-08-05.md). The prior silence is [D0 evidence](evidence/INT4A_D0_SILENCE_2026-08-05.md). |
+| External watchdog / source-age | **Nothing dispatcher-side; all hits are Hermes-stack files — the thing alerts must NOT depend on.** | `proven` on 2026-08-05 for dispatcher staleness, live-run source age, both Postgres reachability boundaries, and Hermes-independent Slack delivery. [INT-4a evidence](evidence/INT4A_WATCHDOG_DRILLS_2026-08-05.md). |
+| Poison-event quarantine | **Kernel run-state `quarantined` is handled (`reconcile-run.ts:576`), but no dispatcher-side event quarantine.** | `absent`; unchanged, owned by INT-4b. |
+| Duplicate-binding quarantine | **Refusal exists at claim time; no detector for divergence after the fact.** | `mechanism-only`; unchanged, owned by INT-4b. |
+| Queue backpressure | **Absent.** | `absent`; unchanged, owned by INT-4c. |
+| Orphan detectors | **Absent both sides; kernel half is filed as agent-harness#33.** | `absent`; unchanged, owned by INT-4b. |

--- a/docs/evidence/INT4A_D0_SILENCE_2026-08-05.md
+++ b/docs/evidence/INT4A_D0_SILENCE_2026-08-05.md
@@ -1,0 +1,44 @@
+# INT-4a D0 silence baseline — 2026-08-05
+
+This drill ran against unmodified `main` at
+`1fa532322ce333c82519ca8ac66424670b9fbedd` before any watchdog code existed.
+It used the isolated local Compose project `codex-int4a-d0-42713`, two
+throwaway Postgres containers, a host-side dispatcher built from that commit,
+and a localhost fake sink. It did not start, stop, or inspect the production
+`avg` project and used no real credential.
+
+The two authenticated `select 1` results prove both databases were live. The
+dispatcher PID remained signalable while its heartbeat advanced from
+`2026-08-05T09:19:43.852Z` to `2026-08-05T09:19:48.862Z`, proving the process
+was alive before either injection. The Harness database stop command returned
+success; Compose's default `ps` view reports a stopped service as `missing`,
+which is the `state=missing` value below.
+
+The fake sink was listening before the injections. After the Harness database
+was stopped, and again after the dispatcher was terminated, neither the local
+dispatcher alert stream nor the external sink received a record. This is the
+red silence INT-4a exists to turn green.
+
+```text
+D0_MAIN_SHA=1fa532322ce333c82519ca8ac66424670b9fbedd
+D0_LOCAL_COMPOSE_PROJECT=codex-int4a-d0-42713
+D0_FAKE_SINK_LIVE=true pid=42723 port=52908
+D0_REFERENCE_DB_LIVE=1
+D0_HARNESS_DB_LIVE=1
+D0_DISPATCHER_LIVE=true pid=42785
+D0_HEARTBEAT_ONE=2026-08-05T09:19:43.852Z
+D0_HEARTBEAT_TWO=2026-08-05T09:19:48.862Z
+D0_HEARTBEAT_ADVANCING=true
+D0_HARNESS_DB_STOPPED=true state=missing
+D0_DB_DOWN_DISPATCHER_STILL_LIVE=true
+D0_DB_DOWN_ALERT_FILE_DELTA=0
+D0_DB_DOWN_EXTERNAL_DELIVERY_DELTA=0
+D0_DB_DOWN_SILENCE=true
+D0_DISPATCHER_KILLED=true pid_alive=false
+D0_DISPATCHER_KILLED_ALERT_FILE_DELTA=0
+D0_DISPATCHER_KILLED_EXTERNAL_DELIVERY_DELTA=0
+D0_DISPATCHER_KILLED_SILENCE=true
+D0_RESULT=red_silence_confirmed
+```
+
+The local project and volumes were removed by the drill cleanup.

--- a/docs/evidence/INT4A_WATCHDOG_DRILLS_2026-08-05.md
+++ b/docs/evidence/INT4A_WATCHDOG_DRILLS_2026-08-05.md
@@ -1,0 +1,160 @@
+# INT-4a watchdog drill evidence — 2026-08-05
+
+All runs used disposable Compose projects named `codex-int4a-*`, sentinel-only
+database credentials, and a local fake Slack listener. No production Compose
+project, production database, real webhook, Hermes credential, or Buzz/Nostr
+surface was used.
+
+The accepted pre-change silence and its liveness proofs remain in
+[INT4A_D0_SILENCE_2026-08-05.md](INT4A_D0_SILENCE_2026-08-05.md).
+
+## Red before the watchdog
+
+Dispatcher killed, with the dispatcher first proven live by an advancing
+heartbeat:
+
+```text
+D0_HEARTBEAT_ONE=2026-08-05T09:19:43.852Z
+D0_HEARTBEAT_TWO=2026-08-05T09:19:48.862Z
+D0_HEARTBEAT_ADVANCING=true
+D0_DISPATCHER_KILLED_ALERT_FILE_DELTA=0
+D0_DISPATCHER_KILLED_EXTERNAL_DELIVERY_DELTA=0
+D0_DISPATCHER_KILLED_SILENCE=true
+```
+
+Harness Postgres stopped, after authenticated `select 1` proved it live:
+
+```text
+D0_HARNESS_DB_LIVE=1
+D0_HARNESS_DB_STOPPED=true state=missing
+D0_DB_DOWN_DISPATCHER_STILL_LIVE=true
+D0_DB_DOWN_ALERT_FILE_DELTA=0
+D0_DB_DOWN_EXTERNAL_DELIVERY_DELTA=0
+D0_DB_DOWN_SILENCE=true
+```
+
+Hermes unavailable, with every local Hermes/slack-operator container stopped
+and no watchdog process present:
+
+```text
+INT4A_DATABASE_LIVE service=reference-db authenticated_select=1
+INT4A_DATABASE_LIVE service=harness-db authenticated_select=1
+INT4A_DRILL_RED hermes-unavailable-baseline external_delivery_missing watchdog_absent hermes=stopped slack_operator=stopped
+Error: INT4A_DRILL_ASSERTION_FAILED hermes-unavailable-baseline: external_delivery_missing watchdog_absent hermes=stopped slack_operator=stopped
+```
+
+## Restored green drills
+
+The real dispatcher heartbeat advanced before injection, both databases
+answered authenticated queries, and all three assertions passed through the
+local HTTP listener:
+
+```text
+INT4A_DATABASE_LIVE service=reference-db authenticated_select=1
+INT4A_DATABASE_LIVE service=harness-db authenticated_select=1
+INT4A_DISPATCHER_LIVE heartbeat_one=2026-08-05T13:37:51.205Z heartbeat_two=2026-08-05T13:37:56.227Z
+INT4A_DRILL_START dispatcher-killed
+INT4A_DRILL_GREEN dispatcher-killed file=present slack=delivered watchdog=running
+INT4A_DRILL_START harness-db-down
+INT4A_DRILL_GREEN harness-db-down file=present slack=delivered watchdog=running
+INT4A_DRILL_START hermes-unavailable
+INT4A_DRILL_GREEN hermes-unavailable hermes=stopped slack_operator=stopped dispatcher_alert=delivered harness_db_alert=delivered
+INT4A_DRILLS_RESULT=green 3/3
+```
+
+The first DB-down implementation attempt was also usefully red:
+
+```text
+INT4A_DRILL_RED harness-db-down delivery_missing code=watchdog_harness_database_unreachable file_emission=false slack_delivery=false mutation=none
+```
+
+It exposed that `pg` emits an unhandled error when an idle pooled connection is
+severed. Handling that pool event and bounding query time made the restored
+green above possible; the watchdog, rather than Node's EventEmitter, now owns
+the failure transition.
+
+## Mutation proofs
+
+### Dispatcher threshold set to infinity
+
+The runner injected `9007199254740991`, Compose passed it to the watchdog, and
+the delivery assertion went red:
+
+```text
+INT4A_DRILL_RED dispatcher-killed delivery_missing code=watchdog_dispatcher_heartbeat_stale file_emission=false slack_delivery=false mutation=threshold-infinity
+Error: INT4A_DRILL_ASSERTION_FAILED dispatcher-killed: delivery_missing code=watchdog_dispatcher_heartbeat_stale file_emission=false slack_delivery=false mutation=threshold-infinity
+```
+
+Removing the mutation restored:
+
+```text
+INT4A_DRILL_GREEN dispatcher-killed file=present slack=delivered watchdog=running
+```
+
+### Redaction scrub replaced by identity
+
+The focused test printed proof that the mutation reached the forwarder, then
+failed on the outbound HTTP body:
+
+```text
+INT4A_MUTATION_APPLIED=redaction_identity_scrub
+AssertionError: expected '{"text":"[HARNESS WATCHDOG CRITICAL] …' not to contain 'INT4A_TOKEN_SENTINEL_DO_NOT_LEAK'
+Expected: "INT4A_TOKEN_SENTINEL_DO_NOT_LEAK"
+Received: "{"text":"[HARNESS WATCHDOG CRITICAL] sentinel_probe: Authorization: Bearer INT4A_TOKEN_SENTINEL_DO_NOT_LEAK"}"
+Tests  1 failed | 8 skipped (9)
+```
+
+Removing the mutation restored:
+
+```text
+✓ test/unit/harness-watchdog.test.ts > the direct Slack forwarder > scrubs secret-bearing fields and authorization text before delivery
+Tests  1 passed | 8 skipped (9)
+```
+
+### Slack URL black-holed
+
+The local JSONL emission remained present, but the delivery assertion went red:
+
+```text
+INT4A_DRILL_RED dispatcher-killed delivery_missing code=watchdog_dispatcher_heartbeat_stale file_emission=true slack_delivery=false mutation=slack-blackhole
+Error: INT4A_DRILL_ASSERTION_FAILED dispatcher-killed: delivery_missing code=watchdog_dispatcher_heartbeat_stale file_emission=true slack_delivery=false mutation=slack-blackhole
+```
+
+Removing the mutation restored:
+
+```text
+INT4A_DRILL_GREEN dispatcher-killed file=present slack=delivered watchdog=running
+```
+
+This is the load-bearing proof that the drill checks delivery, not merely file
+emission.
+
+## Structural independence mutation
+
+An actual side-effect import was temporarily added as
+`services/harness-watchdog/src/forbidden-mutation.ts`:
+
+```text
+1:import "../../slack-operator/src/index.js";
+AssertionError: forbidden watchdog imports: expected [ Array(1) ] to deeply equal []
++ Array [
++   "forbidden-mutation.ts -> ../../slack-operator/src/index.js",
++ ]
+Tests  1 failed | 8 skipped (9)
+```
+
+This first revealed and corrected a gap in the guard for bare side-effect
+imports. After deleting the deliberate import:
+
+```text
+✓ test/unit/harness-watchdog.test.ts > the watchdog import surface > has no slack-operator or Hermes-facing import
+Tests  1 passed | 8 skipped (9)
+```
+
+## Disabled-sink status
+
+With `WATCHDOG_SLACK_WEBHOOK_URL` absent:
+
+```text
+INT4A_STATUS_JSON={"schemaVersion":1,"kind":"harness_watchdog_status","updatedAt":"2026-08-05T10:00:00.000Z","activeIssues":[],"sinks":[{"name":"slack","state":"disabled"}],"lastAlertForwarded":null,"thresholds":{"dispatcherStaleMs":90000,"harnessSourceStaleMs":900000,"databaseTimeoutMs":5000,"pollIntervalMs":10}}
+```

--- a/ops/.env.example
+++ b/ops/.env.example
@@ -225,6 +225,16 @@ HARNESS_DATABASE_URL=
 HARNESS_PROFILES_ROOT=
 HARNESS_PROFILE_SHA256=
 
+# INT-4a standalone Harness watchdog. Slack delivery stays disabled until the
+# operator provisions the incoming-webhook URL after merge.
+WATCHDOG_HEARTBEAT_PATH=/data/harness-watchdog-heartbeat.json
+WATCHDOG_STATUS_PATH=/data/harness-watchdog-status.json
+WATCHDOG_POLL_INTERVAL_MS=15000
+WATCHDOG_DISPATCHER_STALE_MS=90000
+WATCHDOG_HARNESS_SOURCE_STALE_MS=900000
+WATCHDOG_DATABASE_TIMEOUT_MS=5000
+WATCHDOG_SLACK_WEBHOOK_URL=
+
 # Claude branch worker (the greenfield executor the runner spawns). It creates
 # a claude/<slug> branch, runs Claude, pushes, and opens a PR for review.
 # ALLOWED_REPOS is the gate on this unattended push power: empty = refuse every

--- a/ops/compose.yml
+++ b/ops/compose.yml
@@ -964,6 +964,37 @@ services:
       - harness-dispatch-workspaces:/var/lib/harness-dispatcher
     networks: [avg-internal]
 
+  # INT-4a external Harness watchdog. It is deliberately outside both the
+  # dispatcher and Hermes: a dispatcher crash or a stopped conversational
+  # stack must not remove the process responsible for reporting that outage.
+  # Slack remains disabled until the operator provisions the one webhook env.
+  harness-watchdog:
+    init: true
+    build:
+      context: ..
+      dockerfile: ops/Dockerfile.node
+      args:
+        GIT_SHA: ${GIT_SHA:-unknown}
+        GIT_DIRTY: ${GIT_DIRTY:-false}
+    image: ${AVERRAY_IMAGE:-avg-node-runtime}
+    restart: unless-stopped
+    command: ["node", "services/harness-watchdog/dist/index.js"]
+    environment:
+      DATABASE_URL: ${DATABASE_URL}
+      HARNESS_DATABASE_URL: ${HARNESS_DATABASE_URL:-}
+      HARNESS_DISPATCH_HEARTBEAT_PATH: ${HARNESS_DISPATCH_HEARTBEAT_PATH:-/data/harness-dispatcher-heartbeat.json}
+      HARNESS_DISPATCH_ALERTS_PATH: ${HARNESS_DISPATCH_ALERTS_PATH:-/data/harness-dispatch-alerts.jsonl}
+      WATCHDOG_HEARTBEAT_PATH: ${WATCHDOG_HEARTBEAT_PATH:-/data/harness-watchdog-heartbeat.json}
+      WATCHDOG_STATUS_PATH: ${WATCHDOG_STATUS_PATH:-/data/harness-watchdog-status.json}
+      WATCHDOG_POLL_INTERVAL_MS: ${WATCHDOG_POLL_INTERVAL_MS:-15000}
+      WATCHDOG_DISPATCHER_STALE_MS: ${WATCHDOG_DISPATCHER_STALE_MS:-90000}
+      WATCHDOG_HARNESS_SOURCE_STALE_MS: ${WATCHDOG_HARNESS_SOURCE_STALE_MS:-900000}
+      WATCHDOG_DATABASE_TIMEOUT_MS: ${WATCHDOG_DATABASE_TIMEOUT_MS:-5000}
+      WATCHDOG_SLACK_WEBHOOK_URL: ${WATCHDOG_SLACK_WEBHOOK_URL:-}
+    volumes:
+      - avg-data:/data
+    networks: [avg-internal]
+
   # Claude task runner (O2). Mirrors codex-task-runner; claims approved
   # agent="claude" tasks. The startup route gate (claude-worker-auth) refuses
   # to claim on a billing-route mismatch. Disabled by default; the operator

--- a/package-lock.json
+++ b/package-lock.json
@@ -68,6 +68,10 @@
       "resolved": "services/harness-dispatcher",
       "link": true
     },
+    "node_modules/@avg/harness-watchdog": {
+      "resolved": "services/harness-watchdog",
+      "link": true
+    },
     "node_modules/@avg/mcp-common": {
       "resolved": "packages/mcp-common",
       "link": true
@@ -5260,6 +5264,13 @@
         "@avg/mcp-common": "0.1.0",
         "@avg/schemas": "0.1.0",
         "yaml": "^2.7.0"
+      }
+    },
+    "services/harness-watchdog": {
+      "name": "@avg/harness-watchdog",
+      "version": "0.1.0",
+      "dependencies": {
+        "pg": "^8.13.1"
       }
     },
     "services/skills-observer": {

--- a/scripts/ceremony/compose.int4a-watchdog-drill.yml
+++ b/scripts/ceremony/compose.int4a-watchdog-drill.yml
@@ -1,0 +1,122 @@
+services:
+  reference-db:
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_USER: int4a
+      POSTGRES_PASSWORD: int4a-reference-sentinel
+      POSTGRES_DB: reference
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U int4a -d reference"]
+      interval: 1s
+      timeout: 1s
+      retries: 30
+    volumes:
+      - reference-db:/var/lib/postgresql/data
+
+  harness-db:
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_USER: int4a
+      POSTGRES_PASSWORD: int4a-harness-sentinel
+      POSTGRES_DB: harness
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U int4a -d harness"]
+      interval: 1s
+      timeout: 1s
+      retries: 30
+    volumes:
+      - harness-db:/var/lib/postgresql/data
+
+  reference-migrate:
+    image: postgres:16-alpine
+    depends_on:
+      reference-db:
+        condition: service_healthy
+    environment:
+      DATABASE_URL: postgres://int4a:int4a-reference-sentinel@reference-db:5432/reference
+    volumes:
+      - ../../ops/migrations:/migrations:ro
+      - ../../ops/migrate.sh:/migrate.sh:ro
+    entrypoint: ["/bin/sh", "/migrate.sh"]
+
+  harness-migrate:
+    image: postgres:16-alpine
+    depends_on:
+      harness-db:
+        condition: service_healthy
+    environment:
+      PGURL: postgres://int4a:int4a-harness-sentinel@harness-db:5432/harness
+    volumes:
+      - ../../test/fixtures/agent-integration/ceremony/int4a-harness-schema.sql:/schema.sql:ro
+    command: ["sh", "-c", "psql $$PGURL -v ON_ERROR_STOP=1 -f /schema.sql"]
+
+  fake-slack:
+    image: node:22-bookworm-slim
+    working_dir: /workspace
+    command: ["node", "scripts/ceremony/int4a-fake-slack.mjs"]
+    environment:
+      INT4A_FAKE_SLACK_DELIVERIES_PATH: /evidence/slack-deliveries.jsonl
+    volumes:
+      - ../..:/workspace:ro
+      - evidence:/evidence
+
+  hermes:
+    image: node:22-bookworm-slim
+    command: ["node", "-e", "setInterval(() => {}, 60000)"]
+
+  slack-operator:
+    image: node:22-bookworm-slim
+    command: ["node", "-e", "setInterval(() => {}, 60000)"]
+
+  dispatcher:
+    image: node:22-bookworm-slim
+    working_dir: /workspace
+    depends_on:
+      reference-migrate:
+        condition: service_completed_successfully
+      harness-migrate:
+        condition: service_completed_successfully
+    command: ["node", "services/harness-dispatcher/dist/index.js"]
+    environment:
+      DATABASE_URL: postgres://int4a:int4a-reference-sentinel@reference-db:5432/reference
+      HARNESS_DATABASE_URL: postgres://int4a:int4a-harness-sentinel@harness-db:5432/harness
+      HARNESS_DISPATCH_ENABLED: "false"
+      HARNESS_DISPATCH_POLL_INTERVAL_MS: "5000"
+      HARNESS_DISPATCH_HEARTBEAT_PATH: /data/dispatcher-heartbeat.json
+      HARNESS_DISPATCH_ALERTS_PATH: /data/dispatch-alerts.jsonl
+    volumes:
+      - ../..:/workspace:ro
+      - runtime-data:/data
+
+  watchdog:
+    image: node:22-bookworm-slim
+    working_dir: /workspace
+    depends_on:
+      reference-migrate:
+        condition: service_completed_successfully
+      harness-migrate:
+        condition: service_completed_successfully
+      fake-slack:
+        condition: service_started
+    command: ["node", "services/harness-watchdog/dist/index.js"]
+    environment:
+      DATABASE_URL: postgres://int4a:int4a-reference-sentinel@reference-db:5432/reference
+      HARNESS_DATABASE_URL: postgres://int4a:int4a-harness-sentinel@harness-db:5432/harness
+      HARNESS_DISPATCH_HEARTBEAT_PATH: /data/dispatcher-heartbeat.json
+      HARNESS_DISPATCH_ALERTS_PATH: /data/dispatch-alerts.jsonl
+      WATCHDOG_HEARTBEAT_PATH: /data/watchdog-heartbeat.json
+      WATCHDOG_STATUS_PATH: /data/watchdog-status.json
+      WATCHDOG_POLL_INTERVAL_MS: "200"
+      WATCHDOG_DISPATCHER_STALE_MS: ${INT4A_DRILL_DISPATCHER_STALE_MS:-1000}
+      WATCHDOG_HARNESS_SOURCE_STALE_MS: "1000"
+      WATCHDOG_DATABASE_TIMEOUT_MS: "500"
+      WATCHDOG_SLACK_WEBHOOK_URL: ${INT4A_DRILL_SLACK_URL:-http://fake-slack:8080/hook}
+    volumes:
+      - ../..:/workspace:ro
+      - runtime-data:/data
+
+volumes:
+  reference-db:
+  harness-db:
+  runtime-data:
+  evidence:

--- a/scripts/ceremony/int4a-fake-slack.mjs
+++ b/scripts/ceremony/int4a-fake-slack.mjs
@@ -1,0 +1,46 @@
+import { appendFile, mkdir } from "node:fs/promises";
+import http from "node:http";
+import path from "node:path";
+
+const target = process.env.INT4A_FAKE_SLACK_DELIVERIES_PATH
+  ?? "/evidence/slack-deliveries.jsonl";
+const port = Number(process.env.INT4A_FAKE_SLACK_PORT ?? "8080");
+
+const server = http.createServer((request, response) => {
+  if (request.method === "GET" && request.url === "/health") {
+    response.writeHead(200, { "content-type": "text/plain" });
+    response.end("ok\n");
+    return;
+  }
+  if (request.method !== "POST" || request.url !== "/hook") {
+    response.writeHead(404);
+    response.end();
+    return;
+  }
+  const chunks = [];
+  request.on("data", (chunk) => chunks.push(chunk));
+  request.on("end", () => {
+    const body = Buffer.concat(chunks).toString("utf8");
+    void (async () => {
+      await mkdir(path.dirname(target), { recursive: true });
+      await appendFile(target, `${body}\n`, "utf8");
+      response.writeHead(200, { "content-type": "text/plain" });
+      response.end("ok\n");
+    })().catch(() => {
+      response.writeHead(500);
+      response.end();
+    });
+  });
+});
+
+server.listen(port, "0.0.0.0", () => {
+  console.info(`INT4A_FAKE_SLACK_READY port=${port}`);
+});
+
+for (const signal of ["SIGINT", "SIGTERM"]) {
+  process.once(signal, () => {
+    server.close(() => {
+      process.exitCode = 0;
+    });
+  });
+}

--- a/scripts/ceremony/run-int4a-watchdog-drills.mjs
+++ b/scripts/ceremony/run-int4a-watchdog-drills.mjs
@@ -1,0 +1,280 @@
+import { execFileSync, spawnSync } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+const composeFile = path.join(root, "scripts/ceremony/compose.int4a-watchdog-drill.yml");
+const mutation = argument("--mutation");
+const baselineHermes = process.argv.includes("--baseline-hermes-unavailable");
+const project = `codex-int4a-${process.pid}-${Date.now()}`.toLowerCase();
+if (!/^codex-int4a-[a-z0-9-]+$/u.test(project)) {
+  throw new Error("INT4A_REFUSE unsafe Compose project name");
+}
+
+const composeEnvironment = {
+  ...process.env,
+  ...(mutation === "threshold-infinity"
+    ? { INT4A_DRILL_DISPATCHER_STALE_MS: String(Number.MAX_SAFE_INTEGER) }
+    : {}),
+  ...(mutation === "slack-blackhole"
+    ? { INT4A_DRILL_SLACK_URL: "http://127.0.0.1:9/hook" }
+    : {}),
+};
+
+try {
+  up();
+  await waitFor(() => logs("fake-slack").includes("INT4A_FAKE_SLACK_READY"), 30_000,
+    "fake Slack listener ready");
+  await waitFor(() => readRuntime("dispatcher-heartbeat.json", "dispatcher") !== "", 30_000,
+    "dispatcher heartbeat present");
+  assertDatabaseLive("reference-db", "reference");
+  assertDatabaseLive("harness-db", "harness");
+
+  if (baselineHermes) {
+    stop("hermes", "slack-operator");
+    stop("dispatcher", "harness-db");
+    await delay(2_000);
+    const deliveries = readDeliveries();
+    if (deliveries.length !== 0) fail(
+      "hermes-unavailable-baseline",
+      `expected no delivery without watchdog, observed=${deliveries.length}`,
+    );
+    fail("hermes-unavailable-baseline",
+      "external_delivery_missing watchdog_absent hermes=stopped slack_operator=stopped");
+  }
+
+  const firstHeartbeat = await heartbeatUpdatedAt();
+  await waitFor(async () => (await heartbeatUpdatedAt()) !== firstHeartbeat, 12_000,
+    "dispatcher heartbeat advancing");
+  const secondHeartbeat = await heartbeatUpdatedAt();
+  console.info(
+    `INT4A_DISPATCHER_LIVE heartbeat_one=${firstHeartbeat} heartbeat_two=${secondHeartbeat}`,
+  );
+
+  console.info("INT4A_DRILL_START dispatcher-killed");
+  stop("dispatcher");
+  await requireDelivery(
+    "dispatcher-killed",
+    "watchdog_dispatcher_heartbeat_stale",
+    5_000,
+  );
+  console.info(
+    "INT4A_DRILL_GREEN dispatcher-killed file=present slack=delivered watchdog=running",
+  );
+
+  start("dispatcher");
+  await waitFor(() => serviceRunning("dispatcher"), 15_000, "dispatcher restarted");
+  await waitFor(() => !statusIssues().includes("watchdog_dispatcher_heartbeat_stale"),
+    10_000, "dispatcher staleness recovered");
+
+  console.info("INT4A_DRILL_START harness-db-down");
+  stop("harness-db");
+  await requireDelivery(
+    "harness-db-down",
+    "watchdog_harness_database_unreachable",
+    5_000,
+  );
+  if (!serviceRunning("watchdog")) fail("harness-db-down", "watchdog_stopped");
+  console.info(
+    "INT4A_DRILL_GREEN harness-db-down file=present slack=delivered watchdog=running",
+  );
+
+  start("harness-db");
+  await waitFor(() => postgresReady("harness-db", "harness"), 20_000,
+    "Harness database restarted");
+  await waitFor(() => !statusIssues().includes("watchdog_harness_database_unreachable"),
+    10_000, "Harness database issue recovered");
+
+  console.info("INT4A_DRILL_START hermes-unavailable");
+  stop("hermes", "slack-operator");
+  if (serviceRunning("hermes") || serviceRunning("slack-operator")) {
+    fail("hermes-unavailable", "local coordinator container still running");
+  }
+  stop("dispatcher");
+  await requireDeliveryCount(
+    "hermes-unavailable",
+    "watchdog_dispatcher_heartbeat_stale",
+    2,
+    5_000,
+  );
+  start("dispatcher");
+  await waitFor(() => serviceRunning("dispatcher"), 15_000, "dispatcher restarted under Hermes outage");
+  await waitFor(() => !statusIssues().includes("watchdog_dispatcher_heartbeat_stale"),
+    10_000, "dispatcher recovered under Hermes outage");
+  stop("harness-db");
+  await requireDeliveryCount(
+    "hermes-unavailable",
+    "watchdog_harness_database_unreachable",
+    2,
+    5_000,
+  );
+  console.info(
+    "INT4A_DRILL_GREEN hermes-unavailable hermes=stopped slack_operator=stopped dispatcher_alert=delivered harness_db_alert=delivered",
+  );
+  console.info(`INT4A_STATUS_JSON=${readRuntime("watchdog-status.json").trim()}`);
+  console.info("INT4A_DRILLS_RESULT=green 3/3");
+} finally {
+  down();
+}
+
+function up() {
+  const services = [
+    "reference-db",
+    "harness-db",
+    "reference-migrate",
+    "harness-migrate",
+    "fake-slack",
+    "hermes",
+    "slack-operator",
+    "dispatcher",
+    ...(baselineHermes ? [] : ["watchdog"]),
+  ];
+  compose(["up", "-d", ...services]);
+  console.info(`INT4A_LOCAL_COMPOSE_PROJECT=${project}`);
+}
+
+function down() {
+  compose(["down", "--volumes", "--remove-orphans"], { allowFailure: true });
+}
+
+function start(...services) {
+  compose(["start", ...services]);
+}
+
+function stop(...services) {
+  compose(["stop", ...services]);
+}
+
+function compose(args, options = {}) {
+  const result = spawnSync(
+    "docker",
+    ["compose", "-p", project, "-f", composeFile, ...args],
+    {
+      cwd: root,
+      env: composeEnvironment,
+      encoding: "utf8",
+      stdio: options.capture ? "pipe" : "inherit",
+    },
+  );
+  if (!options.allowFailure && result.status !== 0) {
+    throw new Error(`INT4A_COMPOSE_FAILED status=${result.status}`);
+  }
+  return `${result.stdout ?? ""}${result.stderr ?? ""}`;
+}
+
+function logs(service) {
+  return compose(["logs", "--no-color", service], { capture: true, allowFailure: true });
+}
+
+function serviceRunning(service) {
+  return compose(["ps", "--status", "running", "--services", service], {
+    capture: true,
+    allowFailure: true,
+  }).trim() === service;
+}
+
+function assertDatabaseLive(service, database) {
+  if (!postgresReady(service, database)) {
+    throw new Error(`INT4A_DATABASE_NOT_LIVE service=${service}`);
+  }
+  console.info(`INT4A_DATABASE_LIVE service=${service} authenticated_select=1`);
+}
+
+function postgresReady(service, database) {
+  const result = spawnSync(
+    "docker",
+    [
+      "compose", "-p", project, "-f", composeFile,
+      "exec", "-T", service,
+      "psql", "-U", "int4a", "-d", database, "-Atqc", "select 1",
+    ],
+    { cwd: root, env: composeEnvironment, encoding: "utf8" },
+  );
+  return result.status === 0 && result.stdout.trim() === "1";
+}
+
+function readRuntime(name, service = "watchdog") {
+  return execIn(service, ["cat", `/data/${name}`]);
+}
+
+function readDeliveries() {
+  const text = execIn(
+    "fake-slack",
+    ["cat", "/evidence/slack-deliveries.jsonl"],
+    true,
+  );
+  return text.trim() ? text.trim().split("\n") : [];
+}
+
+function execIn(service, command, allowFailure = false) {
+  const result = spawnSync(
+    "docker",
+    ["compose", "-p", project, "-f", composeFile, "exec", "-T", service, ...command],
+    { cwd: root, env: composeEnvironment, encoding: "utf8" },
+  );
+  if (!allowFailure && result.status !== 0) return "";
+  return result.status === 0 ? result.stdout : "";
+}
+
+async function heartbeatUpdatedAt() {
+  const raw = readRuntime("dispatcher-heartbeat.json");
+  if (!raw) return "";
+  return String(JSON.parse(raw).updatedAt ?? "");
+}
+
+function statusIssues() {
+  const raw = readRuntime("watchdog-status.json");
+  if (!raw) return [];
+  const parsed = JSON.parse(raw);
+  return Array.isArray(parsed.activeIssues) ? parsed.activeIssues : [];
+}
+
+async function requireDelivery(drill, code, timeoutMs) {
+  return requireDeliveryCount(drill, code, 1, timeoutMs);
+}
+
+async function requireDeliveryCount(drill, code, count, timeoutMs) {
+  const emitted = await waitFor(
+    () => readRuntime("dispatch-alerts.jsonl").includes(code),
+    timeoutMs,
+    `${drill} file emission ${code}`,
+    false,
+  );
+  const delivered = await waitFor(
+    () => readDeliveries().filter((line) => line.includes(code)).length >= count,
+    timeoutMs,
+    `${drill} Slack delivery ${code}`,
+    false,
+  );
+  if (!emitted || !delivered) {
+    fail(
+      drill,
+      `delivery_missing code=${code} file_emission=${emitted} slack_delivery=${delivered} mutation=${mutation ?? "none"}`,
+    );
+  }
+}
+
+async function waitFor(predicate, timeoutMs, label, throwOnTimeout = true) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (await predicate()) return true;
+    await delay(100);
+  }
+  if (throwOnTimeout) throw new Error(`INT4A_WAIT_TIMEOUT ${label}`);
+  return false;
+}
+
+function fail(drill, reason) {
+  console.error(`INT4A_DRILL_RED ${drill} ${reason}`);
+  process.exitCode = 1;
+  throw new Error(`INT4A_DRILL_ASSERTION_FAILED ${drill}: ${reason}`);
+}
+
+function argument(name) {
+  const index = process.argv.indexOf(name);
+  return index === -1 ? undefined : process.argv[index + 1];
+}
+
+function delay(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/services/harness-watchdog/package.json
+++ b/services/harness-watchdog/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@avg/harness-watchdog",
+  "version": "0.1.0",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc -b",
+    "typecheck": "tsc -b --pretty false",
+    "start": "node dist/index.js"
+  },
+  "dependencies": {
+    "pg": "^8.13.1"
+  }
+}

--- a/services/harness-watchdog/src/forwarders.ts
+++ b/services/harness-watchdog/src/forwarders.ts
@@ -1,0 +1,100 @@
+export type WatchdogSinkState = "configured" | "disabled";
+
+export interface AlertForwarder {
+  readonly name: string;
+  readonly state: WatchdogSinkState;
+  forward(alert: Readonly<Record<string, unknown>>): Promise<void>;
+}
+
+export type WatchdogFetch = (
+  input: string,
+  init: RequestInit,
+) => Promise<Pick<Response, "ok" | "status">>;
+
+export type OutboundScrubber = (
+  value: Readonly<Record<string, unknown>>,
+) => Record<string, unknown>;
+
+const SENSITIVE_KEY = /(?:^|[_-])(?:authorization|token|secret|api[_-]?key|private[_-]?key)(?:$|[_-])/iu;
+const AUTHORIZATION_VALUE = /(authorization\s*[:=]\s*)(?:bearer\s+)?(?:"[^"]*"|'[^']*'|[^\s,;}\]]+)/giu;
+const SENSITIVE_ASSIGNMENT = /([a-z0-9_.-]*(?:token|secret|api[_-]?key|private[_-]?key)[a-z0-9_.-]*\s*[:=]\s*)(?:"[^"]*"|'[^']*'|[^\s,;}\]]+)/giu;
+
+export function scrubOutboundAlert(
+  input: Readonly<Record<string, unknown>>,
+): Record<string, unknown> {
+  return scrubObject(input);
+}
+
+export function createSlackForwarder(options: {
+  webhookUrl?: string;
+  fetchImpl?: WatchdogFetch;
+  scrub?: OutboundScrubber;
+  timeoutMs?: number;
+}): AlertForwarder {
+  const webhookUrl = options.webhookUrl?.trim();
+  const fetchImpl = options.fetchImpl ?? fetch;
+  const scrub = options.scrub ?? scrubOutboundAlert;
+  const timeoutMs = options.timeoutMs ?? 5_000;
+
+  return {
+    name: "slack",
+    state: webhookUrl ? "configured" : "disabled",
+    async forward(alert): Promise<void> {
+      if (!webhookUrl) return;
+      const safeAlert = scrub(alert);
+      const response = await fetchImpl(webhookUrl, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ text: renderSlackText(safeAlert) }),
+        signal: AbortSignal.timeout(timeoutMs),
+      });
+      if (!response.ok) {
+        throw new SlackDeliveryError(response.status);
+      }
+    },
+  };
+}
+
+export class SlackDeliveryError extends Error {
+  constructor(readonly status: number) {
+    super(`Slack webhook refused the watchdog alert with HTTP ${status}`);
+    this.name = "SlackDeliveryError";
+  }
+}
+
+function renderSlackText(alert: Readonly<Record<string, unknown>>): string {
+  const severity = stringField(alert.severity, "warn").toUpperCase();
+  const code = stringField(alert.code, "watchdog_alert");
+  const message = stringField(alert.message, "Watchdog alert details unavailable.");
+  return `[HARNESS WATCHDOG ${severity}] ${code}: ${message}`;
+}
+
+function scrubObject(
+  input: Readonly<Record<string, unknown>>,
+): Record<string, unknown> {
+  return Object.fromEntries(Object.entries(input).map(([key, value]) => [
+    key,
+    SENSITIVE_KEY.test(key) ? "[REDACTED]" : scrubValue(value),
+  ]));
+}
+
+function scrubValue(value: unknown): unknown {
+  if (typeof value === "string") return scrubText(value);
+  if (Array.isArray(value)) return value.map(scrubValue);
+  if (isRecord(value)) return scrubObject(value);
+  return value;
+}
+
+function scrubText(value: string): string {
+  return value
+    .replace(AUTHORIZATION_VALUE, "$1[REDACTED]")
+    .replace(SENSITIVE_ASSIGNMENT, "$1[REDACTED]");
+}
+
+function stringField(value: unknown, fallback: string): string {
+  return typeof value === "string" && value.length > 0 ? value : fallback;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/services/harness-watchdog/src/index.ts
+++ b/services/harness-watchdog/src/index.ts
@@ -1,0 +1,89 @@
+import { fileURLToPath } from "node:url";
+
+import { createSlackForwarder } from "./forwarders.js";
+import { createPostgresWatchdogProbes } from "./postgres-probes.js";
+import {
+  createWatchdogProcess,
+  parseWatchdogConfig,
+  type WatchdogLogger,
+  type WatchdogProcess,
+} from "./watchdog.js";
+
+export interface ProductionWatchdog {
+  process: WatchdogProcess;
+  close(): Promise<void>;
+}
+
+export function createProductionWatchdog(
+  environmentInput: Readonly<Record<string, string | undefined>> = process.env,
+  logger: WatchdogLogger = consoleWatchdogLogger,
+): ProductionWatchdog {
+  const environment = Object.freeze({ ...environmentInput });
+  const config = parseWatchdogConfig(environment);
+  const probes = createPostgresWatchdogProbes({
+    referenceDatabaseUrl: environment.DATABASE_URL,
+    harnessDatabaseUrl: environment.HARNESS_DATABASE_URL,
+    connectionTimeoutMs: config.databaseTimeoutMs,
+  });
+  const forwarders = [
+    createSlackForwarder({
+      webhookUrl: environment.WATCHDOG_SLACK_WEBHOOK_URL,
+    }),
+  ];
+  const watchdog = createWatchdogProcess(config, {
+    ...probes,
+    forwarders,
+    now: () => new Date(),
+    logger,
+    scheduler: {
+      setTimeout: (callback, delayMs) => setTimeout(callback, delayMs),
+      clearTimeout: (timer) => clearTimeout(timer),
+    },
+  });
+  return {
+    process: watchdog,
+    async close(): Promise<void> {
+      try {
+        await watchdog.shutdown();
+      } finally {
+        await probes.close();
+      }
+    },
+  };
+}
+
+const consoleWatchdogLogger: WatchdogLogger = {
+  info(fields, message) {
+    console.info(`[harness-watchdog] ${message}`, fields);
+  },
+  warn(fields, message) {
+    console.warn(`[harness-watchdog] ${message}`, fields);
+  },
+};
+
+async function main(): Promise<void> {
+  const watchdog = createProductionWatchdog();
+  let shutdownPromise: Promise<void> | undefined;
+  const shutdown = (): Promise<void> => {
+    shutdownPromise ??= watchdog.close().then(() => {
+      process.exitCode = 0;
+    });
+    return shutdownPromise;
+  };
+  process.once("SIGINT", () => {
+    void shutdown();
+  });
+  process.once("SIGTERM", () => {
+    void shutdown();
+  });
+  watchdog.process.start();
+}
+
+if (fileURLToPath(import.meta.url) === process.argv[1]) {
+  main().catch((error) => {
+    console.error("[harness-watchdog] fatal", {
+      errorName: error instanceof Error ? error.name : "UnknownError",
+    });
+    process.exitCode = 1;
+  });
+}

--- a/services/harness-watchdog/src/postgres-probes.ts
+++ b/services/harness-watchdog/src/postgres-probes.ts
@@ -1,0 +1,81 @@
+import { Pool } from "pg";
+
+import type { HarnessSourceState, WatchdogDatabaseProbes } from "./watchdog.js";
+
+interface HarnessSourceRow {
+  live_run: boolean;
+  newest_event_at: Date | string | null;
+}
+
+export interface ProductionWatchdogDatabaseProbes extends WatchdogDatabaseProbes {
+  close(): Promise<void>;
+}
+
+export function createPostgresWatchdogProbes(options: {
+  referenceDatabaseUrl?: string;
+  harnessDatabaseUrl?: string;
+  connectionTimeoutMs?: number;
+}): ProductionWatchdogDatabaseProbes {
+  const connectionTimeoutMillis = options.connectionTimeoutMs ?? 5_000;
+  const referenceDatabaseUrl = options.referenceDatabaseUrl?.trim();
+  const harnessDatabaseUrl = options.harnessDatabaseUrl?.trim();
+  const referencePool = referenceDatabaseUrl
+    ? new Pool({
+        connectionString: referenceDatabaseUrl,
+        connectionTimeoutMillis,
+        query_timeout: connectionTimeoutMillis,
+      })
+    : undefined;
+  const harnessPool = harnessDatabaseUrl
+    ? new Pool({
+        connectionString: harnessDatabaseUrl,
+        connectionTimeoutMillis,
+        query_timeout: connectionTimeoutMillis,
+      })
+    : undefined;
+
+  // pg emits an EventEmitter "error" when an idle pooled connection dies.
+  // Without listeners, stopping either watched database terminates Node before
+  // the next read-only probe can turn the outage into an alert.
+  referencePool?.on("error", () => {});
+  harnessPool?.on("error", () => {});
+
+  return {
+    async probeReferenceDatabase(): Promise<void> {
+      if (!referencePool) throw new DatabaseProbeConfigurationError("reference");
+      await referencePool.query("select 1");
+    },
+    async probeHarnessDatabase(): Promise<HarnessSourceState> {
+      if (!harnessPool) throw new DatabaseProbeConfigurationError("harness");
+      const result = await harnessPool.query<HarnessSourceRow>(
+        `select
+           exists(select 1 from runs where outcome is null) as live_run,
+           (select max(ts) from domain_events) as newest_event_at`,
+      );
+      const row = result.rows[0];
+      return {
+        liveRun: row?.live_run === true,
+        newestEventAt: parseTimestamp(row?.newest_event_at),
+      };
+    },
+    async close(): Promise<void> {
+      await Promise.all([
+        referencePool?.end(),
+        harnessPool?.end(),
+      ]);
+    },
+  };
+}
+
+export class DatabaseProbeConfigurationError extends Error {
+  constructor(readonly database: "reference" | "harness") {
+    super(`${database} database connection is not configured`);
+    this.name = "DatabaseProbeConfigurationError";
+  }
+}
+
+function parseTimestamp(value: Date | string | null | undefined): Date | null {
+  if (value === null || value === undefined) return null;
+  const parsed = value instanceof Date ? value : new Date(value);
+  return Number.isFinite(parsed.getTime()) ? parsed : null;
+}

--- a/services/harness-watchdog/src/watchdog.ts
+++ b/services/harness-watchdog/src/watchdog.ts
@@ -1,0 +1,441 @@
+import {
+  appendFile,
+  mkdir,
+  open,
+  readFile,
+  stat,
+  writeFile,
+} from "node:fs/promises";
+import path from "node:path";
+
+import type { AlertForwarder, WatchdogSinkState } from "./forwarders.js";
+
+const DEFAULT_POLL_INTERVAL_MS = 15_000;
+const DEFAULT_DISPATCHER_STALE_MS = 90_000;
+const DEFAULT_HARNESS_SOURCE_STALE_MS = 15 * 60_000;
+const DEFAULT_DATABASE_TIMEOUT_MS = 5_000;
+const DEFAULT_HEARTBEAT_PATH = "/data/harness-watchdog-heartbeat.json";
+const DEFAULT_STATUS_PATH = "/data/harness-watchdog-status.json";
+const DEFAULT_DISPATCHER_HEARTBEAT_PATH = "/data/harness-dispatcher-heartbeat.json";
+const DEFAULT_ALERTS_PATH = "/data/harness-dispatch-alerts.jsonl";
+
+export interface WatchdogConfig {
+  pollIntervalMs: number;
+  dispatcherStaleMs: number;
+  harnessSourceStaleMs: number;
+  databaseTimeoutMs: number;
+  heartbeatPath: string;
+  statusPath: string;
+  dispatcherHeartbeatPath: string;
+  alertsPath: string;
+}
+
+export interface HarnessSourceState {
+  liveRun: boolean;
+  newestEventAt: Date | null;
+}
+
+export interface WatchdogDatabaseProbes {
+  probeReferenceDatabase(): Promise<void>;
+  probeHarnessDatabase(): Promise<HarnessSourceState>;
+}
+
+export interface WatchdogLogger {
+  info(fields: Record<string, unknown>, message: string): void;
+  warn(fields: Record<string, unknown>, message: string): void;
+}
+
+export interface WatchdogScheduler {
+  setTimeout(callback: () => void, delayMs: number): NodeJS.Timeout;
+  clearTimeout(timer: NodeJS.Timeout): void;
+}
+
+export interface WatchdogDeps extends WatchdogDatabaseProbes {
+  forwarders: AlertForwarder[];
+  now(): Date;
+  logger: WatchdogLogger;
+  scheduler: WatchdogScheduler;
+}
+
+export interface WatchdogProcess {
+  start(): void;
+  tick(): Promise<WatchdogStatus>;
+  shutdown(): Promise<void>;
+}
+
+export interface WatchdogStatus {
+  schemaVersion: 1;
+  kind: "harness_watchdog_status";
+  updatedAt: string;
+  activeIssues: string[];
+  sinks: Array<{ name: string; state: WatchdogSinkState }>;
+  lastAlertForwarded: null | {
+    at: string;
+    code: string;
+    sinks: string[];
+  };
+  thresholds: {
+    dispatcherStaleMs: number;
+    harnessSourceStaleMs: number;
+    databaseTimeoutMs: number;
+    pollIntervalMs: number;
+  };
+}
+
+interface WatchdogAlert extends Record<string, unknown> {
+  schemaVersion: 1;
+  kind: "harness_watchdog_alert";
+  severity: "warn" | "critical";
+  code: string;
+  message: string;
+  at: string;
+}
+
+interface AlertTailState {
+  offset: number;
+  remainder: string;
+}
+
+export function parseWatchdogConfig(
+  environment: Readonly<Record<string, string | undefined>> = process.env,
+): WatchdogConfig {
+  return {
+    pollIntervalMs: positiveInteger(
+      environment.WATCHDOG_POLL_INTERVAL_MS,
+      DEFAULT_POLL_INTERVAL_MS,
+    ),
+    dispatcherStaleMs: positiveInteger(
+      environment.WATCHDOG_DISPATCHER_STALE_MS,
+      DEFAULT_DISPATCHER_STALE_MS,
+    ),
+    harnessSourceStaleMs: positiveInteger(
+      environment.WATCHDOG_HARNESS_SOURCE_STALE_MS,
+      DEFAULT_HARNESS_SOURCE_STALE_MS,
+    ),
+    databaseTimeoutMs: positiveInteger(
+      environment.WATCHDOG_DATABASE_TIMEOUT_MS,
+      DEFAULT_DATABASE_TIMEOUT_MS,
+    ),
+    heartbeatPath: path.resolve(
+      environment.WATCHDOG_HEARTBEAT_PATH?.trim() || DEFAULT_HEARTBEAT_PATH,
+    ),
+    statusPath: path.resolve(
+      environment.WATCHDOG_STATUS_PATH?.trim() || DEFAULT_STATUS_PATH,
+    ),
+    dispatcherHeartbeatPath: path.resolve(
+      environment.HARNESS_DISPATCH_HEARTBEAT_PATH?.trim()
+        || DEFAULT_DISPATCHER_HEARTBEAT_PATH,
+    ),
+    alertsPath: path.resolve(
+      environment.HARNESS_DISPATCH_ALERTS_PATH?.trim() || DEFAULT_ALERTS_PATH,
+    ),
+  };
+}
+
+export function createWatchdogProcess(
+  config: WatchdogConfig,
+  deps: WatchdogDeps,
+): WatchdogProcess {
+  let stopped = true;
+  let timer: NodeJS.Timeout | undefined;
+  let inFlight: Promise<WatchdogStatus> | undefined;
+  let shutdownPromise: Promise<void> | undefined;
+  let tailState: AlertTailState | undefined;
+  let lastAlertForwarded: WatchdogStatus["lastAlertForwarded"] = null;
+  const activeIssues = new Set<string>();
+  const startedAt = deps.now();
+
+  const appendDetection = async (
+    code: string,
+    active: boolean,
+    alert: { severity: "warn" | "critical"; message: string },
+  ): Promise<void> => {
+    if (!active) {
+      activeIssues.delete(code);
+      return;
+    }
+    if (activeIssues.has(code)) return;
+    const record: WatchdogAlert = {
+      schemaVersion: 1,
+      kind: "harness_watchdog_alert",
+      severity: alert.severity,
+      code,
+      message: alert.message,
+      at: deps.now().toISOString(),
+    };
+    await mkdir(path.dirname(config.alertsPath), { recursive: true });
+    await appendFile(config.alertsPath, `${JSON.stringify(record)}\n`, "utf8");
+    activeIssues.add(code);
+  };
+
+  const probeDatabases = async (): Promise<void> => {
+    let referenceReachable = true;
+    try {
+      await deps.probeReferenceDatabase();
+    } catch {
+      referenceReachable = false;
+    }
+    await appendDetection(
+      "watchdog_reference_database_unreachable",
+      !referenceReachable,
+      {
+        severity: "critical",
+        message: "The reference-agent Postgres database is unreachable.",
+      },
+    );
+
+    let harnessState: HarnessSourceState | undefined;
+    try {
+      harnessState = await deps.probeHarnessDatabase();
+    } catch {
+      // The alert names the affected boundary without retaining a DSN-bearing
+      // driver error.
+    }
+    await appendDetection(
+      "watchdog_harness_database_unreachable",
+      harnessState === undefined,
+      {
+        severity: "critical",
+        message: "The Harness Postgres database is unreachable.",
+      },
+    );
+    if (!harnessState) {
+      activeIssues.delete("watchdog_harness_source_stale");
+      return;
+    }
+
+    const sourceAgeMs = harnessState.newestEventAt
+      ? deps.now().getTime() - harnessState.newestEventAt.getTime()
+      : deps.now().getTime() - startedAt.getTime();
+    await appendDetection(
+      "watchdog_harness_source_stale",
+      harnessState.liveRun && sourceAgeMs > config.harnessSourceStaleMs,
+      {
+        severity: "critical",
+        message: `A live Harness run has produced no event within ${config.harnessSourceStaleMs}ms.`,
+      },
+    );
+  };
+
+  const probeDispatcherHeartbeat = async (): Promise<void> => {
+    const heartbeatAt = await readDispatcherHeartbeatTimestamp(
+      config.dispatcherHeartbeatPath,
+    );
+    const ageMs = deps.now().getTime()
+      - (heartbeatAt?.getTime() ?? startedAt.getTime());
+    await appendDetection(
+      "watchdog_dispatcher_heartbeat_stale",
+      ageMs > config.dispatcherStaleMs,
+      {
+        severity: "critical",
+        message: `The Harness dispatcher heartbeat is older than ${config.dispatcherStaleMs}ms.`,
+      },
+    );
+  };
+
+  const initializeTail = async (): Promise<void> => {
+    if (tailState) return;
+    const size = await stat(config.alertsPath)
+      .then((value) => value.size)
+      .catch(() => 0);
+    tailState = { offset: size, remainder: "" };
+  };
+
+  const forwardNewAlerts = async (): Promise<void> => {
+    if (!tailState) throw new Error("Watchdog alert tail was not initialized");
+    const next = await readAlertTail(config.alertsPath, tailState);
+    tailState = next.state;
+    for (const line of next.lines) {
+      let alert: Record<string, unknown>;
+      try {
+        const parsed: unknown = JSON.parse(line);
+        if (!isRecord(parsed)) throw new Error("not an object");
+        alert = parsed;
+      } catch {
+        deps.logger.warn(
+          { source: "dispatch_alert_stream" },
+          "Watchdog skipped a malformed alert-stream record",
+        );
+        continue;
+      }
+
+      const delivered: string[] = [];
+      for (const forwarder of deps.forwarders) {
+        if (forwarder.state === "disabled") continue;
+        try {
+          await forwarder.forward(alert);
+          delivered.push(forwarder.name);
+        } catch (error) {
+          deps.logger.warn(
+            { sink: forwarder.name, errorName: errorName(error) },
+            "Watchdog alert forwarding failed",
+          );
+        }
+      }
+      if (delivered.length > 0) {
+        lastAlertForwarded = {
+          at: deps.now().toISOString(),
+          code: stringField(alert.code, "unknown_alert"),
+          sinks: delivered,
+        };
+      }
+    }
+  };
+
+  const writeObservability = async (): Promise<WatchdogStatus> => {
+    const now = deps.now().toISOString();
+    const status: WatchdogStatus = {
+      schemaVersion: 1,
+      kind: "harness_watchdog_status",
+      updatedAt: now,
+      activeIssues: [...activeIssues].sort(),
+      sinks: deps.forwarders.map(({ name, state }) => ({ name, state })),
+      lastAlertForwarded,
+      thresholds: {
+        dispatcherStaleMs: config.dispatcherStaleMs,
+        harnessSourceStaleMs: config.harnessSourceStaleMs,
+        databaseTimeoutMs: config.databaseTimeoutMs,
+        pollIntervalMs: config.pollIntervalMs,
+      },
+    };
+    const heartbeat = {
+      schemaVersion: 1,
+      kind: "harness_watchdog_heartbeat",
+      status: activeIssues.size === 0 ? "healthy" : "degraded",
+      updatedAt: now,
+      activeIssueCount: activeIssues.size,
+    };
+    await Promise.all([
+      writeJsonLine(config.heartbeatPath, heartbeat),
+      writeJsonLine(config.statusPath, status),
+    ]);
+    return status;
+  };
+
+  const performTick = async (): Promise<WatchdogStatus> => {
+    await initializeTail();
+    await Promise.all([
+      probeDatabases(),
+      probeDispatcherHeartbeat(),
+    ]);
+    await forwardNewAlerts();
+    return writeObservability();
+  };
+
+  const tick = (): Promise<WatchdogStatus> => {
+    if (inFlight) return inFlight;
+    const current = performTick().finally(() => {
+      if (inFlight === current) inFlight = undefined;
+    });
+    inFlight = current;
+    return current;
+  };
+
+  const runLoopTick = async (): Promise<void> => {
+    if (stopped) return;
+    try {
+      await tick();
+    } catch (error) {
+      deps.logger.warn(
+        { errorName: errorName(error) },
+        "Harness watchdog tick failed",
+      );
+    }
+    if (stopped) return;
+    timer = deps.scheduler.setTimeout(() => {
+      timer = undefined;
+      void runLoopTick();
+    }, config.pollIntervalMs);
+  };
+
+  return {
+    start(): void {
+      if (!stopped) return;
+      stopped = false;
+      void runLoopTick();
+    },
+    tick,
+    shutdown(): Promise<void> {
+      shutdownPromise ??= (async () => {
+        stopped = true;
+        if (timer) {
+          deps.scheduler.clearTimeout(timer);
+          timer = undefined;
+        }
+        if (inFlight) await inFlight;
+        await writeObservability();
+      })();
+      return shutdownPromise;
+    },
+  };
+}
+
+export async function readDispatcherHeartbeatTimestamp(
+  target: string,
+): Promise<Date | null> {
+  try {
+    const raw = await readFile(target, "utf8");
+    const parsed: unknown = JSON.parse(raw);
+    if (!isRecord(parsed) || typeof parsed.updatedAt !== "string") return null;
+    const timestamp = new Date(parsed.updatedAt);
+    return Number.isFinite(timestamp.getTime()) ? timestamp : null;
+  } catch {
+    return null;
+  }
+}
+
+async function readAlertTail(
+  target: string,
+  previous: AlertTailState,
+): Promise<{ state: AlertTailState; lines: string[] }> {
+  let size: number;
+  try {
+    size = (await stat(target)).size;
+  } catch {
+    return { state: { offset: 0, remainder: "" }, lines: [] };
+  }
+  const offset = size < previous.offset ? 0 : previous.offset;
+  if (size === offset) return { state: { ...previous, offset }, lines: [] };
+  const handle = await open(target, "r");
+  try {
+    const length = size - offset;
+    const buffer = Buffer.alloc(length);
+    await handle.read(buffer, 0, length, offset);
+    const combined = `${offset === previous.offset ? previous.remainder : ""}${buffer.toString("utf8")}`;
+    const parts = combined.split("\n");
+    const remainder = parts.pop() ?? "";
+    return {
+      state: { offset: size, remainder },
+      lines: parts.filter((line) => line.trim().length > 0),
+    };
+  } finally {
+    await handle.close();
+  }
+}
+
+async function writeJsonLine(
+  target: string,
+  value: Readonly<object>,
+): Promise<void> {
+  await mkdir(path.dirname(target), { recursive: true });
+  await writeFile(target, `${JSON.stringify(value)}\n`, "utf8");
+}
+
+function positiveInteger(input: string | undefined, fallback: number): number {
+  if (!input?.trim()) return fallback;
+  const parsed = Number(input);
+  if (!Number.isSafeInteger(parsed) || parsed <= 0) return fallback;
+  return parsed;
+}
+
+function errorName(error: unknown): string {
+  return error instanceof Error ? error.name : "UnknownError";
+}
+
+function stringField(value: unknown, fallback: string): string {
+  return typeof value === "string" && value.length > 0 ? value : fallback;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/services/harness-watchdog/tsconfig.json
+++ b/services/harness-watchdog/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "composite": true
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/test/fixtures/agent-integration/ceremony/int4a-harness-schema.sql
+++ b/test/fixtures/agent-integration/ceremony/int4a-harness-schema.sql
@@ -1,0 +1,13 @@
+create table if not exists runs (
+  run_id text primary key,
+  outcome text,
+  state text not null,
+  created_at timestamptz not null default current_timestamp,
+  updated_at timestamptz not null default current_timestamp
+);
+
+create table if not exists domain_events (
+  seq bigint generated always as identity primary key,
+  run_id text not null,
+  ts timestamptz not null
+);

--- a/test/unit/harness-watchdog.test.ts
+++ b/test/unit/harness-watchdog.test.ts
@@ -1,0 +1,324 @@
+import { mkdtemp, readFile, readdir, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { parse as parseYaml } from "yaml";
+
+import {
+  createSlackForwarder,
+  type AlertForwarder,
+  type WatchdogFetch,
+} from "../../services/harness-watchdog/src/forwarders.js";
+import {
+  createWatchdogProcess,
+  parseWatchdogConfig,
+  type HarnessSourceState,
+  type WatchdogConfig,
+  type WatchdogDeps,
+} from "../../services/harness-watchdog/src/watchdog.js";
+
+const TOKEN_SENTINEL = "INT4A_TOKEN_SENTINEL_DO_NOT_LEAK";
+const roots: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) =>
+    rm(root, { recursive: true, force: true })));
+});
+
+describe("the standalone Harness watchdog", () => {
+  it("defaults to the ordered INT-4a thresholds and paths", () => {
+    const config = parseWatchdogConfig({});
+    expect(config).toMatchObject({
+      pollIntervalMs: 15_000,
+      dispatcherStaleMs: 90_000,
+      harnessSourceStaleMs: 900_000,
+      databaseTimeoutMs: 5_000,
+      dispatcherHeartbeatPath: "/data/harness-dispatcher-heartbeat.json",
+      alertsPath: "/data/harness-dispatch-alerts.jsonl",
+      heartbeatPath: "/data/harness-watchdog-heartbeat.json",
+      statusPath: "/data/harness-watchdog-status.json",
+    });
+  });
+
+  it("states plainly that Slack is disabled when its env is absent", async () => {
+    const harness = await createHarness({
+      forwarders: [createSlackForwarder({})],
+    });
+    const status = await harness.process.tick();
+    expect(status.sinks).toEqual([{ name: "slack", state: "disabled" }]);
+    const writtenStatus = JSON.parse(
+      await readFile(harness.config.statusPath, "utf8"),
+    );
+    if (process.env.INT4A_PRINT_STATUS === "1") {
+      console.info(`INT4A_STATUS_JSON=${JSON.stringify(writtenStatus)}`);
+    }
+    expect(writtenStatus).toMatchObject({
+        kind: "harness_watchdog_status",
+        sinks: [{ name: "slack", state: "disabled" }],
+      });
+  });
+
+  it("writes a stale-dispatcher alert to the file before forwarding it", async () => {
+    const seen: string[] = [];
+    let now = new Date("2026-08-05T10:00:00.000Z");
+    const harness = await createHarness({
+      now: () => now,
+      dispatcherStaleMs: 1_000,
+      forwarders: [{
+        name: "slack",
+        state: "configured",
+        async forward(alert): Promise<void> {
+          const file = await readFile(harness.config.alertsPath, "utf8");
+          expect(file).toContain(String(alert.code));
+          seen.push(String(alert.code));
+        },
+      }],
+    });
+    await harness.process.tick();
+    now = new Date(now.getTime() + 1_001);
+    const status = await harness.process.tick();
+    expect(seen).toEqual(["watchdog_dispatcher_heartbeat_stale"]);
+    expect(status.activeIssues).toContain("watchdog_dispatcher_heartbeat_stale");
+    expect(status.lastAlertForwarded?.sinks).toEqual(["slack"]);
+  });
+
+  it("forwards new dispatcher alerts without rewriting the source record", async () => {
+    const forwarded: Array<Readonly<Record<string, unknown>>> = [];
+    const harness = await createHarness({
+      forwarders: [capturingForwarder(forwarded)],
+    });
+    await harness.process.tick();
+    const source = {
+      severity: "warn",
+      code: "dispatcher_source_alert",
+      message: "source record",
+      at: "2026-08-05T10:00:01.000Z",
+    };
+    await writeFile(harness.config.alertsPath, `${JSON.stringify(source)}\n`, "utf8");
+    await harness.process.tick();
+    expect(forwarded).toEqual([source]);
+    expect((await readFile(harness.config.alertsPath, "utf8")).trim())
+      .toBe(JSON.stringify(source));
+  });
+
+  it("alerts on either unreachable Postgres boundary without stopping itself", async () => {
+    const harness = await createHarness({
+      probeReferenceDatabase: vi.fn().mockRejectedValue(new Error("dsn secret")),
+      probeHarnessDatabase: vi.fn().mockRejectedValue(new Error("dsn secret")),
+    });
+    const first = await harness.process.tick();
+    const second = await harness.process.tick();
+    expect(first.activeIssues).toEqual([
+      "watchdog_harness_database_unreachable",
+      "watchdog_reference_database_unreachable",
+    ]);
+    expect(second.activeIssues).toEqual(first.activeIssues);
+    const records = await alertRecords(harness.config.alertsPath);
+    expect(records).toHaveLength(2);
+    expect(JSON.stringify(records)).not.toContain("dsn secret");
+  });
+
+  it("checks source age only while a Harness run is live", async () => {
+    let source: HarnessSourceState = {
+      liveRun: false,
+      newestEventAt: new Date("2026-08-05T09:00:00.000Z"),
+    };
+    const harness = await createHarness({
+      harnessSourceStaleMs: 1_000,
+      probeHarnessDatabase: async () => source,
+    });
+    expect((await harness.process.tick()).activeIssues)
+      .not.toContain("watchdog_harness_source_stale");
+    source = { ...source, liveRun: true };
+    expect((await harness.process.tick()).activeIssues)
+      .toContain("watchdog_harness_source_stale");
+  });
+
+  it("keeps later forwarders live when one sink fails", async () => {
+    const delivered: string[] = [];
+    const harness = await createHarness({
+      dispatcherStaleMs: 1,
+      now: sequenceClock([
+        "2026-08-05T10:00:00.000Z",
+        "2026-08-05T10:00:00.002Z",
+      ]),
+      forwarders: [
+        {
+          name: "failed",
+          state: "configured",
+          async forward(): Promise<void> {
+            throw new Error("sink down");
+          },
+        },
+        {
+          name: "slack",
+          state: "configured",
+          async forward(): Promise<void> {
+            delivered.push("slack");
+          },
+        },
+      ],
+    });
+    await harness.process.tick();
+    expect(delivered).toEqual(["slack"]);
+  });
+});
+
+describe("the direct Slack forwarder", () => {
+  it("scrubs secret-bearing fields and authorization text before delivery", async () => {
+    let body = "";
+    const fetchImpl: WatchdogFetch = async (_input, init) => {
+      body = String(init.body);
+      return { ok: true, status: 200 };
+    };
+    const scrub = process.env.INT4A_MUTATE_REDACTION === "1"
+      ? (value: Readonly<Record<string, unknown>>) => {
+          console.info("INT4A_MUTATION_APPLIED=redaction_identity_scrub");
+          return { ...value };
+        }
+      : undefined;
+    const forwarder = createSlackForwarder({
+      webhookUrl: "http://127.0.0.1.invalid/slack",
+      fetchImpl,
+      ...(scrub ? { scrub } : {}),
+    });
+    await forwarder.forward({
+      severity: "critical",
+      code: "sentinel_probe",
+      message: `Authorization: Bearer ${TOKEN_SENTINEL}`,
+      api_token: TOKEN_SENTINEL,
+    });
+    expect(body).not.toContain(TOKEN_SENTINEL);
+    expect(body).toContain("[REDACTED]");
+  });
+});
+
+describe("the watchdog import surface", () => {
+  it("has no slack-operator or Hermes-facing import", async () => {
+    const root = path.resolve(
+      path.dirname(new URL(import.meta.url).pathname),
+      "../../services/harness-watchdog/src",
+    );
+    const sources = await sourceFiles(root);
+    const forbidden: string[] = [];
+    for (const source of sources) {
+      const text = await readFile(source, "utf8");
+      for (const specifier of importSpecifiers(text)) {
+        if (/slack-operator|hermes/iu.test(specifier)) {
+          forbidden.push(`${path.basename(source)} -> ${specifier}`);
+        }
+      }
+    }
+    expect(forbidden, "forbidden watchdog imports").toEqual([]);
+  });
+
+  it("runs as a standalone restartable Compose service with Slack only", async () => {
+    const composePath = path.resolve(
+      path.dirname(new URL(import.meta.url).pathname),
+      "../../ops/compose.yml",
+    );
+    const compose = parseYaml(await readFile(composePath, "utf8")) as {
+      services: Record<string, {
+        restart?: string;
+        profiles?: string[];
+        command?: string[];
+        environment?: Record<string, unknown>;
+      }>;
+    };
+    const service = compose.services["harness-watchdog"];
+    expect(service).toMatchObject({
+      restart: "unless-stopped",
+      command: ["node", "services/harness-watchdog/dist/index.js"],
+    });
+    expect(service?.profiles).toBeUndefined();
+    expect(service?.environment).toHaveProperty("WATCHDOG_SLACK_WEBHOOK_URL");
+    expect(Object.keys(service?.environment ?? {}))
+      .not.toContain("WATCHDOG_BUZZ_TOKEN");
+  });
+});
+
+async function createHarness(options: {
+  now?: () => Date;
+  dispatcherStaleMs?: number;
+  harnessSourceStaleMs?: number;
+  forwarders?: AlertForwarder[];
+  probeReferenceDatabase?: WatchdogDeps["probeReferenceDatabase"];
+  probeHarnessDatabase?: WatchdogDeps["probeHarnessDatabase"];
+} = {}) {
+  const root = await mkdtemp(path.join(tmpdir(), "int4a-watchdog-unit-"));
+  roots.push(root);
+  const config: WatchdogConfig = {
+    pollIntervalMs: 10,
+    dispatcherStaleMs: options.dispatcherStaleMs ?? 90_000,
+    harnessSourceStaleMs: options.harnessSourceStaleMs ?? 900_000,
+    databaseTimeoutMs: 5_000,
+    alertsPath: path.join(root, "alerts.jsonl"),
+    dispatcherHeartbeatPath: path.join(root, "dispatcher-heartbeat.json"),
+    heartbeatPath: path.join(root, "watchdog-heartbeat.json"),
+    statusPath: path.join(root, "watchdog-status.json"),
+  };
+  const now = options.now ?? (() => new Date("2026-08-05T10:00:00.000Z"));
+  await writeFile(config.dispatcherHeartbeatPath, JSON.stringify({
+    updatedAt: now().toISOString(),
+  }), "utf8");
+  const process = createWatchdogProcess(config, {
+    now,
+    forwarders: options.forwarders ?? [createSlackForwarder({})],
+    probeReferenceDatabase: options.probeReferenceDatabase ?? (async () => {}),
+    probeHarnessDatabase: options.probeHarnessDatabase ?? (async () => ({
+      liveRun: false,
+      newestEventAt: null,
+    })),
+    logger: { info: vi.fn(), warn: vi.fn() },
+    scheduler: {
+      setTimeout: (callback, delayMs) => setTimeout(callback, delayMs),
+      clearTimeout: (timer) => clearTimeout(timer),
+    },
+  });
+  return { root, config, process };
+}
+
+function capturingForwarder(
+  target: Array<Readonly<Record<string, unknown>>>,
+): AlertForwarder {
+  return {
+    name: "slack",
+    state: "configured",
+    async forward(alert): Promise<void> {
+      target.push(alert);
+    },
+  };
+}
+
+async function alertRecords(target: string): Promise<unknown[]> {
+  return (await readFile(target, "utf8"))
+    .trim()
+    .split("\n")
+    .filter(Boolean)
+    .map((line) => JSON.parse(line));
+}
+
+function sequenceClock(values: string[]): () => Date {
+  let index = 0;
+  return () => new Date(values[Math.min(index++, values.length - 1)]!);
+}
+
+async function sourceFiles(root: string): Promise<string[]> {
+  const entries = await readdir(root, { withFileTypes: true });
+  const nested = await Promise.all(entries.map(async (entry) => {
+    const target = path.join(root, entry.name);
+    if (entry.isDirectory()) return sourceFiles(target);
+    return entry.isFile() && entry.name.endsWith(".ts") ? [target] : [];
+  }));
+  return nested.flat();
+}
+
+function importSpecifiers(source: string): string[] {
+  const results: string[] = [];
+  const pattern = /(?:from\s+|import\s*(?:\(\s*)?)(["'])([^"']+)\1/gu;
+  for (const match of source.matchAll(pattern)) {
+    if (match[2]) results.push(match[2]);
+  }
+  return results;
+}


### PR DESCRIPTION
## What changed

- adds `services/harness-watchdog`, a standalone restartable service independent of the dispatcher, Hermes, and slack-operator
- watches dispatcher heartbeat age, new dispatcher alerts, live-run Harness source age, and both Postgres reachability boundaries
- writes alerts to the local JSONL first, then forwards redacted bodies best-effort through an extensible sink list
- implements direct Slack incoming-webhook delivery only; absent webhook is reported as `disabled`
- adds the default Compose service, environment examples, operator runbook, 22-row INT-4 drill ledger, disposable drill project, and dated evidence
- retains the accepted D0 silence commit as the packet foundation

## Why

Before this packet, killing the dispatcher or stopping Harness Postgres produced no off-machine alert. The watchdog supplies an independent detection path, and direct Slack remains live while every local Hermes/slack-operator container is stopped.

The original Buzz design was deliberately not implemented. The amended work order defers signed Nostr delivery to INT-4a.1; this PR contains no Buzz code, Nostr dependency, or second credential.

## Checks

- `npm run typecheck` — exit 0
- `npm test` — exit 0; 188 passed / 2 skipped files, 2,754 passed / 18 skipped tests
- `npm run build` — exit 0
- both AGENTS.md production Compose config checks — exit 0
- disposable INT-4a Compose config — exit 0
- real local Compose drill — 3/3 green
- deliberate mutations: infinity threshold, redaction bypass, Slack black hole, and forbidden import all went red, then restored green

## Surfaces

Backend watchdog service, Compose/runtime configuration, local ceremony tooling, tests, drill ledger, evidence, and runbook. No dispatcher logic, `alerts.ts`, INT-2/INT-3 suite, kernel, production database, credential, deployment, dispatch authority, task state, or Buzz surface changed.

After merge, the operator provisions exactly one watchdog-only value: `WATCHDOG_SLACK_WEBHOOK_URL`.
