### PR TITLE
docs(int4b): amend D0 — the projection class was never silent; my premise was wrong

### DIFF
--- a/docs/HARNESS_INT4B_QUARANTINE_WORK_ORDER.md
+++ b/docs/HARNESS_INT4B_QUARANTINE_WORK_ORDER.md
@@ -15,11 +15,21 @@
 Three silences, each demonstrated against current `main` before building, each
 seeding a ledger row:
 
-1. **Poison read.** Tamper a bound run's stored state in a disposable Harness DB
-   so projection fails validation. Record that reconciliation retries it every
-   cycle, forever — `unhealthyCount` steady, no escalation, no quarantine, the
-   same log line each loop. (The `awaiting_manifest` loop watched during the
-   first send is the benign cousin; the drill needs the malformed one.)
+1. **Poison read.** *(Amended 2026-08-06, seventh stop — my premise was wrong
+   for one of two failure classes, found by recording against exact main.)*
+   There are two classes and only one is silent:
+   - **Read failures** (`HarnessReadError` before projection — malformed status,
+     store read errors): these DO retry every cycle forever, `unhealthyCount`
+     steady, no escalation, no quarantine. The silence is real; record it with
+     the liveness proof. D1 quarantines this class.
+   - **Projection/containment failures** are ALREADY fail-closed on main
+     (`reconcile-run.ts:443-471`): a terminal projection with no resolvable
+     outcome refuses with a critical `terminal_projection_unresolved`; anything
+     else force-cancels with `lifecycle: "blocked"` and a critical
+     `containment_expansion` alert. Not silent, not looping, already parked for
+     operator review. No D1 change applies; recording a "silence" here would be
+     false. One nit filed separately: plain data corruption receives the
+     authority-expansion message, which overstates what happened.
 2. **Conflicting binding.** In a disposable reference DB, tamper a binding row so
    `harness_run_id` no longer equals the hash-derived intended run id. Record
    that nothing anywhere notices.


### PR DESCRIPTION
Seventh stop, and the wall was in my work order's premise — found the only way it could be: by recording the D0 silence against exact `main` with a liveness proof, and watching the "silence" refuse to happen.

## What main actually does

`reconcile-run.ts:443-471`, verified in source:

- terminal projection, unresolvable outcome → `refuseTask`, **critical** `terminal_projection_unresolved`, stopped for operator review (the #554 fix)
- any other projection/containment failure → `forceCancelTask` with **`lifecycle: "blocked"`** and a **critical** `containment_expansion` alert

Not silent. Not looping. Already parked. My order told the implementer to record a silence that does not exist for this class, and they blocked the PR rather than record it falsely.

## What was genuinely silent — and now isn't

**Read failures** (`HarnessReadError` before projection): retried every cycle forever, `unhealthyCount` steady, zero alerts, zero escalation — proven with advancing-heartbeat liveness on exact main. That class is what D1's quarantine covers, and the packet as built needs no change.

## The one real blemish, filed separately

Plain data corruption lands in the same catch as authority expansion and receives its message: *"Harness projection exceeded the approved task authority"* — an overstatement when nothing exceeded anything. A small honest-labeling fix, its own issue, not smuggled here.

Merge order: this amendment → then #762 (unblocked against the amended order) and kernel #36 (independent, complete).

Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)