### PR TITLE
feat(ceremony): add the §9.1 burn-in battery

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,6 +67,11 @@ INT-2 cases against the real dispatcher, disposable Postgres databases, the
 pinned Harness and Docker. Local `npm test` skips that slow tier unless its
 explicit environment is present; CI fails if the suite skips.
 
+The operator-run §9.1 burn-in battery reuses that same supervised machinery via
+`node scripts/ceremony/run-burnin-batch.mjs --evidence <dir>`. The evidence path
+is mandatory; eligible runs and the non-counting red sentinel append to
+`LEDGER.jsonl`, while `burnin-status.mjs` regenerates the measured summary.
+
 If you touched `ops/`, the `Dockerfile`, or compose files, also validate what CI validates:
 
 ```bash

--- a/docs/evidence/burnin/SUMMARY.md
+++ b/docs/evidence/burnin/SUMMARY.md
@@ -1,0 +1,17 @@
+# Harness §9.1 Burn-in Summary
+
+thresholds: not yet approved
+generated: 2026-08-05T18:44:17.656Z
+
+items: 0/20   families: 0/3   span: 0.00 days of 14
+incident-free: true (0 incidents)
+correlation: 0/0   unverified PR openings: 0
+red sentinels: 0 recorded, 0 correctly refused, 0 counted
+
+## Measurements
+
+No eligible measurements recorded.
+
+## Violations
+
+None.

--- a/scripts/ceremony/burnin-ledger.mjs
+++ b/scripts/ceremony/burnin-ledger.mjs
@@ -1,0 +1,441 @@
+import { mkdir, open, readFile, rename, writeFile } from "node:fs/promises";
+import path from "node:path";
+
+export const BURNIN_LEDGER_NAME = "LEDGER.jsonl";
+export const BURNIN_SUMMARY_NAME = "SUMMARY.md";
+export const BURNIN_GREEN_FAMILIES = Object.freeze([
+  "lint-format",
+  "docs-fix",
+  "add-unit-test",
+  "small-refactor",
+]);
+export const BURNIN_SENTINEL_FAMILY = "lint-format-red";
+export const DEFAULT_THRESHOLD_LINE = "thresholds: not yet approved";
+
+export class BurninLedgerError extends Error {
+  constructor(message) {
+    super(`burn-in ledger refused: ${message}`);
+    this.name = "BurninLedgerError";
+  }
+}
+
+export async function readBurninLedger(evidenceDirectory) {
+  const ledgerPath = path.join(evidenceDirectory, BURNIN_LEDGER_NAME);
+  let bytes = "";
+  try {
+    bytes = await readFile(ledgerPath, "utf8");
+  } catch (error) {
+    if (error?.code !== "ENOENT") throw error;
+  }
+  const lines = [];
+  for (const [index, text] of bytes.split(/\r?\n/u).entries()) {
+    if (!text.trim()) continue;
+    let value;
+    try {
+      value = JSON.parse(text);
+    } catch (error) {
+      throw new BurninLedgerError(
+        `invalid_json line=${index + 1} detail=${error.message}; summary refused`,
+      );
+    }
+    lines.push(value);
+  }
+  assertContiguousSequence(lines);
+  return lines;
+}
+
+export async function appendBurninLedgerLines(evidenceDirectory, additions) {
+  const existing = await readBurninLedger(evidenceDirectory);
+  const expectedFirst = existing.length + 1;
+  additions.forEach((line, index) => {
+    const expected = expectedFirst + index;
+    if (line?.seq !== expected) {
+      throw new BurninLedgerError(
+        `append_seq expected=${expected} actual=${String(line?.seq)}`,
+      );
+    }
+  });
+  await mkdir(evidenceDirectory, { recursive: true });
+  const target = path.join(evidenceDirectory, BURNIN_LEDGER_NAME);
+  const handle = await open(target, "a");
+  try {
+    await handle.writeFile(
+      additions.map((line) => JSON.stringify(line)).join("\n")
+        + (additions.length > 0 ? "\n" : ""),
+      "utf8",
+    );
+    await handle.sync();
+  } finally {
+    await handle.close();
+  }
+  return [...existing, ...additions];
+}
+
+export function aggregateBurninLedger(lines) {
+  assertContiguousSequence(lines);
+  const violations = [];
+  const incidents = [];
+  const duplicateWorkItems = duplicateValues(lines, "workItemId");
+  const duplicateRuns = duplicateValues(lines, "boundRunId");
+  for (const [value, seqs] of duplicateWorkItems) {
+    violations.push({
+      code: "duplicate_work_item",
+      seqs,
+      detail: `workItemId=${value}`,
+    });
+  }
+  for (const [value, seqs] of duplicateRuns) {
+    const incident = {
+      code: "duplicate_dispatch",
+      seqs,
+      detail: `boundRunId=${value}`,
+    };
+    violations.push(incident);
+    incidents.push(incident);
+  }
+
+  const duplicateSeqs = new Set([
+    ...duplicateWorkItems.values(),
+    ...duplicateRuns.values(),
+  ].flat());
+  const eligible = [];
+  const greenLines = [];
+  let correlationPassed = 0;
+  let sentinelCount = 0;
+  let correctSentinelCount = 0;
+  let prOpenings = 0;
+
+  for (const line of lines) {
+    const sentinel = line?.family === BURNIN_SENTINEL_FAMILY;
+    const green = BURNIN_GREEN_FAMILIES.includes(line?.family);
+    if (green) greenLines.push(line);
+    if (sentinel) sentinelCount += 1;
+    const lineViolations = validateEvidenceLine(line, { green, sentinel });
+    for (const violation of lineViolations) violations.push(violation);
+    if (line?.intendedRunId && line.intendedRunId === line.boundRunId) {
+      if (green) correlationPassed += 1;
+    }
+    if (line?.prOpened === true) {
+      prOpenings += 1;
+      const incident = {
+        code: "pr_opened",
+        seqs: [line.seq],
+        detail: `workItemId=${String(line.workItemId)}`,
+      };
+      incidents.push(incident);
+      violations.push(incident);
+    }
+    if (line?.effectsMutates === true) {
+      const incident = {
+        code: "unexpected_actuation",
+        seqs: [line.seq],
+        detail: `workItemId=${String(line.workItemId)}`,
+      };
+      incidents.push(incident);
+      violations.push(incident);
+    }
+    const invalid = lineViolations.length > 0 || duplicateSeqs.has(line?.seq)
+      || line?.prOpened === true || line?.effectsMutates === true;
+    if (green && !invalid) eligible.push(line);
+    if (sentinel && !invalid) correctSentinelCount += 1;
+  }
+
+  const timestamps = lines
+    .map((line) => ({ seq: line?.seq, value: timestamp(line?.ts) }))
+    .filter((item) => item.value !== null)
+    .sort((left, right) => left.value - right.value);
+  const incidentTimestamps = incidents.flatMap((incident) =>
+    incident.seqs.map((seq) => ({
+      seq,
+      value: timestamp(lines.find((line) => line?.seq === seq)?.ts),
+    }))).filter((item) => item.value !== null);
+  const newest = timestamps.at(-1)?.value ?? null;
+  const latestIncident = incidentTimestamps
+    .sort((left, right) => left.value - right.value)
+    .at(-1)?.value ?? null;
+  const oldestEligible = eligible
+    .map((line) => timestamp(line.ts))
+    .filter((value) => value !== null)
+    .sort((left, right) => left - right)[0] ?? null;
+  const spanStart = latestIncident ?? oldestEligible;
+  const spanDays = newest !== null && spanStart !== null
+    ? Math.max(0, newest - spanStart) / 86_400_000
+    : 0;
+
+  return {
+    items: eligible.length,
+    itemTarget: 20,
+    families: new Set(eligible.map((line) => line.family)).size,
+    familyTarget: 3,
+    spanDays,
+    spanTargetDays: 14,
+    spanResetAt: latestIncident === null
+      ? null
+      : new Date(latestIncident).toISOString(),
+    incidentFree: incidents.length === 0,
+    incidents,
+    correlationPassed,
+    correlationTotal: greenLines.length,
+    prOpenings,
+    sentinelCount,
+    correctSentinelCount,
+    violations,
+    measurements: measurementsByFamily(eligible),
+  };
+}
+
+export function renderBurninSummary(
+  aggregation,
+  {
+    generatedAt = new Date().toISOString(),
+    thresholdLine = DEFAULT_THRESHOLD_LINE,
+  } = {},
+) {
+  const lines = [
+    "# Harness §9.1 Burn-in Summary",
+    "",
+    thresholdLine,
+    `generated: ${generatedAt}`,
+    "",
+    `items: ${aggregation.items}/${aggregation.itemTarget}   families: ${aggregation.families}/${aggregation.familyTarget}   span: ${aggregation.spanDays.toFixed(2)} days of ${aggregation.spanTargetDays}`,
+    `incident-free: ${aggregation.incidentFree} (${aggregation.incidents.length} incidents)`,
+    `correlation: ${aggregation.correlationPassed}/${aggregation.correlationTotal}   unverified PR openings: ${aggregation.prOpenings}`,
+    `red sentinels: ${aggregation.sentinelCount} recorded, ${aggregation.correctSentinelCount} correctly refused, 0 counted`,
+  ];
+  if (aggregation.spanResetAt) {
+    lines.push(`span reset at: ${aggregation.spanResetAt}`);
+  }
+  lines.push("", "## Measurements");
+  if (aggregation.measurements.length === 0) {
+    lines.push("", "No eligible measurements recorded.");
+  } else {
+    for (const measurement of aggregation.measurements) {
+      lines.push(
+        "",
+        `- ${measurement.family}: n=${measurement.count}; elapsedSeconds p50=${formatNumber(measurement.elapsed.p50)} p95=${formatNumber(measurement.elapsed.p95)}; verificationSeconds p50=${formatNumber(measurement.verification.p50)} p95=${formatNumber(measurement.verification.p95)}; modelTokens p50=${formatNumber(measurement.tokens.p50)} p95=${formatNumber(measurement.tokens.p95)}`,
+      );
+    }
+  }
+  lines.push("", "## Violations", "");
+  if (aggregation.violations.length === 0) {
+    lines.push("None.");
+  } else {
+    for (const violation of aggregation.violations) {
+      lines.push(
+        `- ${violation.code} seq=${violation.seqs.join(",")} ${violation.detail}`,
+      );
+    }
+  }
+  return `${lines.join("\n")}\n`;
+}
+
+export async function writeBurninSummary(evidenceDirectory, aggregation, options = {}) {
+  await mkdir(evidenceDirectory, { recursive: true });
+  const target = path.join(evidenceDirectory, BURNIN_SUMMARY_NAME);
+  let thresholdLine = DEFAULT_THRESHOLD_LINE;
+  try {
+    const existing = await readFile(target, "utf8");
+    thresholdLine = existing.match(/^thresholds: .+$/mu)?.[0]
+      ?? DEFAULT_THRESHOLD_LINE;
+  } catch (error) {
+    if (error?.code !== "ENOENT") throw error;
+  }
+  const bytes = renderBurninSummary(aggregation, {
+    ...options,
+    thresholdLine,
+  });
+  const temporary = `${target}.tmp-${process.pid}`;
+  await writeFile(temporary, bytes, "utf8");
+  await rename(temporary, target);
+  return bytes;
+}
+
+export function buildBurninLedgerLine(evidence, { family, seq }) {
+  const handoffs = Array.isArray(evidence?.decisions)
+    ? evidence.decisions.filter((decision) => decision?.decisionType === "handoff")
+    : [];
+  const boundRuns = Array.isArray(evidence?.outbox)
+    ? [...new Set(evidence.outbox.map((row) => row?.harness_run_id).filter(Boolean))]
+    : [];
+  const run = Array.isArray(evidence?.runs)
+    ? evidence.runs.find((candidate) => candidate?.runId === evidence?.intendedRunId)
+    : undefined;
+  const criteria = Array.isArray(evidence?.verification?.details)
+    ? evidence.verification.details.map((detail) => ({
+        id: detail?.id,
+        passed: detail?.passed,
+        reason: detail?.reason,
+      }))
+    : null;
+  const pullRequestBound = evidence?.task?.bindings?.pullRequest !== undefined;
+  return {
+    seq,
+    ts: evidence?.metrics?.observedAt ?? run?.updatedAt ?? null,
+    workItemId: evidence?.workItemId ?? null,
+    family,
+    taskVersion: evidence?.task?.taskVersion ?? null,
+    intendedRunId: evidence?.intendedRunId ?? null,
+    boundRunId: boundRuns.length === 1 ? boundRuns[0] : null,
+    lifecycle: evidence?.task?.lifecycle ?? null,
+    harnessOutcome: run?.outcome ?? null,
+    ...(evidence?.verification?.verdict === undefined
+      ? {}
+      : { verificationVerdict: evidence.verification.verdict }),
+    criteria,
+    handoffDecisions: handoffs.length,
+    prOpened: pullRequestBound
+      || (Array.isArray(evidence?.pullRequestReferences)
+        && evidence.pullRequestReferences.length > 0),
+    effectsMutates: handoffs.some(
+      (decision) => decision?.effects?.mutates === true,
+    ),
+    elapsedSeconds: evidence?.metrics?.elapsedSeconds ?? null,
+    verificationSeconds: evidence?.metrics?.verificationSeconds ?? null,
+    modelTokens: evidence?.metrics?.modelTokens ?? null,
+    alerts: Array.isArray(evidence?.alerts)
+      ? evidence.alerts.map((alert) => ({
+          code: alert?.code,
+          severity: alert?.severity,
+          message: alert?.message,
+        }))
+      : null,
+  };
+}
+
+function assertContiguousSequence(lines) {
+  lines.forEach((line, index) => {
+    const expected = index + 1;
+    if (line?.seq !== expected) {
+      throw new BurninLedgerError(
+        `seq_gap expected=${expected} actual=${String(line?.seq)} line=${index + 1}; summary refused`,
+      );
+    }
+  });
+}
+
+function validateEvidenceLine(line, { green, sentinel }) {
+  const violations = [];
+  const add = (code, detail) => violations.push({
+    code,
+    seqs: [Number.isSafeInteger(line?.seq) ? line.seq : -1],
+    detail,
+  });
+  if (!green && !sentinel) add("unknown_family", `family=${String(line?.family)}`);
+  for (const key of [
+    "ts",
+    "workItemId",
+    "taskVersion",
+    "intendedRunId",
+    "boundRunId",
+    "lifecycle",
+    "harnessOutcome",
+    "verificationVerdict",
+    "criteria",
+    "handoffDecisions",
+    "prOpened",
+    "effectsMutates",
+    "elapsedSeconds",
+    "verificationSeconds",
+    "modelTokens",
+    "alerts",
+  ]) {
+    if (line?.[key] === undefined || line?.[key] === null) {
+      add("missing_evidence", `field=${key}`);
+    }
+  }
+  if (timestamp(line?.ts) === null) add("invalid_timestamp", `ts=${String(line?.ts)}`);
+  if (!Array.isArray(line?.criteria) || line.criteria.length === 0) {
+    add("criteria_missing", "criteria must contain verifier results");
+  } else if (line.criteria.some((criterion) =>
+    typeof criterion?.id !== "string"
+      || typeof criterion?.passed !== "boolean"
+      || typeof criterion?.reason !== "string")) {
+    add("criteria_ambiguous", "criterion id, passed, or reason is missing");
+  }
+  if (!Array.isArray(line?.alerts)) add("alerts_missing", "alerts is not an array");
+  if (green) {
+    if (line?.lifecycle !== "handoff_ready") {
+      add("green_lifecycle", `expected=handoff_ready actual=${String(line?.lifecycle)}`);
+    }
+    if (line?.harnessOutcome !== "completed") {
+      add("green_outcome", `expected=completed actual=${String(line?.harnessOutcome)}`);
+    }
+    if (line?.verificationVerdict !== "completed") {
+      add("green_verdict", `expected=completed actual=${String(line?.verificationVerdict)}`);
+    }
+    if (line?.handoffDecisions !== 1) {
+      add("green_handoff_count", `expected=1 actual=${String(line?.handoffDecisions)}`);
+    }
+    if (Array.isArray(line?.criteria)
+        && line.criteria.some((criterion) => criterion?.passed !== true)) {
+      add("green_criterion_failed", "at least one criterion did not pass");
+    }
+  }
+  if (sentinel) {
+    if (line?.lifecycle !== "failed") {
+      add("sentinel_lifecycle", `expected=failed actual=${String(line?.lifecycle)}`);
+    }
+    if (line?.verificationVerdict !== "failed") {
+      add("sentinel_verdict", `expected=failed actual=${String(line?.verificationVerdict)}`);
+    }
+    if (line?.handoffDecisions !== 0) {
+      add("sentinel_handoff_count", `expected=0 actual=${String(line?.handoffDecisions)}`);
+    }
+  }
+  if (line?.intendedRunId !== line?.boundRunId) {
+    add(
+      "correlation_mismatch",
+      `intended=${String(line?.intendedRunId)} bound=${String(line?.boundRunId)}`,
+    );
+  }
+  return violations;
+}
+
+function duplicateValues(lines, key) {
+  const locations = new Map();
+  for (const line of lines) {
+    const value = line?.[key];
+    if (typeof value !== "string" || !value) continue;
+    const seqs = locations.get(value) ?? [];
+    seqs.push(line.seq);
+    locations.set(value, seqs);
+  }
+  return new Map([...locations].filter(([, seqs]) => seqs.length > 1));
+}
+
+function measurementsByFamily(lines) {
+  return BURNIN_GREEN_FAMILIES.flatMap((family) => {
+    const rows = lines.filter((line) => line.family === family);
+    if (rows.length === 0) return [];
+    return [{
+      family,
+      count: rows.length,
+      elapsed: percentiles(rows.map((line) => line.elapsedSeconds)),
+      verification: percentiles(rows.map((line) => line.verificationSeconds)),
+      tokens: percentiles(rows.map((line) => line.modelTokens)),
+    }];
+  });
+}
+
+function percentiles(values) {
+  const sorted = values.filter(Number.isFinite).sort((left, right) => left - right);
+  return {
+    p50: percentile(sorted, 0.5),
+    p95: percentile(sorted, 0.95),
+  };
+}
+
+function percentile(values, fraction) {
+  if (values.length === 0) return null;
+  return values[Math.ceil(fraction * values.length) - 1];
+}
+
+function timestamp(value) {
+  if (typeof value !== "string") return null;
+  const parsed = Date.parse(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function formatNumber(value) {
+  return value === null ? "n/a" : Number(value.toFixed(3)).toString();
+}

--- a/scripts/ceremony/burnin-status.mjs
+++ b/scripts/ceremony/burnin-status.mjs
@@ -1,0 +1,57 @@
+#!/usr/bin/env node
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+import {
+  aggregateBurninLedger,
+  BurninLedgerError,
+  readBurninLedger,
+  writeBurninSummary,
+} from "./burnin-ledger.mjs";
+
+export async function runBurninStatus(
+  argv,
+  {
+    output = (text) => process.stdout.write(text),
+    errorOutput = (text) => process.stderr.write(text),
+    generatedAt,
+  } = {},
+) {
+  let evidenceDirectory;
+  try {
+    evidenceDirectory = parseEvidenceArgument(argv);
+  } catch (error) {
+    errorOutput(`burnin-status: ${error.message}\n`);
+    return 2;
+  }
+  try {
+    const ledger = await readBurninLedger(evidenceDirectory);
+    const aggregation = aggregateBurninLedger(ledger);
+    const summary = await writeBurninSummary(
+      evidenceDirectory,
+      aggregation,
+      generatedAt ? { generatedAt } : {},
+    );
+    output(summary);
+    return aggregation.violations.length === 0 ? 0 : 1;
+  } catch (error) {
+    const message = error instanceof BurninLedgerError
+      ? error.message
+      : `burn-in status failed: ${error.message}`;
+    errorOutput(`burnin-status: ${message}\n`);
+    return 1;
+  }
+}
+
+function parseEvidenceArgument(argv) {
+  if (argv.length !== 2 || argv[0] !== "--evidence" || !argv[1]?.trim()) {
+    throw new Error("usage: burnin-status.mjs --evidence <dir>");
+  }
+  return path.resolve(argv[1]);
+}
+
+const invokedAsScript = process.argv[1]
+  && import.meta.url === pathToFileURL(process.argv[1]).href;
+if (invokedAsScript) {
+  process.exitCode = await runBurninStatus(process.argv.slice(2));
+}

--- a/scripts/ceremony/int2-evidence.mjs
+++ b/scripts/ceremony/int2-evidence.mjs
@@ -748,6 +748,7 @@ export async function collectInt2Evidence({
       outboxRows,
       decisionRows,
       runRows,
+      metricRows,
     ] = await Promise.all([
       referencePool.query(
         `select task
@@ -778,11 +779,20 @@ export async function collectInt2Evidence({
         [workItemId],
       ),
       harnessPool.query(
-        `select run_id, state, outcome, outcome_reason, attempt, task, manifest
+        `select run_id, state, outcome, outcome_reason, attempt, task, manifest,
+                created_at, updated_at
          from runs
          where task->'metadata'->'labels'->>'averray_work_item_id' = $1
          order by created_at, run_id`,
         [workItemId],
+      ),
+      harnessPool.query(
+        `select event_type, payload, ts
+         from domain_events
+         where run_id = $1
+           and event_type in ('ModelResponded', 'VerificationCompleted')
+         order by seq`,
+        [intendedRunId],
       ),
     ]);
     raw = {
@@ -791,6 +801,7 @@ export async function collectInt2Evidence({
       outbox: outboxRows.rows,
       decisions: decisionRows.rows.map((row) => row.record),
       runs: runRows.rows.map(normalizeRunRow),
+      metrics: metricsFromRows(runRows.rows, metricRows.rows, intendedRunId),
     };
   } finally {
     await Promise.allSettled([
@@ -858,6 +869,7 @@ export async function collectInt2Evidence({
     events,
     deliverables,
     verification,
+    metrics: raw.metrics,
     patch,
     exit128Present: /(?:exit_128|exit 128|exit_code["']?\s*:\s*128)/iu
       .test(eventsText),
@@ -1846,7 +1858,54 @@ function normalizeRunRow(row) {
     task: row.task,
     manifest: row.manifest,
     workspacePath: row.task?.spec?.context?.workspace?.path,
+    createdAt: timestampString(row.created_at),
+    updatedAt: timestampString(row.updated_at),
   };
+}
+
+function metricsFromRows(runRows, eventRows, intendedRunId) {
+  const run = runRows.find((row) => row.run_id === intendedRunId);
+  if (!run) return null;
+  const createdAt = Date.parse(timestampString(run.created_at));
+  const updatedAt = Date.parse(timestampString(run.updated_at));
+  let modelTokens = 0;
+  let modelUsageComplete = true;
+  let latestModelResponse;
+  let verificationCompleted;
+  for (const row of eventRows) {
+    const timestamp = Date.parse(timestampString(row.ts));
+    if (row.event_type === "ModelResponded") {
+      latestModelResponse = timestamp;
+      const input = row.payload?.usage?.input_tokens;
+      const output = row.payload?.usage?.output_tokens;
+      if (!Number.isSafeInteger(input) || !Number.isSafeInteger(output)) {
+        modelUsageComplete = false;
+      } else {
+        modelTokens += input + output;
+      }
+    }
+    if (row.event_type === "VerificationCompleted") {
+      verificationCompleted = timestamp;
+    }
+  }
+  return {
+    observedAt: Number.isFinite(updatedAt)
+      ? new Date(updatedAt).toISOString()
+      : null,
+    elapsedSeconds: Number.isFinite(createdAt) && Number.isFinite(updatedAt)
+      ? Math.max(0, (updatedAt - createdAt) / 1_000)
+      : null,
+    verificationSeconds:
+      Number.isFinite(latestModelResponse)
+        && Number.isFinite(verificationCompleted)
+        ? Math.max(0, (verificationCompleted - latestModelResponse) / 1_000)
+        : null,
+    modelTokens: modelUsageComplete ? modelTokens : null,
+  };
+}
+
+function timestampString(value) {
+  return value instanceof Date ? value.toISOString() : String(value);
 }
 
 function countDecisions(decisions) {

--- a/scripts/ceremony/run-burnin-batch.mjs
+++ b/scripts/ceremony/run-burnin-batch.mjs
@@ -1,0 +1,137 @@
+#!/usr/bin/env node
+import { spawn } from "node:child_process";
+import { mkdir, readFile } from "node:fs/promises";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+import {
+  aggregateBurninLedger,
+  appendBurninLedgerLines,
+  buildBurninLedgerLine,
+  readBurninLedger,
+  writeBurninSummary,
+} from "./burnin-ledger.mjs";
+import { verifyInt2Evidence } from "./int2-evidence.mjs";
+
+const REPOSITORY_ROOT = path.resolve(import.meta.dirname, "../..");
+const CASES = Object.freeze([
+  Object.freeze({ family: "lint-format", caseName: "green" }),
+  Object.freeze({ family: "docs-fix", caseName: "docs-fix" }),
+  Object.freeze({ family: "add-unit-test", caseName: "add-unit-test" }),
+  Object.freeze({ family: "small-refactor", caseName: "small-refactor" }),
+  Object.freeze({ family: "lint-format-red", caseName: "negative" }),
+]);
+
+export async function runBurninBatch(
+  argv,
+  {
+    environment = process.env,
+    now = () => new Date(),
+    output = (text) => process.stdout.write(text),
+    errorOutput = (text) => process.stderr.write(text),
+    executeSuite = executeRealSuite,
+    verifyEvidence = verifyInt2Evidence,
+  } = {},
+) {
+  let evidenceDirectory;
+  try {
+    evidenceDirectory = parseEvidenceArgument(argv);
+  } catch (error) {
+    errorOutput(`run-burnin-batch: ${error.message}\n`);
+    return 2;
+  }
+
+  try {
+    await mkdir(evidenceDirectory, { recursive: true });
+    const existing = await readBurninLedger(evidenceDirectory);
+    const firstSequence = existing.length + 1;
+    const date = now().toISOString().slice(0, 10).replaceAll("-", "");
+    const batchPrefix = `burnin-${date}-${String(firstSequence).padStart(6, "0")}`;
+    const batchDirectory = path.join(
+      evidenceDirectory,
+      "batches",
+      batchPrefix,
+    );
+    await mkdir(path.dirname(batchDirectory), { recursive: true });
+    await mkdir(batchDirectory, { recursive: false });
+
+    await executeSuite({
+      repositoryRoot: REPOSITORY_ROOT,
+      evidenceDirectory: batchDirectory,
+      batchPrefix,
+      environment,
+    });
+
+    const lines = [];
+    for (const [index, definition] of CASES.entries()) {
+      const target = path.join(
+        batchDirectory,
+        definition.caseName,
+        "evidence.json",
+      );
+      const evidence = JSON.parse(await readFile(target, "utf8"));
+      verifyEvidence(evidence, definition.caseName);
+      lines.push(buildBurninLedgerLine(evidence, {
+        family: definition.family,
+        seq: firstSequence + index,
+      }));
+    }
+
+    const ledger = await appendBurninLedgerLines(evidenceDirectory, lines);
+    const aggregation = aggregateBurninLedger(ledger);
+    const summary = await writeBurninSummary(evidenceDirectory, aggregation);
+    output(
+      `BURNIN_BATCH_COMPLETED prefix=${batchPrefix} items=4 sentinel=1\n`,
+    );
+    output(summary);
+    return aggregation.violations.length === 0 ? 0 : 1;
+  } catch (error) {
+    errorOutput(`run-burnin-batch: ${error.message}\n`);
+    return 1;
+  }
+}
+
+function parseEvidenceArgument(argv) {
+  if (argv.length !== 2 || argv[0] !== "--evidence" || !argv[1]?.trim()) {
+    throw new Error("--evidence <dir> is required; no default evidence path exists");
+  }
+  return path.resolve(argv[1]);
+}
+
+async function executeRealSuite({
+  repositoryRoot,
+  evidenceDirectory,
+  batchPrefix,
+  environment,
+}) {
+  const child = spawn(
+    path.join(repositoryRoot, "scripts/ceremony/run-int2-automated-suite.sh"),
+    [],
+    {
+      cwd: repositoryRoot,
+      env: {
+        ...environment,
+        INT2_BURNIN_BATCH_MODE: "1",
+        INT2_BURNIN_WORK_ITEM_PREFIX: batchPrefix,
+        INT2_SUITE_EVIDENCE_DIR: evidenceDirectory,
+      },
+      stdio: "inherit",
+    },
+  );
+  const code = await new Promise((resolve, reject) => {
+    child.once("error", reject);
+    child.once("exit", (value, signal) => {
+      if (signal) reject(new Error(`INT-2 machinery exited on signal ${signal}`));
+      else resolve(value ?? 1);
+    });
+  });
+  if (code !== 0) {
+    throw new Error(`INT-2 machinery exited ${code}`);
+  }
+}
+
+const invokedAsScript = process.argv[1]
+  && import.meta.url === pathToFileURL(process.argv[1]).href;
+if (invokedAsScript) {
+  process.exitCode = await runBurninBatch(process.argv.slice(2));
+}

--- a/scripts/ceremony/run-int2-automated-suite.sh
+++ b/scripts/ceremony/run-int2-automated-suite.sh
@@ -320,6 +320,34 @@ printf '%s\n' "INT2_WORKSPACE_SNAPSHOT spared=$(
   grep -c . "$_int2_workspaces_before" 2>/dev/null || echo 0
 )" >> "$_int2_bootstrap_log"
 
+# The operator-run burn-in battery uses this exact bootstrap, worker path, and
+# cleanup trap, then selects the five already-merged lifecycle cases it needs.
+# The default INT-2 gate below remains a fixed 14-case skip detector.
+if [ "${INT2_BURNIN_BATCH_MODE:-0}" = "1" ]; then
+  : "${INT2_BURNIN_WORK_ITEM_PREFIX:?INT2_BURNIN_WORK_ITEM_PREFIX is required}"
+  printf '%s\n' "BURNIN_CASES_STARTED expected=5" >> "$_int2_bootstrap_log"
+  (
+    cd "$_int2_repo"
+    npm run build
+    npx vitest run test/integration/int2-automated-suite.test.ts \
+      --reporter=verbose \
+      --testNamePattern='rejects the negative fixture on its merits with no handoff|produces one verified, unactuated green handoff|executes the docs-fix family with command and search verification|executes the add-unit-test family through the pinned offline toolchain|executes the small-refactor family with typecheck, test, and search'
+  )
+
+  _int2_executed="$(tr -d '[:space:]' < "$_int2_marker")"
+  test "$_int2_executed" = "5" \
+    || {
+      echo "Burn-in batch executed $_int2_executed cases; expected 5" >&2
+      exit 1
+    }
+  _int2_elapsed="$(( $(date +%s) - _int2_started ))"
+  printf '%s\n' "$_int2_elapsed" > "$_int2_evidence/wall-time-seconds.txt"
+  printf '%s\n' "BURNIN_CASES_COMPLETED executed=$_int2_executed elapsed=$_int2_elapsed" \
+    >> "$_int2_bootstrap_log"
+  echo "Burn-in batch: $_int2_executed cases executed in ${_int2_elapsed}s"
+  exit 0
+fi
+
 printf '%s\n' "INT2_CASES_STARTED expected=14" >> "$_int2_bootstrap_log"
 (
   cd "$_int2_repo"

--- a/test/integration/int2-automated-suite.test.ts
+++ b/test/integration/int2-automated-suite.test.ts
@@ -825,7 +825,22 @@ describe.skipIf(!ready)("INT-2 automated supervised-dispatch suite", () => {
   }
 
   function nextWorkItem(caseName: string): string {
-    const value = `${suitePrefix}-${caseName}`;
+    const burninPrefix = process.env.INT2_BURNIN_WORK_ITEM_PREFIX?.trim();
+    const burninFamily = {
+      "add-unit-test": "add-unit-test",
+      "docs-fix": "docs-fix",
+      green: "lint-format",
+      negative: "lint-format-red",
+      "small-refactor": "small-refactor",
+    }[caseName];
+    if (burninPrefix && !burninFamily) {
+      throw new Error(
+        `INT-2 case ${caseName} is not part of the burn-in battery`,
+      );
+    }
+    const value = burninPrefix
+      ? `${burninPrefix}-${burninFamily}`
+      : `${suitePrefix}-${caseName}`;
     workItemIds.add(value);
     return value;
   }

--- a/test/unit/burnin-battery.test.ts
+++ b/test/unit/burnin-battery.test.ts
@@ -1,0 +1,273 @@
+import { mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import {
+  aggregateBurninLedger,
+  BurninLedgerError,
+  readBurninLedger,
+  renderBurninSummary,
+} from "../../scripts/ceremony/burnin-ledger.mjs";
+import { runBurninBatch } from "../../scripts/ceremony/run-burnin-batch.mjs";
+import { runBurninStatus } from "../../scripts/ceremony/burnin-status.mjs";
+
+describe("Harness §9.1 burn-in battery", () => {
+  it("counts four green families and excludes the red sentinel", () => {
+    const aggregation = aggregateBurninLedger(validLedger());
+
+    expect(aggregation.items).toBe(4);
+    expect(aggregation.families).toBe(4);
+    expect(aggregation.sentinelCount).toBe(1);
+    expect(aggregation.correctSentinelCount).toBe(1);
+    expect(aggregation.correlationPassed).toBe(4);
+    expect(aggregation.violations).toEqual([]);
+    expect(renderBurninSummary(aggregation)).toContain(
+      "thresholds: not yet approved",
+    );
+  });
+
+  it("reports a PR opening as an incident and resets the span", () => {
+    const baseline = aggregateBurninLedger(validLedger());
+    const mutated = structuredClone(validLedger());
+    mutated[3].prOpened = true;
+
+    const aggregation = aggregateBurninLedger(mutated);
+
+    expect(aggregation.incidentFree).toBe(false);
+    expect(aggregation.incidents).toEqual(expect.arrayContaining([
+      expect.objectContaining({ code: "pr_opened", seqs: [4] }),
+    ]));
+    expect(aggregation.spanResetAt).toBe("2026-08-04T00:00:00.000Z");
+    expect(aggregation.spanDays).toBeLessThan(baseline.spanDays);
+  });
+
+  it("reports duplicate dispatch when two lines share one bound run", () => {
+    const mutated = structuredClone(validLedger());
+    mutated[1].boundRunId = mutated[0].boundRunId;
+
+    const aggregation = aggregateBurninLedger(mutated);
+
+    expect(aggregation.incidents).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        code: "duplicate_dispatch",
+        seqs: [1, 2],
+      }),
+    ]));
+    expect(aggregation.items).toBe(2);
+  });
+
+  it("counts a missing verification verdict as a violation, never progress", () => {
+    const mutated = structuredClone(validLedger());
+    delete mutated[0].verificationVerdict;
+
+    const aggregation = aggregateBurninLedger(mutated);
+
+    expect(aggregation.items).toBe(3);
+    expect(aggregation.violations).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        code: "missing_evidence",
+        seqs: [1],
+        detail: "field=verificationVerdict",
+      }),
+    ]));
+  });
+
+  it("refuses the summary when a line is deleted from the middle", async () => {
+    const directory = await mkdtemp(path.join(tmpdir(), "burnin-gap-"));
+    const mutated = validLedger().filter((line) => line.seq !== 2);
+    await writeFile(
+      path.join(directory, "LEDGER.jsonl"),
+      `${mutated.map((line) => JSON.stringify(line)).join("\n")}\n`,
+      "utf8",
+    );
+
+    await expect(readBurninLedger(directory)).rejects.toEqual(
+      expect.objectContaining({
+        name: "BurninLedgerError",
+        message: expect.stringContaining("seq_gap expected=2 actual=3"),
+      }),
+    );
+    await expect(readBurninLedger(directory)).rejects.toBeInstanceOf(
+      BurninLedgerError,
+    );
+  });
+
+  it("requires an explicit evidence directory before starting machinery", async () => {
+    let stderr = "";
+    let invoked = false;
+    const code = await runBurninBatch([], {
+      errorOutput: (text: string) => {
+        stderr += text;
+      },
+      executeSuite: async () => {
+        invoked = true;
+      },
+    });
+
+    expect(code).toBe(2);
+    expect(invoked).toBe(false);
+    expect(stderr).toBe(
+      "run-burnin-batch: --evidence <dir> is required; no default evidence path exists\n",
+    );
+  });
+
+  it("builds one append-only batch from the selected cases' evidence", async () => {
+    const directory = await mkdtemp(path.join(tmpdir(), "burnin-batch-"));
+    let stdout = "";
+    const code = await runBurninBatch(["--evidence", directory], {
+      now: () => new Date("2026-08-05T12:00:00.000Z"),
+      output: (text: string) => {
+        stdout += text;
+      },
+      verifyEvidence: () => undefined,
+      executeSuite: async ({
+        evidenceDirectory,
+        batchPrefix,
+      }: {
+        evidenceDirectory: string;
+        batchPrefix: string;
+      }) => {
+        const cases = [
+          ["green", "lint-format", false],
+          ["docs-fix", "docs-fix", false],
+          ["add-unit-test", "add-unit-test", false],
+          ["small-refactor", "small-refactor", false],
+          ["negative", "lint-format-red", true],
+        ] as const;
+        for (const [caseName, family, sentinel] of cases) {
+          const target = path.join(evidenceDirectory, caseName);
+          await mkdir(target, { recursive: true });
+          await writeFile(
+            path.join(target, "evidence.json"),
+            JSON.stringify(evidenceForLine({
+              workItemId: `${batchPrefix}-${family}`,
+              sentinel,
+            })),
+            "utf8",
+          );
+        }
+      },
+    });
+
+    expect(code).toBe(0);
+    expect(stdout).toContain("items: 4/20");
+    expect(stdout).toContain(
+      "red sentinels: 1 recorded, 1 correctly refused, 0 counted",
+    );
+    const ledger = await readBurninLedger(directory);
+    expect(ledger).toHaveLength(5);
+    expect(ledger.map((line) => line.seq)).toEqual([1, 2, 3, 4, 5]);
+    expect(ledger.map((line) => line.workItemId)).toEqual([
+      "burnin-20260805-000001-lint-format",
+      "burnin-20260805-000001-docs-fix",
+      "burnin-20260805-000001-add-unit-test",
+      "burnin-20260805-000001-small-refactor",
+      "burnin-20260805-000001-lint-format-red",
+    ]);
+  });
+
+  it("writes an honest status for an empty, explicitly selected ledger", async () => {
+    const directory = await mkdtemp(path.join(tmpdir(), "burnin-empty-"));
+    let stdout = "";
+    const code = await runBurninStatus(["--evidence", directory], {
+      generatedAt: "2026-08-05T00:00:00.000Z",
+      output: (text: string) => {
+        stdout += text;
+      },
+    });
+
+    expect(code).toBe(0);
+    expect(stdout).toContain("items: 0/20");
+    expect(stdout).toContain("thresholds: not yet approved");
+    expect(await readFile(path.join(directory, "SUMMARY.md"), "utf8"))
+      .toBe(stdout);
+  });
+});
+
+function validLedger(): Array<Record<string, any>> {
+  const families = [
+    "lint-format",
+    "docs-fix",
+    "add-unit-test",
+    "small-refactor",
+    "lint-format-red",
+  ];
+  return families.map((family, index) => {
+    const sentinel = family === "lint-format-red";
+    const seq = index + 1;
+    const runId = `00000000-0000-4000-8000-${String(seq).padStart(12, "0")}`;
+    return {
+      seq,
+      ts: `2026-08-0${seq}T00:00:00.000Z`,
+      workItemId: `burnin-20260805-000001-${family}`,
+      family,
+      taskVersion: 1,
+      intendedRunId: runId,
+      boundRunId: runId,
+      lifecycle: sentinel ? "failed" : "handoff_ready",
+      harnessOutcome: sentinel ? "failed" : "completed",
+      verificationVerdict: sentinel ? "failed" : "completed",
+      criteria: [{
+        id: "criterion",
+        passed: !sentinel,
+        reason: sentinel ? "exit_2" : "exit_0",
+        detail: sentinel ? "trailing whitespace" : "accepted",
+      }],
+      handoffDecisions: sentinel ? 0 : 1,
+      prOpened: false,
+      effectsMutates: false,
+      elapsedSeconds: 10 + index,
+      verificationSeconds: 2 + index,
+      modelTokens: 7,
+      alerts: [],
+    };
+  });
+}
+
+function evidenceForLine({
+  workItemId,
+  sentinel,
+}: {
+  workItemId: string;
+  sentinel: boolean;
+}): Record<string, any> {
+  const runId = `00000000-0000-4000-8000-${workItemId.length
+    .toString().padStart(12, "0")}`;
+  return {
+    workItemId,
+    intendedRunId: runId,
+    task: {
+      workItemId,
+      taskVersion: 1,
+      lifecycle: sentinel ? "failed" : "handoff_ready",
+    },
+    outbox: [{ harness_run_id: runId }],
+    runs: [{
+      runId,
+      outcome: sentinel ? "failed" : "completed",
+      updatedAt: "2026-08-05T12:00:00.000Z",
+    }],
+    verification: {
+      verdict: sentinel ? "failed" : "completed",
+      details: [{
+        id: "criterion",
+        passed: !sentinel,
+        reason: sentinel ? "exit_2" : "exit_0",
+        detail: sentinel ? "refused" : "accepted",
+      }],
+    },
+    decisions: sentinel
+      ? []
+      : [{ decisionType: "handoff", effects: { mutates: false } }],
+    pullRequestReferences: [],
+    metrics: {
+      observedAt: "2026-08-05T12:00:00.000Z",
+      elapsedSeconds: 10,
+      verificationSeconds: 2,
+      modelTokens: 7,
+    },
+    alerts: [],
+  };
+}


### PR DESCRIPTION
## What changed

- add the operator-run `run-burnin-batch.mjs --evidence <dir>` command
- reuse the existing INT-2 bootstrap, worker environment, selected lifecycle cases, and teardown ordering
- append run-derived task/run/verifier facts to a sequence-checked `LEDGER.jsonl`
- regenerate `SUMMARY.md` with item/family/span progress, incidents, correlation, and per-family latency/token measurements
- keep the committed production ledger empty so the 14-day clock starts with the first operator batch
- add focused tests for the runner, sentinel exclusion, evidence refusal, and all four aggregator mutations

## Checks run

- `npm run typecheck` — exit 0
- `npm test` — exit 0; 189 files passed, 2 skipped; 2762 tests passed, 18 skipped
- `npm run build` — exit 0
- real container-backed batch — 5/5 selected cases; 4 eligible items, 4 families, 1 correctly refused red sentinel, 4/4 correlation, zero PR openings, zero violations; 243s wall time
- mutation proofs — `prOpened: true`, duplicate `boundRunId`, missing `verificationVerdict`, and a deleted middle ledger line each produced a non-zero status with a named violation; restoring each ledger returned green

## Affected surfaces

Ceremony scripts, INT-2 evidence measurement, one opt-in INT-2 work-item naming seam, tests, AGENTS guidance, and the empty burn-in evidence ledger/summary. No dispatcher, alert, watchdog, kernel, fixture budget, Compose, migration, money-rail, wallet, signer, claim, submission, actuation, or production authority change.

## Rollout / rollback

No credential or environment provisioning is required. The operator supplies an explicit evidence directory. The batch uses disposable Postgres containers, the pinned Harness, Docker network deny-by-default, and opens no PR. Rollback is removal of the operator scripts and opt-in reuse seam; existing INT-2 and INT-3b case counts are unchanged.