### PR TITLE
docs(burnin): say where the battery runs — local only, never the VPS

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,6 +71,10 @@ The operator-run §9.1 burn-in battery reuses that same supervised machinery via
 `node scripts/ceremony/run-burnin-batch.mjs --evidence <dir>`. The evidence path
 is mandatory; eligible runs and the non-counting red sentinel append to
 `LEDGER.jsonl`, while `burnin-status.mjs` regenerates the measured summary.
+Run it on a LOCAL machine only — never on the VPS. The battery stands up the
+same disposable ceremony infrastructure as the INT-2 suite, and the standing
+rule since the first failed ceremony is that this never runs beside production;
+the VPS dispatch profile stays dormant.
 
 If you touched `ops/`, the `Dockerfile`, or compose files, also validate what CI validates:
 

--- a/docs/HARNESS_BURNIN_BATTERY_WORK_ORDER.md
+++ b/docs/HARNESS_BURNIN_BATTERY_WORK_ORDER.md
@@ -147,6 +147,15 @@ for now; automation is a later decision).
    ledger-backed, incident-free items — not 14 days since someone remembers
    starting.
 
+### Where it runs
+
+**Local machine only, never the VPS.** The battery reuses the INT-2 ceremony
+machinery — disposable databases, pinned kernel, pilot image — and the standing
+rule since the first failed ceremony (plan F1) is that this infrastructure never
+stands beside production. The VPS host does not even carry node; that is not an
+installation gap to fix, it is the boundary working. *(Added 2026-08-05 after
+the first attempted batch was pointed at the VPS.)*
+
 ### Operator note
 
 Your only recurring action is one command per batch. The first batch's evidence


### PR DESCRIPTION
The first attempted batch was pointed at the production VPS and failed on a missing `node` — which is the boundary working, not an installation gap. The local-only rule has been standing since the first failed ceremony (plan F1: ceremony infrastructure never beside production), but nothing near the battery docs said so. Now AGENTS.md and the work order both do.

🤖 Generated with [Claude Code](https://claude.com/claude-code)