### PR TITLE
Colleague register for inbound Hermes answers

### DIFF
--- a/services/slack-operator/src/buzz-inbound.ts
+++ b/services/slack-operator/src/buzz-inbound.ts
@@ -214,6 +214,7 @@ export const INBOUND_PREAMBLE = [
   "- `averray_ops_health` answers a DIFFERENT question: database and control-plane health read from Postgres. It is not the board and not the product verdict. Do not use it to say whether Averray is ok, and never describe something as \"the board\" unless it came from `averray_board_health`.",
   "- If the board cannot be reached, say the state is UNKNOWN. Never infer health from silence.",
   "- Answer the question. Do not take actions, move funds, deploy, or change configuration; you cannot, and claiming otherwise is worse than declining.",
+  "- Write like a colleague, not a readout: plain conversational sentences, lead with the answer. Keep every figure, id and probe detail verbatim — reword the words AROUND the facts, never the facts, and never present the state as better or worse than the board says.",
   "- Keep it short — a few lines. This is read in a chat client, often on a phone.",
   "",
   "The operator asks:",

--- a/test/unit/buzz-inbound.test.ts
+++ b/test/unit/buzz-inbound.test.ts
@@ -199,6 +199,16 @@ describe("the prompt", () => {
   it("forbids taking action", () => {
     expect(buildInboundPrompt("x").toLowerCase()).toContain("do not take actions");
   });
+
+  it("sets the colleague register without loosening the facts", () => {
+    // Operator feedback 2026-08-05: answers read like a readout ("Board
+    // verdict: nominal. All 9 probes green…"). The register rule and the
+    // facts rule travel in the same sentence so neither is quotable alone.
+    const prompt = buildInboundPrompt("x");
+    expect(prompt).toContain("like a colleague, not a readout");
+    expect(prompt).toContain("never the facts");
+    expect(prompt).toContain("never present the state as better or worse");
+  });
 });
 
 describe("formatting the reply", () => {


### PR DESCRIPTION
Live check after #755 deployed: `hermes whats up` in #Ops still answered in readout style — the inbound listener has its own preamble (`INBOUND_PREAMBLE`, buzz-inbound.ts) and the digest voice never touched it.

One rule added to the preamble, register and truth in the same sentence so neither travels alone: *write like a colleague, not a readout; lead with the answer; keep every figure, id and probe detail verbatim — reword the words around the facts, never the facts, and never present the state as better or worse than the board says.* The tool-routing rules (`averray_board_health` / `verdict.reason` / UNKNOWN / no-actions) are untouched, and the answers were already LLM-written so no new gate is needed — this only sets the voice.

Test added asserting the register rule is present and inseparable from the facts rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)