### PR TITLE
Human voice for the morning digest and status lines

### DIFF
--- a/services/slack-operator/src/digest-voice.ts
+++ b/services/slack-operator/src/digest-voice.ts
@@ -1,0 +1,111 @@
+// The Hermes-written morning briefing — conversational words, mechanical truth.
+//
+// The operator asked for the briefing to read like a colleague rather than a
+// stat dump, and Hermes — a full LLM — already fronts the channel, so the
+// words should genuinely be his. The danger is equally plain: a model
+// paraphrasing money facts will eventually improve one. The ops contract
+// exists because paraphrase drift burned us before ("read verdict.reason,
+// never the headline"), and a briefing is the highest-trust message the
+// channel sends.
+//
+// Resolution: Hermes writes AROUND the facts, and a mechanical gate proves
+// the facts survived. The gate extracts every number and hex id from the fact
+// strings (the probes' own details — the same strings the board renders) and
+// requires each to appear verbatim in the prose; the verdict headline must be
+// quoted whole; and the prose may not claim green over a red board. Any miss
+// — or the model being down, slow, or empty — sends the plain digest instead.
+// The briefing is therefore never absent and never wrong; only sometimes less
+// charming.
+//
+// Kept pure of transport: the caller injects a `request` function (bound to
+// requestHermesCompletion, the ONE LLM client), so every rule here runs in the
+// local unit suite with a stub.
+
+import type { HermesCompletionRequest } from "./monitor-hermes-voice.js";
+
+export interface ConversationalDigestInput {
+  /** The deterministic digest — the model's source AND the fallback text. */
+  plain: string;
+  /** deriveOpsVerdict headline; must survive verbatim, quoted once. */
+  verdictHeadline: string;
+  /** The strings whose numbers must survive: probe details + the bank line. */
+  facts: readonly string[];
+  /** Red probe count — a red board must never read as green. */
+  redCount: number;
+  request: (req: HermesCompletionRequest) => Promise<string | null>;
+}
+
+export interface ConversationalDigestResult {
+  text: string;
+  voice: "hermes" | "plain";
+  /** Why the plain form went out; absent when voice is "hermes". */
+  reason?: string;
+}
+
+/**
+ * Every number and hex id in the fact strings. "gas ×3.2" yields "3.2", which
+ * "3.2×" and "3.2 times" both contain — the gate constrains the FIGURES, not
+ * the phrasing around them. Deliberately necessary-not-sufficient: a token the
+ * model drops or rewrites ("1,234" → "1234") fails closed to the plain form.
+ */
+export function digestFactTokens(facts: readonly string[]): string[] {
+  const tokens = new Set<string>();
+  for (const fact of facts) {
+    for (const match of fact.match(/0x[0-9a-fA-F]+|\d+(?:[.,]\d+)?/g) ?? []) tokens.add(match);
+  }
+  return [...tokens];
+}
+
+const CLAIMS_ALL_GREEN = /all\s+(?:\d+\s+)?probes?\s+(?:are\s+)?green|all\s+green|all\s+clear/i;
+
+/** Null when the candidate may ship; otherwise the named reason it may not. */
+export function conversationalDigestViolation(
+  input: Pick<ConversationalDigestInput, "verdictHeadline" | "facts" | "redCount">,
+  candidate: string,
+): string | null {
+  const text = candidate.trim();
+  if (!text) return "empty";
+  // A briefing longer than the plain form ever gets is the model rambling.
+  if (text.length > 1600) return "too_long";
+  if (!text.includes(input.verdictHeadline)) return "headline_missing";
+  for (const token of digestFactTokens(input.facts)) {
+    if (!text.includes(token)) return `fact_missing:${token}`;
+  }
+  if (input.redCount > 0 && CLAIMS_ALL_GREEN.test(text)) return "polarity";
+  return null;
+}
+
+const VOICE_RULES = [
+  "You are Hermes, the ops co-pilot for Averray, writing the once-daily briefing to the operator in the #Ops channel.",
+  "Rewrite the briefing below as short, warm, conversational PLAIN TEXT — a colleague catching someone up, not a report. No markdown, no headings, no bullet lists.",
+  "Hard rules, none negotiable:",
+  "- Every number and id in the briefing appears verbatim in your text. Do not round, convert, or drop any.",
+  '- Quote the line after "The board reads:" exactly once, verbatim, in double quotes.',
+  "- Never present the state as better or worse than the briefing does. If items need attention, name every one of them.",
+  "- 4 to 8 sentences. End with the briefing's own closing sense: whether anything is waiting on the operator.",
+].join("\n");
+
+export async function composeConversationalDigest(
+  input: ConversationalDigestInput,
+): Promise<ConversationalDigestResult> {
+  let reply: string | null = null;
+  try {
+    reply = await input.request({
+      messages: [
+        { role: "system", content: VOICE_RULES },
+        {
+          role: "user",
+          content: `Today's briefing, already correct and complete:\n\n${input.plain}\n\nSay it as yourself.`,
+        },
+      ],
+      maxTokens: 480,
+      temperature: 0.4,
+    });
+  } catch {
+    reply = null;
+  }
+  if (reply === null) return { text: input.plain, voice: "plain", reason: "llm_unavailable" };
+  const violation = conversationalDigestViolation(input, reply);
+  if (violation) return { text: input.plain, voice: "plain", reason: violation };
+  return { text: reply.trim(), voice: "hermes" };
+}

--- a/services/slack-operator/src/index.ts
+++ b/services/slack-operator/src/index.ts
@@ -156,7 +156,8 @@ import { decideOpsNarration, type OpsStatus } from "./ops-narration.js";
 import { publishNarration, readBuzzConfig } from "./buzz-client.js";
 import { startBuzzInbound } from "./buzz-inbound-start.js";
 import { decideProbeTransitions } from "./probe-transitions.js";
-import { buildMorningDigest, digestDue, readDigestSchedule } from "./morning-digest.js";
+import { buildMorningDigest, digestDue, digestFactStrings, readDigestSchedule } from "./morning-digest.js";
+import { composeConversationalDigest } from "./digest-voice.js";
 import { describeBuzzDelivery, recordBuzzDelivery, type BuzzDeliveryState } from "./buzz-delivery.js";
 import type { ProbeResult } from "./product-health.js";
 import { isBurnUnmeasurable, measuredGasBurn } from "./gas-burn-rate.js";
@@ -3919,27 +3920,57 @@ function startOperatorRoutines() {
         lastSentLocalDate: morningDigestSentLocalDate ?? readMorningDigestState(),
       });
       if (digestCheck.due && !(getServerAlertMuteUntilMs() > digestNowMs)) {
-        const digestText = buildMorningDigest({
+        // The SAME verdict inputs the /monitor/product-health endpoint uses —
+        // one verdict system, quoted rather than re-derived.
+        const digestVerdictHeadline = deriveOpsVerdict({
+          enabled: routineConfig.productHealth.enabled,
+          checks: productHealthHistory.length,
+          probes: result.evaluation.probes,
+          pools: productHealthSnapshotBlocks?.solvency?.pools ?? [],
+          runway: productHealthSnapshotBlocks?.solvency?.runway ?? [],
+          ...(productHealthSnapshotBlocks?.flow?.payout
+            ? { payout: productHealthSnapshotBlocks.flow.payout }
+            : {}),
+        }).headline;
+        const digestInput = {
           localDate: digestCheck.localDate,
           localTime: digestCheck.localTime,
+          weekday: digestCheck.weekday,
+          humanDate: digestCheck.humanDate,
           timeZone: morningDigestSchedule.timeZone,
           network:
             (process.env.WALLET_NETWORK ?? "").trim().toLowerCase() === "mainnet" ? "mainnet" : "testnet",
-          // The SAME verdict inputs the /monitor/product-health endpoint uses —
-          // one verdict system, quoted rather than re-derived.
-          verdictHeadline: deriveOpsVerdict({
-            enabled: routineConfig.productHealth.enabled,
-            checks: productHealthHistory.length,
-            probes: result.evaluation.probes,
-            pools: productHealthSnapshotBlocks?.solvency?.pools ?? [],
-            runway: productHealthSnapshotBlocks?.solvency?.runway ?? [],
-            ...(productHealthSnapshotBlocks?.flow?.payout
-              ? { payout: productHealthSnapshotBlocks.flow.payout }
-              : {}),
-          }).headline,
+          verdictHeadline: digestVerdictHeadline,
           probes: result.evaluation.probes,
           bankRequests: productHealthSnapshotBlocks?.bank?.lane?.requests ?? null,
-        });
+        };
+        // The plain digest is both the fallback and Hermes's source text; the
+        // gate in digest-voice guarantees his prose carries every figure, so a
+        // model outage or a paraphrase slip degrades to plain, never to wrong.
+        const digestPlain = buildMorningDigest(digestInput);
+        let digestText = digestPlain;
+        const digestLlmKey = optionalEnv("OLLAMA_API_KEY");
+        if (digestLlmKey) {
+          const composed = await composeConversationalDigest({
+            plain: digestPlain,
+            verdictHeadline: digestVerdictHeadline,
+            facts: digestFactStrings(digestInput),
+            redCount: result.evaluation.probes.filter((p) => p.status === "red").length,
+            request: (req) =>
+              requestHermesCompletion(req, {
+                apiKey: digestLlmKey,
+                baseUrl: optionalEnv("OLLAMA_BASE_URL") ?? "https://ollama.com/v1",
+                // Scheduled, not interactive — it can afford to wait for a good
+                // draft where chat replies cannot.
+                timeoutMs: 25_000,
+              }),
+          });
+          digestText = composed.text;
+          logger.info(
+            { voice: composed.voice, ...(composed.reason ? { reason: composed.reason } : {}) },
+            "morning_digest_voice",
+          );
+        }
         const digestBuzz = readBuzzConfig();
         if (!digestBuzz.config) {
           // No relay configured: the local collaboration record IS the digest.

--- a/services/slack-operator/src/morning-digest.ts
+++ b/services/slack-operator/src/morning-digest.ts
@@ -19,8 +19,17 @@
 //
 // The digest quotes the SAME strings the board renders — probe details decided
 // server-side, the shared deriveOpsVerdict headline — and composes zero
-// opinions of its own. Two verdict systems disagree eventually, and the first
+// judgments of its own. Two verdict systems disagree eventually, and the first
 // disagreement is the last time the operator believes either.
+//
+// This file writes the digest in sentences rather than caps-keyed telegraph
+// (operator feedback 2026-08-05, reading it on the phone: "more human … not
+// just some boring stats") — but "human" here is FRAMING. The opening counts
+// statuses the producers decided; the closing line maps mechanically from
+// (red, degraded, bank tone); every detail is quoted verbatim. The genuinely
+// conversational rendering — Hermes writing the same facts in his own words —
+// lives in digest-voice.ts behind a gate that falls back to this text, which
+// makes this the digest's floor: always present, never wrong.
 //
 // ── TIME IS LOCAL, AND FAIL-CLOSED ────────────────────────────────────────
 //
@@ -29,9 +38,12 @@
 // guessing — a digest at a wrong-guessed hour is the wrong-subject failure
 // wearing a clock. Late is honest: if the process was down at 08:00, the
 // digest fires on the first tick after it comes back, stamped with the time it
-// actually ran.
+// actually ran — and greetingFor() reads that stamp, so a 14:37 catch-up does
+// not open with "Good morning".
 //
 // Kept pure — no clock, no I/O — so every rule is testable without a relay.
+
+import { greetingFor, probeLabel, statusGlyph } from "./ops-voice.js";
 
 export interface DigestSchedule {
   enabled: boolean;
@@ -70,8 +82,16 @@ export function readDigestSchedule(env: NodeJS.ProcessEnv = process.env): Digest
   return { enabled: true, hour: Number(m[1]), minute: Number(m[2]), timeZone };
 }
 
-/** The local calendar date and minutes-since-midnight at `nowMs` in `timeZone`. */
-export function localStamp(nowMs: number, timeZone: string): { date: string; minutes: number; hhmm: string } {
+/**
+ * The local calendar date and minutes-since-midnight at `nowMs` in `timeZone`,
+ * plus the human forms of the same instant ("Wednesday", "6 Aug"). `date`
+ * stays strictly YYYY-MM-DD — it is the once-per-day dedupe identity and must
+ * never absorb formatting concerns.
+ */
+export function localStamp(
+  nowMs: number,
+  timeZone: string,
+): { date: string; minutes: number; hhmm: string; weekday: string; humanDate: string } {
   const fmt = new Intl.DateTimeFormat("en-CA", {
     timeZone,
     year: "numeric",
@@ -85,10 +105,14 @@ export function localStamp(nowMs: number, timeZone: string): { date: string; min
   // Intl emits "24" for midnight in some ICU versions; normalise.
   const hour = Number(parts.hour) % 24;
   const minute = Number(parts.minute);
+  const human = new Intl.DateTimeFormat("en-GB", { timeZone, weekday: "long", day: "numeric", month: "short" });
+  const humanParts = Object.fromEntries(human.formatToParts(new Date(nowMs)).map((p) => [p.type, p.value]));
   return {
     date: `${parts.year}-${parts.month}-${parts.day}`,
     minutes: hour * 60 + minute,
     hhmm: `${String(hour).padStart(2, "0")}:${String(minute).padStart(2, "0")}`,
+    weekday: humanParts.weekday ?? "",
+    humanDate: humanParts.day && humanParts.month ? `${humanParts.day} ${humanParts.month}` : "",
   };
 }
 
@@ -104,14 +128,14 @@ export function digestDue(input: {
   nowMs: number;
   schedule: DigestSchedule;
   lastSentLocalDate: string | null;
-}): { due: boolean; localDate: string; localTime: string } {
+}): { due: boolean; localDate: string; localTime: string; weekday: string; humanDate: string } {
   const { schedule } = input;
   const stamp = localStamp(input.nowMs, schedule.timeZone);
   const due =
     schedule.enabled &&
     stamp.minutes >= schedule.hour * 60 + schedule.minute &&
     input.lastSentLocalDate !== stamp.date;
-  return { due, localDate: stamp.date, localTime: stamp.hhmm };
+  return { due, localDate: stamp.date, localTime: stamp.hhmm, weekday: stamp.weekday, humanDate: stamp.humanDate };
 }
 
 /** The probe shape the digest reads — the same one the board renders. */
@@ -124,6 +148,9 @@ export interface DigestProbe {
 export interface MorningDigestInput {
   localDate: string;
   localTime: string;
+  /** Human forms of the same instant; the ISO date stands in when absent. */
+  weekday?: string;
+  humanDate?: string;
   timeZone: string;
   network: string;
   /** deriveOpsVerdict output — headline is prose FOR humans; that is this. */
@@ -134,44 +161,100 @@ export interface MorningDigestInput {
 }
 
 const DIGEST_LINE_PROBES: readonly { key: string; name: string }[] = [
-  { key: "FLOW", name: "money_path" },
-  { key: "FLOORS", name: "signer_liquidity" },
-  { key: "CREDS", name: "credential_expiry" },
+  { key: "Money", name: "money_path" },
+  { key: "Floors", name: "signer_liquidity" },
+  { key: "Credentials", name: "credential_expiry" },
 ];
 
 /**
+ * The strings whose figures are load-bearing: the daily fact lines, every
+ * not-ok detail, and the bank line. digest-voice.ts extracts its must-survive
+ * tokens from exactly this list, so "which strings may Hermes not lose" has
+ * one definition, and it lives beside the layout that renders them.
+ */
+export function digestFactStrings(input: MorningDigestInput): string[] {
+  const byName = new Map(input.probes.map((p) => [p.name, p] as const));
+  const facts: string[] = [];
+  for (const { name } of DIGEST_LINE_PROBES) {
+    const probe = byName.get(name);
+    if (probe) facts.push(probe.detail);
+  }
+  for (const probe of input.probes) {
+    if (probe.status !== "ok") facts.push(probe.detail);
+  }
+  if (input.bankRequests) facts.push(input.bankRequests.text);
+  return facts;
+}
+
+/**
  * Compose the message. Every content string is a probe's own detail or the
- * shared verdict headline — this function chooses layout and nothing else.
+ * shared verdict headline — this function chooses layout and framing words,
+ * nothing else.
  *
+ *  · The first line is the lock screen: greeting + the status count, so the
+ *    notification preview alone says whether to reach for the phone.
  *  · A probe that is absent contributes NO line. Absence is not zero, and a
- *    "FLOW —" placeholder would claim a measurement nobody took.
- *  · Probes that are not ok get quoted in full under ATTENTION, because the
- *    alert hold may have (correctly) never announced a flapping one — the
- *    digest is the once-a-day complete picture.
+ *    "Money: —" placeholder would claim a measurement nobody took.
+ *  · Probes that are not ok get quoted in full under "Needs attention" (red
+ *    first), because the alert hold may have (correctly) never announced a
+ *    flapping one — the digest is the once-a-day complete picture.
  *  · The bank line appears only when a lane exists — the same absent-is-
  *    nothing rule the board and the phone follow.
+ *  · The closing line maps mechanically from (red, degraded, bank tone): who
+ *    is waiting on the operator, said plainly. Bank tone "awaiting" is an
+ *    instrument that cannot see, not a problem — it never summons anyone.
  */
 export function buildMorningDigest(input: MorningDigestInput): string {
   const byName = new Map(input.probes.map((p) => [p.name, p] as const));
-  const ok = input.probes.filter((p) => p.status === "ok").length;
-  const red = input.probes.filter((p) => p.status === "red").length;
+  const total = input.probes.length;
+  const attention = input.probes.filter((p) => p.status !== "ok");
+  const reds = attention.filter((p) => p.status === "red").length;
 
-  const lines: string[] = [];
-  lines.push(`MORNING DIGEST · ${input.localDate} ${input.localTime} ${input.timeZone} · AVERRAY ${input.network.toUpperCase()}`);
-  lines.push(input.verdictHeadline);
-  lines.push(`PROBES ${ok} ok / ${red} red of ${input.probes.length}`);
+  const greeting = greetingFor(input.localTime);
+  const where = `Averray ${input.network}`;
+  const opener =
+    total === 0
+      ? `${greeting} — no probes reporting on ${where}.`
+      : attention.length === 0
+        ? `${greeting} — all ${total} probes green on ${where}.`
+        : `${greeting} — ${attention.length} of ${total} probe${total === 1 ? "" : "s"} need${attention.length === 1 ? "s" : ""} attention on ${where}.`;
+
+  const stamp =
+    input.weekday && input.humanDate
+      ? `${input.weekday} ${input.humanDate}, ${input.localTime} (${input.timeZone})`
+      : `${input.localDate} ${input.localTime} (${input.timeZone})`;
+
+  const lines: string[] = [opener];
+  lines.push(`${stamp}. The board reads: "${input.verdictHeadline}"`);
+  lines.push("");
 
   for (const { key, name } of DIGEST_LINE_PROBES) {
     const probe = byName.get(name);
-    if (probe) lines.push(`${key} ${probe.detail}`);
+    if (probe) lines.push(`${key}: ${probe.detail}`);
+  }
+  if (input.bankRequests) lines.push(`Bank: ${input.bankRequests.text}`);
+
+  if (attention.length > 0) {
+    const redFirst = [...attention].sort(
+      (a, b) => (a.status === "red" ? 0 : 1) - (b.status === "red" ? 0 : 1),
+    );
+    lines.push("");
+    lines.push("Needs attention:");
+    for (const probe of redFirst) {
+      lines.push(`${statusGlyph(probe.status)} ${probeLabel(probe.name)} — ${probe.detail}`);
+    }
   }
 
-  if (input.bankRequests) lines.push(`BANK ${input.bankRequests.text}`);
-
-  const attention = input.probes.filter((p) => p.status !== "ok");
-  if (attention.length > 0) {
-    lines.push("ATTENTION");
-    for (const p of attention) lines.push(`  ${p.status === "red" ? "✗" : "⚠"} ${p.name}: ${p.detail}`);
+  const bankTone = input.bankRequests?.tone;
+  const needsNow = reds + (bankTone === "red" ? 1 : 0);
+  const worthALook = attention.length - reds + (bankTone === "degraded" ? 1 : 0);
+  lines.push("");
+  if (needsNow > 0) {
+    lines.push(needsNow === 1 ? "One item needs you now." : `${needsNow} items need you now.`);
+  } else if (worthALook > 0) {
+    lines.push("Worth a look when you're at the desk — nothing is on fire.");
+  } else {
+    lines.push("Nothing is waiting on you.");
   }
 
   return lines.join("\n");

--- a/services/slack-operator/src/ops-narration.ts
+++ b/services/slack-operator/src/ops-narration.ts
@@ -13,6 +13,8 @@
 // caller (index.ts checkProductHealth) supplies prev/curr, the probes, the
 // resolved network, current mute state, and the last successful narration time.
 
+import { probeLabel } from "./ops-voice.js";
+
 export type OpsStatus = "healthy" | "degraded" | "red" | "unknown";
 export type OpsNetwork = "testnet" | "mainnet" | "unknown";
 
@@ -45,19 +47,7 @@ export interface OpsNarrationDecision {
   suppressed?: "muted" | "cooldown";
 }
 
-const PROBE_LABELS: Record<string, string> = {
-  product_api: "Product API",
-  api_latency: "API latency",
-  chain_height: "Chain height",
-  capabilities: "Capabilities",
-  signer_liquidity: "Signer liquidity",
-  treasury_liquidity: "Treasury",
-  money_path: "Money path",
-};
-
-function label(name: string): string {
-  return PROBE_LABELS[name] ?? name.replace(/_/g, " ");
-}
+// Probe naming lives in ops-voice.ts — one map for every chat surface.
 
 function trim(detail: string, max = 160): string {
   const d = detail.trim();
@@ -102,7 +92,7 @@ export function decideOpsNarration(input: DecideOpsNarrationInput): OpsNarration
     return {
       post: true,
       edge,
-      text: `⚠ Ops — ${lead ? label(lead.name) : "a probe"} red${detail}${extra}. ${tone}`,
+      text: `⚠ Ops — ${lead ? probeLabel(lead.name) : "a probe"} red${detail}${extra}. ${tone}`,
     };
   }
 

--- a/services/slack-operator/src/ops-voice.ts
+++ b/services/slack-operator/src/ops-voice.ts
@@ -1,0 +1,55 @@
+// The shared human vocabulary for everything ops pushes into chat.
+//
+// Three surfaces speak about the same probes — the morning digest, the
+// per-probe transition alerts, and the red-boundary narration — and each had
+// its own idea of what to call one (or none: `⚠ money_path: …` shipped the
+// enum straight to the operator's phone). One map, imported by all three, so a
+// probe is called the same thing everywhere and a rename is one edit.
+//
+// Prompted by the operator, 2026-08-05, the day mobile pairing put these
+// messages in his pocket: "make the status update and briefing a little bit
+// more human … not just some boring stats." The FACTS remain the producers'
+// exact strings on every surface — this module only supplies the words around
+// them, which is why it can live in the frontend of the pipeline without
+// becoming a second verdict system.
+
+export const PROBE_LABELS: Record<string, string> = {
+  product_api: "Product API",
+  api_latency: "API latency",
+  chain_height: "Chain height",
+  capabilities: "Capabilities",
+  signer_liquidity: "Signer liquidity",
+  treasury_liquidity: "Treasury",
+  money_path: "Money path",
+  credential_expiry: "Credentials",
+  external_funnel: "External funnel",
+};
+
+/** Human name for a probe; an unknown name degrades to readable, not to enum. */
+export function probeLabel(name: string): string {
+  const known = PROBE_LABELS[name];
+  if (known) return known;
+  const words = name.replace(/_/g, " ").trim();
+  return words ? words[0]!.toUpperCase() + words.slice(1) : name;
+}
+
+/** The board's severity vocabulary: red ✗, ok ✓, everything between ⚠. */
+export function statusGlyph(status: string): string {
+  if (status === "red") return "✗";
+  if (status === "ok") return "✓";
+  return "⚠";
+}
+
+/**
+ * Greeting matched to when the digest ACTUALLY fires. The schedule fires late
+ * when the process was down at the target time — that lateness is deliberate
+ * and stamped honestly, so "Good morning" at 14:37 would be the one dishonest
+ * word in an otherwise truthful message.
+ */
+export function greetingFor(hhmm: string): string {
+  const hour = Number(hhmm.slice(0, 2));
+  if (!Number.isFinite(hour)) return "Hello";
+  if (hour < 12) return "Good morning";
+  if (hour < 18) return "Good afternoon";
+  return "Good evening";
+}

--- a/services/slack-operator/src/probe-transitions.ts
+++ b/services/slack-operator/src/probe-transitions.ts
@@ -26,6 +26,7 @@
 // Kept pure — no clock, no I/O, no config — so every rule here is testable
 // without a relay or a heartbeat.
 
+import { probeLabel } from "./ops-voice.js";
 import type { ProbeResult, ProbeStatus } from "./product-health.js";
 
 export interface ProbeTransitionAlert {
@@ -134,11 +135,19 @@ export function reasonClass(probe: ProbeResult): string {
   return `${probe.name}:${probe.status}:${shape}`;
 }
 
-/** Human line for the channel. The probe's own words, prefixed so it is greppable. */
-function alertText(probe: ProbeResult, kind: "opened" | "recovered"): string {
-  return kind === "opened"
-    ? `⚠ ${probe.name}: ${probe.detail}`
-    : `✓ ${probe.name} recovered: ${probe.detail}`;
+/**
+ * Human line for the channel: the probe's human name, a plain-words verb for
+ * what changed, then the probe's own detail verbatim. The machine enum used to
+ * lead ("⚠ money_path: …") for grep-ability; operator feedback 2026-08-05 —
+ * these land on a phone now — outranked grep, and the reason-class `key`
+ * still carries the enum for anything programmatic.
+ */
+function alertText(probe: ProbeResult, kind: "opened" | "recovered", before?: ProbeStatus): string {
+  const label = probeLabel(probe.name);
+  if (kind === "recovered") return `✓ ${label} recovered — ${probe.detail}`;
+  if (probe.status === "red") return `✗ ${label} is red — ${probe.detail}`;
+  if (before === "red") return `⚠ ${label} eased to degraded — ${probe.detail}`;
+  return `⚠ ${label} degraded — ${probe.detail}`;
 }
 
 const isAlarm = (status: ProbeStatus): boolean => status === "degraded" || status === "red";
@@ -236,7 +245,7 @@ export function decideProbeTransitions(input: DecideProbeTransitionsInput): Prob
       keys.add(key);
       if (input.muted) continue;
 
-      alerts.push({ probe: probe.name, kind: "opened", from: before.status, to: probe.status, text: alertText(probe, "opened"), key });
+      alerts.push({ probe: probe.name, kind: "opened", from: before.status, to: probe.status, text: alertText(probe, "opened", before.status), key });
       continue;
     }
 

--- a/services/slack-operator/test/unit/morning-digest.test.ts
+++ b/services/slack-operator/test/unit/morning-digest.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, test } from "vitest";
 import {
   buildMorningDigest,
   digestDue,
+  digestFactStrings,
   localStamp,
   readDigestSchedule,
   type DigestProbe,
@@ -95,28 +96,40 @@ describe("the message quotes; it does not opine", () => {
     probes,
   };
 
-  test("a clean morning: header, verdict, counts, and the probes' own words", () => {
+  test("a clean morning: lock-screen opener, verdict quoted, the probes' own words", () => {
     const text = buildMorningDigest({ ...base, bankRequests: { text: "no requests in flight", tone: "ok" } });
-    expect(text).toContain("MORNING DIGEST · 2026-08-06 08:00 Europe/Zurich · AVERRAY MAINNET");
-    expect(text).toContain("money is moving and proven on-chain");
-    expect(text).toContain("PROBES 4 ok / 0 red of 4");
-    expect(text).toContain("FLOW settled24h 16 (0 stuck, 0 failed)");
-    expect(text).toContain("CREDS 3 TLS certs · no tokens watched");
-    expect(text).toContain("BANK no requests in flight");
-    expect(text).not.toContain("ATTENTION");
+    expect(text.split("\n")[0]).toBe("Good morning — all 4 probes green on Averray mainnet.");
+    expect(text).toContain('The board reads: "money is moving and proven on-chain"');
+    // No human stamp supplied → the ISO date stands in; nothing is invented.
+    expect(text).toContain("2026-08-06 08:00 (Europe/Zurich)");
+    expect(text).toContain("Money: settled24h 16 (0 stuck, 0 failed)");
+    expect(text).toContain("Credentials: 3 TLS certs · no tokens watched");
+    expect(text).toContain("Bank: no requests in flight");
+    expect(text).not.toContain("Needs attention");
+    expect(text.endsWith("Nothing is waiting on you.")).toBe(true);
+  });
+
+  test("the human stamp renders when the caller supplies it", () => {
+    const text = buildMorningDigest({ ...base, weekday: "Thursday", humanDate: "6 Aug" });
+    expect(text).toContain("Thursday 6 Aug, 08:00 (Europe/Zurich)");
+  });
+
+  test("greets by when it ACTUALLY fired — a late catch-up is not 'morning'", () => {
+    const text = buildMorningDigest({ ...base, localTime: "16:07" });
+    expect(text.startsWith("Good afternoon — ")).toBe(true);
   });
 
   test("an absent probe contributes NO line — absence is not zero", () => {
     const text = buildMorningDigest({ ...base, probes: probes.filter((p) => p.name !== "money_path") });
-    expect(text).not.toContain("FLOW");
+    expect(text).not.toContain("Money:");
   });
 
-  test("no bank lane, no BANK line — the rule every surface follows", () => {
+  test("no bank lane, no bank line — the rule every surface follows", () => {
     const text = buildMorningDigest({ ...base, bankRequests: null });
-    expect(text).not.toContain("BANK");
+    expect(text).not.toContain("Bank:");
   });
 
-  test("everything not-ok is quoted under ATTENTION — the hold may never have announced it", () => {
+  test("everything not-ok is quoted under 'Needs attention', red first — the hold may never have announced it", () => {
     const text = buildMorningDigest({
       ...base,
       probes: [
@@ -125,9 +138,64 @@ describe("the message quotes; it does not opine", () => {
         { name: "api_latency", status: "red", detail: "/health 4100ms" },
       ],
     });
-    expect(text).toContain("ATTENTION");
-    expect(text).toContain("⚠ capabilities: External posting is staged.");
-    expect(text).toContain("✗ api_latency: /health 4100ms");
-    expect(text).toContain("PROBES 4 ok / 1 red of 6");
+    expect(text.split("\n")[0]).toBe("Good morning — 2 of 6 probes need attention on Averray mainnet.");
+    expect(text).toContain("Needs attention:");
+    expect(text).toContain("⚠ Capabilities — External posting is staged.");
+    expect(text).toContain("✗ API latency — /health 4100ms");
+    expect(text.indexOf("✗ API latency")).toBeLessThan(text.indexOf("⚠ Capabilities"));
+    expect(text.endsWith("One item needs you now.")).toBe(true);
+  });
+
+  test("singular grammar when a lone probe wants eyes", () => {
+    const text = buildMorningDigest({
+      ...base,
+      probes: [{ name: "signer_liquidity", status: "degraded", detail: "gas ×1.1 — near floor" }],
+    });
+    expect(text.split("\n")[0]).toBe("Good morning — 1 of 1 probe needs attention on Averray mainnet.");
+    expect(text.endsWith("Worth a look when you're at the desk — nothing is on fire.")).toBe(true);
+  });
+
+  test("a red bank tone summons the operator even on a green board", () => {
+    const text = buildMorningDigest({
+      ...base,
+      bankRequests: { text: "1 OVERDUE — leg2-dispatched for 8.7h", tone: "red" },
+    });
+    expect(text.endsWith("One item needs you now.")).toBe(true);
+  });
+
+  test("bank tone 'awaiting' is a blind instrument, not a summons", () => {
+    const text = buildMorningDigest({
+      ...base,
+      bankRequests: { text: "aUSDC not read yet", tone: "awaiting" },
+    });
+    expect(text.endsWith("Nothing is waiting on you.")).toBe(true);
+  });
+});
+
+describe("digestDue carries the human stamp beside the dedupe date", () => {
+  test("weekday and short date come from the same instant, same zone", () => {
+    const d = digestDue({ nowMs: MORNING, schedule: enabled, lastSentLocalDate: null });
+    expect(d.weekday).toBe("Thursday");
+    expect(d.humanDate).toBe("6 Aug");
+  });
+});
+
+describe("digestFactStrings — the strings Hermes may not lose", () => {
+  test("fact lines, every not-ok detail, and the bank line", () => {
+    const facts = digestFactStrings({
+      localDate: "2026-08-06",
+      localTime: "08:00",
+      timeZone: ZURICH,
+      network: "mainnet",
+      verdictHeadline: "x",
+      probes: [
+        { name: "money_path", status: "ok", detail: "settled24h 16 (0 stuck, 0 failed)" },
+        { name: "product_api", status: "red", detail: "health check failing for 12m" },
+      ],
+      bankRequests: { text: "1 open request, staged on-chain", tone: "ok" },
+    });
+    expect(facts).toContain("settled24h 16 (0 stuck, 0 failed)");
+    expect(facts).toContain("health check failing for 12m");
+    expect(facts).toContain("1 open request, staged on-chain");
   });
 });

--- a/test/unit/digest-voice.test.ts
+++ b/test/unit/digest-voice.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  composeConversationalDigest,
+  conversationalDigestViolation,
+  digestFactTokens,
+} from "../../services/slack-operator/src/digest-voice.js";
+
+const HEADLINE = "Nominal — money moving, floors clear.";
+const FACTS = ["14 settled in 24h, backlog 0", "gas ×3.2, bank ×5.1", "request 0x9d9a staged"];
+const PLAIN = [
+  "Good morning — all 3 probes green on Averray mainnet.",
+  `The board reads: "${HEADLINE}"`,
+  "Money: 14 settled in 24h, backlog 0",
+].join("\n");
+
+const input = (over: Record<string, unknown> = {}) => ({
+  plain: PLAIN,
+  verdictHeadline: HEADLINE,
+  facts: FACTS,
+  redCount: 0,
+  ...over,
+});
+
+/** A compliant Hermes draft: every figure verbatim, headline quoted whole. */
+const GOOD =
+  `Morning! Quiet board — 14 settled in 24h with a backlog of 0, gas at 3.2× and the bank at 5.1× their floors, ` +
+  `and request 0x9d9a staged. The board reads: "${HEADLINE}" Nothing is waiting on you today.`;
+
+describe("digestFactTokens", () => {
+  it("extracts numbers and hex ids, deduped", () => {
+    const tokens = digestFactTokens(FACTS);
+    expect(tokens).toContain("14");
+    expect(tokens).toContain("3.2");
+    expect(tokens).toContain("0x9d9a");
+    expect(new Set(tokens).size).toBe(tokens.length);
+  });
+});
+
+describe("conversationalDigestViolation", () => {
+  it("passes prose that reworded the phrasing but kept every figure", () => {
+    expect(conversationalDigestViolation(input(), GOOD)).toBeNull();
+  });
+
+  it("names the missing figure — the model rounded 3.2 away", () => {
+    const rounded = GOOD.replace("3.2", "about 3");
+    expect(conversationalDigestViolation(input(), rounded)).toBe("fact_missing:3.2");
+  });
+
+  it("requires the verdict headline verbatim, not paraphrased", () => {
+    const paraphrased = GOOD.replace(HEADLINE, "everything looks nominal");
+    expect(conversationalDigestViolation(input(), paraphrased)).toBe("headline_missing");
+  });
+
+  it("refuses green words over a red board", () => {
+    const lying = `${GOOD} All clear!`;
+    expect(conversationalDigestViolation(input({ redCount: 1 }), lying)).toBe("polarity");
+  });
+
+  it("refuses empty and rambling drafts", () => {
+    expect(conversationalDigestViolation(input(), "   ")).toBe("empty");
+    expect(conversationalDigestViolation(input(), GOOD + " padding".repeat(300))).toBe("too_long");
+  });
+});
+
+describe("composeConversationalDigest", () => {
+  it("ships Hermes's words when the gate passes", async () => {
+    const r = await composeConversationalDigest({ ...input(), request: async () => GOOD });
+    expect(r.voice).toBe("hermes");
+    expect(r.text).toBe(GOOD);
+    expect(r.reason).toBeUndefined();
+  });
+
+  it("falls back to plain, with the named reason, when a figure is lost", async () => {
+    const r = await composeConversationalDigest({
+      ...input(),
+      request: async () => GOOD.replace("14", "fourteen"),
+    });
+    expect(r.voice).toBe("plain");
+    expect(r.text).toBe(PLAIN);
+    expect(r.reason).toBe("fact_missing:14");
+  });
+
+  it("falls back to plain when the model is unreachable", async () => {
+    const r = await composeConversationalDigest({ ...input(), request: async () => null });
+    expect(r).toEqual({ text: PLAIN, voice: "plain", reason: "llm_unavailable" });
+  });
+
+  it("falls back to plain when the request throws — never to a missing digest", async () => {
+    const r = await composeConversationalDigest({
+      ...input(),
+      request: async () => {
+        throw new Error("socket hangup");
+      },
+    });
+    expect(r.voice).toBe("plain");
+    expect(r.reason).toBe("llm_unavailable");
+  });
+});

--- a/test/unit/probe-transitions.test.ts
+++ b/test/unit/probe-transitions.test.ts
@@ -60,7 +60,7 @@ describe("decideProbeTransitions", () => {
     });
     expect(r.alerts).toHaveLength(1);
     expect(r.alerts[0]).toMatchObject({ probe: "external_funnel", kind: "opened", from: "ok", to: "red" });
-    expect(r.alerts[0]?.text).toBe("⚠ external_funnel: rejected 0xaa4b… slashes in 9h");
+    expect(r.alerts[0]?.text).toBe("✗ External funnel is red — rejected 0xaa4b… slashes in 9h");
   });
 
   it("does NOT repeat while the same reason class persists", () => {
@@ -110,7 +110,7 @@ describe("decideProbeTransitions", () => {
     });
     expect(r.alerts).toHaveLength(1);
     expect(r.alerts[0]).toMatchObject({ kind: "recovered", from: "red", to: "ok" });
-    expect(r.alerts[0]?.text).toBe("✓ signer_liquidity recovered: gas 5.2 DOT");
+    expect(r.alerts[0]?.text).toBe("✓ Signer liquidity recovered — gas 5.2 DOT");
   });
 
   it("does not retain recovery keys — breaking twice is two events", () => {


### PR DESCRIPTION
Operator feedback (2026-08-05, now reading #Ops on the freshly-paired phone): *"make the status update and briefing a little bit more human … not just some boring stats"* — and, on the follow-up: use the LLM that's already there.

## What changes

**One vocabulary** — `ops-voice.ts` holds the single probe-name map (plus glyphs and time-honest greetings) shared by the digest, the per-probe transition alerts, and the red-boundary narration. `⚠ money_path: …` becomes `✗ Money path is red — …`; the reason-class `key` still carries the enum for anything programmatic.

**The digest speaks sentences.** First line is the lock screen (`Good morning — all 9 probes green on Averray mainnet.` / `… 2 of 9 probes need attention …`), the verdict headline is quoted verbatim, fact lines keep the probes' exact details under human labels, attention lists red first, and a closing line maps mechanically from (red, degraded, bank tone): `Nothing is waiting on you.` / `Worth a look when you're at the desk — nothing is on fire.` / `One item needs you now.` Bank tone `awaiting` never summons anyone — a blind instrument is not a problem.

**Hermes writes the words — a gate keeps him honest.** `digest-voice.ts` hands the plain digest to `requestHermesCompletion` (the one LLM client) and validates the draft mechanically: every number and hex id from the fact strings verbatim, the headline quoted whole, no green words over a red board, length-capped. Any violation, timeout, or outage ships the plain form with a named reason in the `morning_digest_voice` log line. The briefing is never absent and never wrong — only sometimes less charming. Alarms (⚠/✗ transitions) stay template-built: a red money-path alert does not wait on a model.

## Verify
69 tests green across the touched suites (incl. new `digest-voice` + rewritten `morning-digest` coverage); `tsc -b` clean. No new env: uses the existing `OLLAMA_API_KEY`/`OLLAMA_BASE_URL`; without a key the digest simply stays plain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)