### PR TITLE
Digest closings honor the verdict contract; Hermes must name every attention item

### DIFF
--- a/services/slack-operator/src/digest-voice.ts
+++ b/services/slack-operator/src/digest-voice.ts
@@ -17,6 +17,13 @@
 // The briefing is therefore never absent and never wrong; only sometimes less
 // charming.
 //
+// RESIDUAL, NAMED: the gate is necessary, not sufficient. It cannot detect
+// framing drift that keeps every figure — invented worry over a green board,
+// soothing sentence-shapes around a named red. The controls there are the
+// prompt's hard rules, temperature 0.4, and the operator seeing voice+reason
+// in the morning_digest_voice log line. If the prose ever reads wrong, unset
+// OLLAMA_API_KEY: the digest loses charm, never truth.
+//
 // Kept pure of transport: the caller injects a `request` function (bound to
 // requestHermesCompletion, the ONE LLM client), so every rule here runs in the
 // local unit suite with a stub.
@@ -32,6 +39,12 @@ export interface ConversationalDigestInput {
   facts: readonly string[];
   /** Red probe count — a red board must never read as green. */
   redCount: number;
+  /**
+   * Human labels of every not-ok item. Each must be NAMED in the prose —
+   * a red probe whose detail happens to carry no digits ("settlement
+   * stalled") would otherwise be droppable without tripping the fact gate.
+   */
+  attentionLabels?: readonly string[];
   request: (req: HermesCompletionRequest) => Promise<string | null>;
 }
 
@@ -60,7 +73,7 @@ const CLAIMS_ALL_GREEN = /all\s+(?:\d+\s+)?probes?\s+(?:are\s+)?green|all\s+gree
 
 /** Null when the candidate may ship; otherwise the named reason it may not. */
 export function conversationalDigestViolation(
-  input: Pick<ConversationalDigestInput, "verdictHeadline" | "facts" | "redCount">,
+  input: Pick<ConversationalDigestInput, "verdictHeadline" | "facts" | "redCount" | "attentionLabels">,
   candidate: string,
 ): string | null {
   const text = candidate.trim();
@@ -70,6 +83,9 @@ export function conversationalDigestViolation(
   if (!text.includes(input.verdictHeadline)) return "headline_missing";
   for (const token of digestFactTokens(input.facts)) {
     if (!text.includes(token)) return `fact_missing:${token}`;
+  }
+  for (const label of input.attentionLabels ?? []) {
+    if (!text.toLowerCase().includes(label.toLowerCase())) return `attention_missing:${label}`;
   }
   if (input.redCount > 0 && CLAIMS_ALL_GREEN.test(text)) return "polarity";
   return null;

--- a/services/slack-operator/src/index.ts
+++ b/services/slack-operator/src/index.ts
@@ -158,6 +158,7 @@ import { startBuzzInbound } from "./buzz-inbound-start.js";
 import { decideProbeTransitions } from "./probe-transitions.js";
 import { buildMorningDigest, digestDue, digestFactStrings, readDigestSchedule } from "./morning-digest.js";
 import { composeConversationalDigest } from "./digest-voice.js";
+import { probeLabel } from "./ops-voice.js";
 import { describeBuzzDelivery, recordBuzzDelivery, type BuzzDeliveryState } from "./buzz-delivery.js";
 import type { ProbeResult } from "./product-health.js";
 import { isBurnUnmeasurable, measuredGasBurn } from "./gas-burn-rate.js";
@@ -3922,7 +3923,7 @@ function startOperatorRoutines() {
       if (digestCheck.due && !(getServerAlertMuteUntilMs() > digestNowMs)) {
         // The SAME verdict inputs the /monitor/product-health endpoint uses —
         // one verdict system, quoted rather than re-derived.
-        const digestVerdictHeadline = deriveOpsVerdict({
+        const digestVerdict = deriveOpsVerdict({
           enabled: routineConfig.productHealth.enabled,
           checks: productHealthHistory.length,
           probes: result.evaluation.probes,
@@ -3931,7 +3932,7 @@ function startOperatorRoutines() {
           ...(productHealthSnapshotBlocks?.flow?.payout
             ? { payout: productHealthSnapshotBlocks.flow.payout }
             : {}),
-        }).headline;
+        });
         const digestInput = {
           localDate: digestCheck.localDate,
           localTime: digestCheck.localTime,
@@ -3940,7 +3941,9 @@ function startOperatorRoutines() {
           timeZone: morningDigestSchedule.timeZone,
           network:
             (process.env.WALLET_NETWORK ?? "").trim().toLowerCase() === "mainnet" ? "mainnet" : "testnet",
-          verdictHeadline: digestVerdictHeadline,
+          verdictHeadline: digestVerdict.headline,
+          verdictReason: digestVerdict.reason,
+          verdictTone: digestVerdict.tone,
           probes: result.evaluation.probes,
           bankRequests: productHealthSnapshotBlocks?.bank?.lane?.requests ?? null,
         };
@@ -3953,9 +3956,17 @@ function startOperatorRoutines() {
         if (digestLlmKey) {
           const composed = await composeConversationalDigest({
             plain: digestPlain,
-            verdictHeadline: digestVerdictHeadline,
+            verdictHeadline: digestVerdict.headline,
             facts: digestFactStrings(digestInput),
             redCount: result.evaluation.probes.filter((p) => p.status === "red").length,
+            attentionLabels: [
+              ...result.evaluation.probes
+                .filter((p) => p.status !== "ok")
+                .map((p) => probeLabel(p.name)),
+              ...(digestInput.bankRequests && ["red", "degraded"].includes(digestInput.bankRequests.tone)
+                ? ["Bank"]
+                : []),
+            ],
             request: (req) =>
               requestHermesCompletion(req, {
                 apiKey: digestLlmKey,

--- a/services/slack-operator/src/morning-digest.ts
+++ b/services/slack-operator/src/morning-digest.ts
@@ -155,6 +155,17 @@ export interface MorningDigestInput {
   network: string;
   /** deriveOpsVerdict output — headline is prose FOR humans; that is this. */
   verdictHeadline: string;
+  /**
+   * The verdict CONTRACT fields beside the quotable headline. The closing
+   * line must never out-calm the verdict: floor-breach, payout-shortfall and
+   * pool-draining derive from pools and payout evidence, so they exist with
+   * every probe green — and "Nothing is waiting on you" under such a headline
+   * is exactly the contradiction the one-verdict rule forbids (found by
+   * truth-boundary review of #755). `reason` decides calm; `tone` (producer
+   * severity) decides urgency. Optional for old fixtures; absent means calm.
+   */
+  verdictReason?: string;
+  verdictTone?: string;
   probes: readonly DigestProbe[];
   /** The bank lane's server-decided requests line, when a lane exists at all. */
   bankRequests?: { text: string; tone: string } | null;
@@ -248,13 +259,25 @@ export function buildMorningDigest(input: MorningDigestInput): string {
   const bankTone = input.bankRequests?.tone;
   const needsNow = reds + (bankTone === "red" ? 1 : 0);
   const worthALook = attention.length - reds + (bankTone === "degraded" ? 1 : 0);
+  const verdictCalm = input.verdictReason === undefined || input.verdictReason === "nominal";
+  const verdictUrgent = input.verdictTone === "red";
   lines.push("");
-  if (needsNow > 0) {
+  if (verdictUrgent && needsNow === 0) {
+    // A red verdict with green probes (floor breach, payout shortfall) —
+    // the probes cannot summon the operator, so the verdict must.
+    lines.push("The verdict line above needs you now.");
+  } else if (needsNow > 0) {
     lines.push(needsNow === 1 ? "One item needs you now." : `${needsNow} items need you now.`);
   } else if (worthALook > 0) {
-    lines.push("Worth a look when you're at the desk — nothing is on fire.");
-  } else {
+    lines.push(
+      verdictCalm
+        ? "Worth a look when you're at the desk — nothing is on fire."
+        : "Worth a look when you're at the desk — and read the verdict line above.",
+    );
+  } else if (verdictCalm) {
     lines.push("Nothing is waiting on you.");
+  } else {
+    lines.push("The probes are green, but the verdict line above is the one to read.");
   }
 
   return lines.join("\n");

--- a/services/slack-operator/test/unit/morning-digest.test.ts
+++ b/services/slack-operator/test/unit/morning-digest.test.ts
@@ -163,6 +163,34 @@ describe("the message quotes; it does not opine", () => {
     expect(text.endsWith("One item needs you now.")).toBe(true);
   });
 
+  test("the closing never out-calms the verdict — red verdict on green probes summons", () => {
+    // floor-breach / payout-shortfall derive from pools and payout evidence,
+    // not probes: every probe green and the verdict red is a REAL state.
+    const text = buildMorningDigest({ ...base, verdictReason: "floor-breach", verdictTone: "red" });
+    expect(text.split("\n")[0]).toBe("Good morning — all 4 probes green on Averray mainnet.");
+    expect(text.endsWith("The verdict line above needs you now.")).toBe(true);
+  });
+
+  test("non-nominal, non-red verdict on green probes points at the verdict", () => {
+    const text = buildMorningDigest({ ...base, verdictReason: "pool-draining", verdictTone: "degraded" });
+    expect(text.endsWith("The probes are green, but the verdict line above is the one to read.")).toBe(true);
+  });
+
+  test("'nothing is on fire' is only said when the verdict agrees", () => {
+    const text = buildMorningDigest({
+      ...base,
+      verdictReason: "pool-draining",
+      verdictTone: "degraded",
+      probes: [...probes, { name: "capabilities", status: "degraded", detail: "x staged" }],
+    });
+    expect(text.endsWith("Worth a look when you're at the desk — and read the verdict line above.")).toBe(true);
+  });
+
+  test("a nominal verdict keeps the calm closings", () => {
+    const text = buildMorningDigest({ ...base, verdictReason: "nominal", verdictTone: "ok" });
+    expect(text.endsWith("Nothing is waiting on you.")).toBe(true);
+  });
+
   test("bank tone 'awaiting' is a blind instrument, not a summons", () => {
     const text = buildMorningDigest({
       ...base,

--- a/test/unit/digest-voice.test.ts
+++ b/test/unit/digest-voice.test.ts
@@ -57,6 +57,21 @@ describe("conversationalDigestViolation", () => {
     expect(conversationalDigestViolation(input({ redCount: 1 }), lying)).toBe("polarity");
   });
 
+  it("requires every attention item to be NAMED — numbers or not", () => {
+    // A red probe whose detail carries no digits would otherwise be droppable
+    // without tripping the fact gate.
+    const v = conversationalDigestViolation(input({ attentionLabels: ["Product API"] }), GOOD);
+    expect(v).toBe("attention_missing:Product API");
+  });
+
+  it("accepts the attention name case-insensitively inside flowing prose", () => {
+    const v = conversationalDigestViolation(
+      input({ attentionLabels: ["Product API"] }),
+      `${GOOD} Meanwhile the product API needs eyes.`,
+    );
+    expect(v).toBeNull();
+  });
+
   it("refuses empty and rambling drafts", () => {
     expect(conversationalDigestViolation(input(), "   ")).toBe("empty");
     expect(conversationalDigestViolation(input(), GOOD + " padding".repeat(300))).toBe("too_long");


### PR DESCRIPTION
Truth-boundary review of #755 (run per the house rule before calling a monitoring change done) found two real holes; both fixed here, 75 tests green.

**1. The closing could out-calm the verdict.** `floor-breach`, `payout-shortfall`, and `pool-draining` derive from pools and payout evidence, not probes — so *all probes green + verdict red* is a real, enumerable state, and the digest would have ended it with "Nothing is waiting on you." directly under a headline saying otherwise. The closing now reads the verdict **contract** fields (`reason` decides calm, `tone` decides urgency — per [ops-verdict.ts:75](https://github.com/depre-dev/averray-reference-agent/blob/main/packages/schemas/src/ops-verdict.ts): "headline is prose … `reason` is the contract"):

- red-tone verdict, green probes → `The verdict line above needs you now.`
- non-nominal verdict → "nothing is on fire" and "Nothing is waiting on you" are forfeited; the digest points at the verdict line instead.

**2. A digit-free red item was droppable from Hermes prose.** The gate required every number verbatim — "settlement stalled" has none, so Hermes could omit it entirely and still pass. Every not-ok item's human label must now appear in the prose (case-insensitive), else `attention_missing:<label>` falls back to plain.

**Named residual (accepted, documented in digest-voice.ts):** framing drift that keeps every figure — invented worry over a green board, soothing shapes around a named red — is not mechanically detectable. Controls: the prompt's hard rules, temperature 0.4, the logged `voice`+`reason`, and the kill switch (unset `OLLAMA_API_KEY` → plain forever, charm lost, truth kept).

🤖 Generated with [Claude Code](https://claude.com/claude-code)