### PR TITLE
Close Hermes's paid auxiliary lane structurally

### DIFF
--- a/hermes/config/hermes.yaml
+++ b/hermes/config/hermes.yaml
@@ -6,10 +6,35 @@ model:
   api_key_env: OLLAMA_API_KEY
   default: glm-5.2:cloud
 
-# Pin v0.18's post-turn background-review fork to our own provider. Left unset
-# it defaults to "auto" and falls through the auxiliary chain to OpenRouter →
-# Nous Portal (no credit) → repeated credit-error log spam. Same model as above.
+# ── AUXILIARY SPEND CONTROL ────────────────────────────────────────────────
+# v0.20.0's auxiliary client serves ~30 internal callers (title_generator,
+# insights, conversation_compression, curator, cron classifiers, …) and falls
+# back through OpenRouter with a PAID default model (google/gemini-3.6-flash).
+# Observed live on the gateway through 2026-08-06: "PAID lane engaged … may
+# incur real spend", then "payment / credit error" on every attempt — an
+# unfunded paid lane that only spams today and would silently start billing
+# the day the OpenRouter account gains credit. Per-task pins do not scale:
+# the background_review pin below predates most of those callers, which is
+# exactly how this leak appeared. So the lane is closed structurally:
+#
+#   free_only: true   → the client SKIPS any OpenRouter fallback whose model
+#                       is not a :free SKU (auxiliary_client.py logs the skip
+#                       once instead of engaging).
+#   openrouter_model  → pinned to the PAID default ON PURPOSE. Combined with
+#                       free_only the OpenRouter fallback is unsatisfiable
+#                       even if a future version ships a :free default —
+#                       keeping aux content (channel text, board data) off
+#                       third-party free tiers, whose terms may allow
+#                       training on inputs.
+#
+# Aux tasks still ride ollama-cloud like everything else; when that hiccups
+# they now fail a convenience instead of paying a stranger.
+# test/unit/hermes-config.test.ts enforces this pair.
 auxiliary:
+  free_only: true
+  openrouter_model: google/gemini-3.6-flash
+  # v0.18's post-turn background-review fork, pinned to our own provider.
+  # Left unset it defaults to "auto" and falls through the auxiliary chain.
   background_review:
     provider: ollama-cloud
     model: glm-5.2:cloud

--- a/services/slack-operator/test/unit/hermes-config.test.ts
+++ b/services/slack-operator/test/unit/hermes-config.test.ts
@@ -73,4 +73,17 @@ describe("the pieces that must not silently diverge", () => {
     expect(config.auxiliary?.background_review?.provider).toBe(config.model?.provider);
     expect(config.auxiliary?.background_review?.model).toBe(config.model?.default);
   });
+
+  test("the OpenRouter auxiliary fallback is structurally unsatisfiable", () => {
+    // The pair is the control, not either key alone: free_only makes the
+    // client skip any non-:free fallback, and the pinned model is DELIBERATELY
+    // the paid default so a future upstream :free default cannot re-open the
+    // lane and route aux content (channel text, board data) to a third-party
+    // free tier. Observed live before this: "PAID lane engaged" +
+    // "payment / credit error" on the gateway, 2026-08-04 → 06.
+    expect(config.auxiliary?.free_only).toBe(true);
+    const pinned = String(config.auxiliary?.openrouter_model ?? "");
+    expect(pinned.length).toBeGreaterThan(0);
+    expect(pinned.endsWith(":free")).toBe(false);
+  });
 });


### PR DESCRIPTION
Improvement #1 from this morning's queue — the one quietly set up to bill.

**Evidence (live gateway, 2026-08-04→06):** `PAID lane engaged for auxiliary task — OpenRouter fallback model 'google/gemini-3.6-flash' is not a :free SKU and may incur real spend`, followed by `payment / credit error` on every attempt. Today it only spams (the OpenRouter account has no credit); the day it gains credit, it bills silently.

**Why not another per-task pin:** the auxiliary client has ~30 callers (`title_generator`, `insights`, `conversation_compression`, `curator`, cron classifiers…). `background_review` was pinned in v0.18 and the leak simply arrived through a caller that didn't exist yet — per-task pinning is structurally losing.

**The fix, using upstream's own controls (`agent/auxiliary_client.py`):**
- `auxiliary.free_only: true` — any non-`:free` OpenRouter fallback is skipped, logged once, never called.
- `auxiliary.openrouter_model: google/gemini-3.6-flash` — pinned to the **paid** default *on purpose*: combined with `free_only` the fallback is permanently unsatisfiable, even if a future Hermes ships a `:free` default — which would otherwise route aux content (channel text, board data) to a third-party free tier whose terms may allow training on inputs.

Aux tasks still ride ollama-cloud; when that hiccups they fail a convenience instead of paying a stranger. Guard test enforces the pair (7/7 green).

**Apply:** config is bind-mounted read-only into both Hermes containers — merge, `git pull`, `docker restart avg-hermes-1 avg-hermes-gateway-1`, then verify the mounted file carries `free_only`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)