### PR TITLE
docs(int4c): record D0 and blocked mutation proof

### DIFF
--- a/docs/evidence/INT4C_D0_PARTIAL_2026-08-06.md
+++ b/docs/evidence/INT4C_D0_PARTIAL_2026-08-06.md
@@ -1,0 +1,54 @@
+# INT-4c D0 partial baseline — stopped 2026-08-06
+
+This was the required pre-implementation D0 run against exact unmodified main
+`4164549b146ec87e57d093a926588ea82e17b3e6`. It used one uniquely named,
+throwaway local Postgres 16 container. No production database, production
+Compose profile, credential, kernel checkout, or external service was used.
+
+The run established two of the required baselines:
+
+```text
+INT4C_D0_MAIN_SHA=4164549b146ec87e57d093a926588ea82e17b3e6
+INT4C_D0_DATABASE_LIVE container=int4c-d0-80007-1786007429501
+INT4C_D0_SILENCE orphaned_claim lifecycle=dispatching claim_lease=null run_reads=3 alerts=0 heartbeats=1,2,2,3,3
+INT4C_D0_SILENCE backpressure active_bound=1 queued_attempt=dispatched named_refusal=false operator_signal=false alerts=0
+```
+
+The orphaned-claim probe used a newly constructed dispatcher process over the
+persisted task and claim. Three completed reconciliation reads and heartbeat
+cycles prove the restarted loop was live while the claim remained without an
+expiry, alert, binding, or lifecycle change. The duplicated heartbeat cycle
+numbers are the process's normal start/end heartbeat pair, not repeated work.
+
+The backpressure probe stored one non-terminal bound task, then presented a
+second approved task. Exact main dispatched the second task and emitted neither
+a decision reason nor an alert named `backpressure`.
+
+## Required global-lease proof did not complete
+
+The two-child-process probe failed before it could establish its required
+starting condition:
+
+```text
+× records dead-holder takeover and the live-holder negative with two processes 5321ms
+  → INT4C_D0 lease holder d0-holder was not observed
+
+Error: INT4C_D0 lease holder d0-holder was not observed
+ ❯ waitForHolder test/integration/int4c-d0-baseline.test.ts:450:9
+ ❯ test/integration/int4c-d0-baseline.test.ts:202:7
+
+Test Files  1 failed (1)
+Tests  1 failed | 2 passed (3)
+```
+
+Cause: the probe spawned the holder and contender concurrently, so the
+contender could acquire the empty global lease before the intended holder's
+identity was observed. This is a probe ordering race; it is not evidence for or
+against the production lease mechanism.
+
+The probe was corrected locally to wait until `d0-holder` was visible in
+`dispatch_lease` before spawning `d0-contender`. It was not rerun: the packet's
+standing one-attempt/stop-on-failure rule prohibited treating a repaired probe
+as the original D0 attempt. No D1–D7 implementation was started. The global
+dead-holder takeover and live-holder negative therefore remain unproven by this
+packet.

--- a/docs/evidence/INT4C_D0_PARTIAL_2026-08-06.md
+++ b/docs/evidence/INT4C_D0_PARTIAL_2026-08-06.md
@@ -24,6 +24,11 @@ The backpressure probe stored one non-terminal bound task, then presented a
 second approved task. Exact main dispatched the second task and emitted neither
 a decision reason nor an alert named `backpressure`.
 
+`active_bound=1` describes the probe's intended occupancy, not a pre-existing
+dispatcher limit. Exact main has no in-flight bound at any level; D2 will
+introduce the bound rather than name an existing one. The eventual drill-ledger
+row must preserve that distinction.
+
 ## Required global-lease proof did not complete
 
 The two-child-process probe failed before it could establish its required
@@ -46,9 +51,27 @@ contender could acquire the empty global lease before the intended holder's
 identity was observed. This is a probe ordering race; it is not evidence for or
 against the production lease mechanism.
 
-The probe was corrected locally to wait until `d0-holder` was visible in
-`dispatch_lease` before spawning `d0-contender`. It was not rerun: the packet's
-standing one-attempt/stop-on-failure rule prohibited treating a repaired probe
-as the original D0 attempt. No D1–D7 implementation was started. The global
-dead-holder takeover and live-holder negative therefore remain unproven by this
-packet.
+The probe was corrected to wait until `d0-holder` was visible in
+`dispatch_lease` before spawning `d0-contender`. The correction was committed as
+`5b0f570ca6ed8df63d2e979645138b6b9e405561` before execution.
+
+## Adjudicated corrected-instrument run
+
+The operator classified the concurrent-start race as an instrument defect and
+authorized one run of only the corrected two-process baseline. The two other D0
+cases were skipped rather than rerun:
+
+```text
+INT4C_D0_MAIN_SHA=4164549b146ec87e57d093a926588ea82e17b3e6
+INT4C_D0_PROBE_SHA=5b0f570ca6ed8df63d2e979645138b6b9e405561
+INT4C_D0_DATABASE_LIVE container=int4c-d0-86634-1786008850803
+INT4C_D0_LEASE_LIVE holder=d0-holder contender=d0-contender ttl_windows=3 contender_acquired=false holder_pid=86760 contender_pid=86767
+INT4C_D0_LEASE_TAKEOVER dead_holder=d0-holder new_holder=d0-contender fired=true identities_visible=d0-holder,d0-contender
+Test Files  1 passed (1)
+Tests  1 passed | 2 skipped (3)
+```
+
+This proves both halves of the corrected inventory on exact main: a renewing
+holder is not stolen from across three TTL windows, and the existing global
+lease is acquired by the second real process after the dead holder's expiry.
+No D1–D7 implementation had begun when either D0 run was recorded.

--- a/docs/evidence/INT4C_FRESH_UUID_CONTRADICTION_2026-08-06.md
+++ b/docs/evidence/INT4C_FRESH_UUID_CONTRADICTION_2026-08-06.md
@@ -1,0 +1,45 @@
+# INT-4c fresh-UUID mutation contradiction — stopped 2026-08-06
+
+Implementation stopped while designing D4's Harness-store proof. The work
+order requires both of these conditions in the same takeover drill:
+
+1. The holder crashes at `after-claim-before-submit`.
+2. Mutating the retry to mint a fresh UUID produces two runs in the Harness
+   store.
+
+Those conditions are mutually exclusive. At the named crash point the first
+process has not submitted a run, so the Harness store contains zero runs. The
+takeover retry then submits once. With the correct derived ID the store contains
+one run; with a fresh UUID it also contains one run. The UUID differs, but the
+required failure signature (two stored runs) cannot occur.
+
+This is not a kernel-idempotency finding. It follows from the ordered side
+effects required by the work order:
+
+```text
+claim persisted -> injected crash -> no Harness submission -> zero runs
+takeover -> one Harness submission -> one run
+```
+
+The mutation can become load-bearing in either of two coherent ways:
+
+- apply it to the existing restart-resume drill, whose first process is killed
+  after submit and therefore leaves one Harness run before the retry; or
+- authorize an additional `after-submit-before-binding` crash point and use
+  that point for the fresh-UUID mutation.
+
+In both cases a correct replay converges on the existing run while the mutated
+fresh UUID creates a second run. Choosing between those designs changes the D4
+mapping/fault-injection scope and therefore remains an operator/architect
+decision.
+
+No acceptance check was weakened, and the mutation was not changed to inspect
+dispatcher intentions or logs. All incomplete D1–D7 source edits were removed
+before this evidence commit so the branch contains only the reproducible D0
+probe/evidence and this stop record.
+
+The resume prompt says `docs/CODEX_HANDOFF_PROTOCOL.md` now codifies the
+one-attempt instrument-defect rule. The fetched exact-main checkout at
+`4164549b146ec87e57d093a926588ea82e17b3e6` does not yet contain that section;
+the prompt's explicit adjudication was nevertheless followed for the corrected
+D0 rerun.

--- a/scripts/ceremony/run-int4c-d0.mjs
+++ b/scripts/ceremony/run-int4c-d0.mjs
@@ -1,0 +1,73 @@
+import { spawnSync } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+const container = `int4c-d0-${process.pid}-${Date.now()}`;
+const leaseOnly = process.argv.includes("--lease-only");
+
+try {
+  const started = docker([
+    "run", "--detach", "--name", container,
+    "--publish", "127.0.0.1::5432",
+    "--env", "POSTGRES_PASSWORD=int4c-local",
+    "--env", "POSTGRES_DB=reference_int4c",
+    "postgres:16-alpine",
+  ]);
+  if (started.status !== 0) throw new Error("INT4C_D0_DATABASE_START_FAILED");
+  waitForDatabase();
+  const port = publishedPort();
+  console.info(`INT4C_D0_MAIN_SHA=${git(["merge-base", "HEAD", "origin/main"]).stdout.trim()}`);
+  console.info(`INT4C_D0_PROBE_SHA=${git(["rev-parse", "HEAD"]).stdout.trim()}`);
+  console.info(`INT4C_D0_DATABASE_LIVE container=${container}`);
+  const args = [
+    "vitest", "run", "test/integration/int4c-d0-baseline.test.ts", "--reporter=verbose",
+    ...(leaseOnly
+      ? ["-t", "records dead-holder takeover and the live-holder negative with two processes"]
+      : []),
+  ];
+  const result = spawnSync("npx", args, {
+    cwd: root,
+    env: {
+      ...process.env,
+      INT4C_REFERENCE_DATABASE_URL:
+        `postgresql://postgres:int4c-local@127.0.0.1:${port}/reference_int4c`,
+    },
+    encoding: "utf8",
+  });
+  process.stdout.write(result.stdout ?? "");
+  process.stderr.write(result.stderr ?? "");
+  process.exitCode = result.status ?? 1;
+} finally {
+  docker(["rm", "--force", container], true);
+}
+
+function waitForDatabase() {
+  for (let attempt = 1; attempt <= 60; attempt += 1) {
+    const result = docker([
+      "exec", "--env", "PGPASSWORD=int4c-local", container,
+      "psql", "-h", "127.0.0.1", "-U", "postgres", "-d", "reference_int4c",
+      "-Atqc", "select 1",
+    ], true);
+    if (result.status === 0 && result.stdout.trim() === "1") return;
+    spawnSync("sleep", ["1"]);
+  }
+  throw new Error("INT4C_D0_DATABASE_NEVER_READY");
+}
+
+function publishedPort() {
+  const result = docker(["port", container, "5432/tcp"]);
+  const match = /:(\d+)\s*$/u.exec(result.stdout);
+  if (!match?.[1]) throw new Error("INT4C_D0_DATABASE_PORT_MISSING");
+  return match[1];
+}
+
+function docker(args, allowFailure = false) {
+  const result = spawnSync("docker", args, { cwd: root, encoding: "utf8" });
+  if (!allowFailure && result.status !== 0) process.stderr.write(result.stderr ?? "");
+  return result;
+}
+
+function git(args) {
+  return spawnSync("git", args, { cwd: root, encoding: "utf8" });
+}

--- a/test/fixtures/agent-integration/int4c-d0-lease-process.mjs
+++ b/test/fixtures/agent-integration/int4c-d0-lease-process.mjs
@@ -1,0 +1,41 @@
+import process from "node:process";
+import { setTimeout as delay } from "node:timers/promises";
+
+import {
+  acquireDispatchLease,
+  renewDispatchLease,
+} from "../../../packages/averray-mcp/dist/dispatch-claim.js";
+import { closePool } from "../../../packages/mcp-common/dist/index.js";
+
+const holder = process.argv[2];
+const mode = process.argv[3];
+const ttlSeconds = Number(process.argv[4] ?? "1");
+
+if (!holder || !["renew", "contend"].includes(mode)) {
+  throw new Error("usage: int4c-d0-lease-process.mjs <holder> <renew|contend> <ttl-seconds>");
+}
+
+let stopped = false;
+process.once("SIGTERM", () => {
+  stopped = true;
+});
+
+try {
+  while (!stopped) {
+    const acquired = await acquireDispatchLease({ holder, ttlSeconds });
+    process.stdout.write(`INT4C_D0_LEASE_ATTEMPT holder=${holder} acquired=${acquired}\n`);
+    if (acquired) {
+      while (!stopped) {
+        await delay(200);
+        if (stopped) break;
+        const renewed = await renewDispatchLease({ holder, ttlSeconds });
+        process.stdout.write(`INT4C_D0_LEASE_RENEW holder=${holder} renewed=${renewed}\n`);
+        if (!renewed) break;
+      }
+    } else {
+      await delay(200);
+    }
+  }
+} finally {
+  await closePool();
+}

--- a/test/integration/int4c-d0-baseline.test.ts
+++ b/test/integration/int4c-d0-baseline.test.ts
@@ -1,0 +1,462 @@
+import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
+import { readFile } from "node:fs/promises";
+import { setTimeout as delay } from "node:timers/promises";
+
+import {
+  agentTaskV1Schema,
+  hashAgentTaskApprovalPayload,
+  type AgentTaskV1,
+  type PilotProfileManifest,
+} from "@avg/schemas";
+import { Pool } from "pg";
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+
+import {
+  listAgentTasks,
+  listDispatchableAgentTasks,
+  putAgentTask,
+} from "../../packages/averray-mcp/src/agent-task-store.js";
+import {
+  acquireDispatchLease,
+  claimDispatch,
+  deriveIntendedRunId,
+  getDispatchClaim,
+  releaseDispatchLease,
+  renewDispatchLease,
+} from "../../packages/averray-mcp/src/dispatch-claim.js";
+import {
+  getActiveDispatchQuarantine,
+  listRunBindingAuditRows,
+  markDispatchQuarantine,
+} from "../../packages/averray-mcp/src/dispatch-quarantine.js";
+import { HarnessReadError } from "../../packages/averray-mcp/src/harness-read-port.js";
+import {
+  bindRunToWorkItem,
+  getRunBinding,
+} from "../../packages/averray-mcp/src/run-binding-outbox.js";
+import { buildTaskIntentArtifact } from "../../packages/averray-mcp/src/task-intent-mapping.js";
+import { workspacePathForTask } from "../../packages/averray-mcp/src/workspace-path.js";
+import {
+  createDispatcherProcess,
+  type DispatcherHeartbeat,
+} from "../../services/harness-dispatcher/src/index.js";
+import {
+  runSingleDispatch,
+  type DispatchDeps,
+} from "../../services/harness-dispatcher/src/dispatch-attempt.js";
+import {
+  createPoisonFailureTracker,
+  reconcileDispatchedRuns,
+  type ReconcileRunDeps,
+} from "../../services/harness-dispatcher/src/reconcile-run.js";
+
+const DATABASE_URL = process.env.INT4C_REFERENCE_DATABASE_URL?.trim();
+const RUN = DATABASE_URL ? describe : describe.skip;
+const NOW = new Date("2026-08-06T12:00:00.000Z");
+const OLD = "2026-08-06T10:00:00.000Z";
+const DEADLINE = "2026-08-07T12:00:00.000Z";
+const PLACEHOLDER_HASH = `sha256:${"f".repeat(64)}`;
+const CAPABILITIES: PilotProfileManifest["capabilities"] = [
+  { id: "fs.read_file", effectClass: "none", delegable: false },
+  { id: "fs.write_file", effectClass: "local", delegable: false },
+  { id: "fs.list_files", effectClass: "none", delegable: false },
+  { id: "shell.run", effectClass: "local", delegable: false },
+  { id: "git.status", effectClass: "none", delegable: false },
+  { id: "git.diff", effectClass: "none", delegable: false },
+  { id: "artifact.put", effectClass: "local", delegable: false },
+  { id: "artifact.get", effectClass: "none", delegable: false },
+];
+
+let pool: Pool;
+let fixture: AgentTaskV1;
+
+RUN("INT-4c exact-main D0", () => {
+  beforeAll(async () => {
+    pool = new Pool({ connectionString: DATABASE_URL });
+    fixture = agentTaskV1Schema.parse(JSON.parse(await readFile(
+      new URL("../fixtures/agent-integration/agent-task-v1.json", import.meta.url),
+      "utf8",
+    )));
+    for (const migration of [
+      "001_init.sql",
+      "002_agent_tasks.sql",
+      "003_dispatch_claims_outbox_decisions.sql",
+      "004_dispatch_quarantines.sql",
+    ]) {
+      await pool.query(await readFile(
+        new URL(`../../ops/migrations/${migration}`, import.meta.url),
+        "utf8",
+      ));
+    }
+  });
+
+  beforeEach(async () => {
+    await pool.query(`
+      truncate table
+        hermes_decision_records,
+        agent_task_dispatch_quarantines,
+        agent_task_run_outbox,
+        agent_task_dispatch_claims,
+        agent_tasks,
+        dispatch_lease
+    `);
+  });
+
+  afterAll(async () => {
+    await pool?.end();
+  });
+
+  it("records the orphaned claim silence with a live restarted loop", async () => {
+    const task = await taskFor("orphaned-claim", "dispatching");
+    await putAgentTask(task, deps());
+    const runId = deriveIntendedRunId(
+      task.workItemId,
+      task.taskVersion,
+      task.approval.approvedTaskHash!,
+    );
+    await claimDispatch({
+      workItemId: task.workItemId,
+      taskVersion: task.taskVersion,
+      approvedTaskHash: task.approval.approvedTaskHash!,
+      intendedRunId: runId,
+    }, deps());
+
+    const heartbeats: DispatcherHeartbeat[] = [];
+    let now = new Date(NOW);
+    let runReads = 0;
+    const reconcileDeps: ReconcileRunDeps = {
+      now: () => now,
+      isHalted: () => false,
+      listTasks: () => listAgentTasks({ executorKind: "harness", limit: 1_000 }, deps()),
+      saveTask: (candidate) => putAgentTask(candidate, deps()),
+      getRunBinding: (workItemId) => getRunBinding(workItemId, deps()),
+      getActiveQuarantine: (workItemId, taskVersion) =>
+        getActiveDispatchQuarantine(workItemId, taskVersion, deps()),
+      markQuarantine: (input) => markDispatchQuarantine(input, deps()),
+      listBindingAuditRows: () => listRunBindingAuditRows(deps()),
+      bindRun: (input) => bindRunToWorkItem(input, deps()),
+      readPort: {
+        async readRun() {
+          runReads += 1;
+          throw new HarnessReadError("run_not_started", "run is absent", true);
+        },
+      },
+      controlPort: { cancel: vi.fn(async () => undefined) },
+      recordDecision: vi.fn(async () => undefined),
+      alertSink: vi.fn(async () => undefined),
+      poisonThreshold: 5,
+      poisonFailures: createPoisonFailureTracker(),
+      logger: { warn: vi.fn() },
+    };
+    const restarted = createDispatcherProcess(processConfig("d0-restarted"), {
+      runReconcile: () => reconcileDispatchedRuns(reconcileDeps),
+      runAttempt: async () => ({ outcome: "idle" }),
+      isDispatchEnabled: () => true,
+      isHalted: () => false,
+      releaseLease: async () => true,
+      writeHeartbeat: async (heartbeat) => {
+        heartbeats.push(heartbeat);
+      },
+      now: () => now,
+      logger: { info: vi.fn(), warn: vi.fn() },
+      scheduler: unexpectedScheduler(),
+    });
+
+    for (let cycle = 1; cycle <= 3; cycle += 1) {
+      now = new Date(NOW.getTime() + cycle * 1_000);
+      await restarted.tick();
+    }
+    const claim = await getDispatchClaim(task.workItemId, 1, deps());
+    const stored = (await listAgentTasks({ workItemId: task.workItemId }, deps()))[0]!;
+    const decisions = await pool.query("select count(*)::int as count from hermes_decision_records");
+
+    expect(heartbeats.map(({ cycleCount }) => cycleCount)).toEqual([1, 1, 2, 2, 3, 3]);
+    expect(runReads).toBe(3);
+    expect(claim?.leaseExpiresAt).toBeUndefined();
+    expect(stored.lifecycle).toBe("dispatching");
+    expect(decisions.rows[0]?.count).toBe(0);
+    console.info(
+      `INT4C_D0_SILENCE orphaned_claim lifecycle=${stored.lifecycle} claim_lease=null run_reads=${runReads} alerts=0 heartbeats=${[...new Set(heartbeats.map(({ cycleCount }) => cycleCount))].join(",")}`,
+    );
+  });
+
+  it("records dead-holder takeover and the live-holder negative with two processes", async () => {
+    const holder = spawnLeaseProcess("d0-holder", "renew");
+    let contender: ReturnType<typeof spawnLeaseProcess> | undefined;
+    try {
+      await waitForHolder("d0-holder", 5_000);
+      contender = spawnLeaseProcess("d0-contender", "contend");
+      await delay(3_200);
+      const liveRow = await leaseRow();
+      expect(liveRow.holder).toBe("d0-holder");
+      expect(contender.output).not.toContain("holder=d0-contender acquired=true");
+      console.info(
+        `INT4C_D0_LEASE_LIVE holder=${liveRow.holder} contender=d0-contender ttl_windows=3 contender_acquired=false holder_pid=${holder.child.pid} contender_pid=${contender.child.pid}`,
+      );
+
+      holder.child.kill("SIGKILL");
+      await waitForHolder("d0-contender", 5_000);
+      const takeoverRow = await leaseRow();
+      expect(takeoverRow.holder).toBe("d0-contender");
+      expect(contender.output).toContain("holder=d0-contender acquired=true");
+      console.info(
+        `INT4C_D0_LEASE_TAKEOVER dead_holder=d0-holder new_holder=${takeoverRow.holder} fired=true identities_visible=d0-holder,d0-contender`,
+      );
+    } finally {
+      await stopChild(holder.child);
+      if (contender) await stopChild(contender.child);
+    }
+  }, 20_000);
+
+  it("records missing backpressure with one live binding already present", async () => {
+    const active = await taskFor("active", "running");
+    const activeRunId = deriveIntendedRunId(
+      active.workItemId,
+      active.taskVersion,
+      active.approval.approvedTaskHash!,
+    );
+    await putAgentTask(active, deps());
+    await bindRunToWorkItem({
+      workItemId: active.workItemId,
+      harnessRunId: activeRunId,
+    }, deps());
+
+    const queued = await taskFor("queued", "approved");
+    await putAgentTask(queued, deps());
+    const alerts: Array<Record<string, unknown>> = [];
+    const submitted: string[] = [];
+    const result = await runSingleDispatch(dispatchDeps(alerts, submitted));
+    const decisions = await pool.query<{ decision_type: string; record: unknown }>(
+      "select decision_type, record from hermes_decision_records order by generated_at",
+    );
+
+    expect(result.outcome).toBe("dispatched");
+    expect(submitted).toHaveLength(1);
+    expect(JSON.stringify(decisions.rows)).not.toContain("backpressure");
+    expect(JSON.stringify(alerts)).not.toContain("backpressure");
+    console.info(
+      `INT4C_D0_SILENCE backpressure active_bound=1 queued_attempt=${result.outcome} named_refusal=false operator_signal=false alerts=${alerts.length}`,
+    );
+  });
+});
+
+function deps() {
+  return { query };
+}
+
+async function query<T = Record<string, unknown>>(
+  text: string,
+  values: unknown[] = [],
+): Promise<T[]> {
+  return (await pool.query(text, values)).rows as T[];
+}
+
+async function taskFor(
+  suffix: string,
+  lifecycle: "approved" | "dispatching" | "running",
+): Promise<AgentTaskV1> {
+  const withApproval = agentTaskV1Schema.parse({
+    ...fixture,
+    workItemId: `int4c-d0-${suffix}`,
+    correlationId: `int4c-d0-${suffix}`,
+    lifecycle: "approved",
+    deadline: DEADLINE,
+    requestedAuthority: {
+      ...fixture.requestedAuthority,
+      grants: CAPABILITIES.map((capability) => ({
+        capabilityId: capability.id,
+        resource: fixture.repository.nameWithOwner,
+        constraints: {},
+      })),
+    },
+    approval: {
+      ...fixture.approval,
+      status: "approved",
+      actor: { type: "operator", id: "int4c-d0-operator" },
+      decidedAt: OLD,
+      approvedTaskHash: PLACEHOLDER_HASH,
+    },
+    timestamps: {
+      ...fixture.timestamps,
+      approvedAt: OLD,
+      updatedAt: OLD,
+    },
+  });
+  const artifact = await buildTaskIntentArtifact(withApproval, {
+    workspacePath: workspacePathForTask(withApproval.workItemId, 1),
+  });
+  const withTemplate = agentTaskV1Schema.parse({
+    ...withApproval,
+    intent: {
+      ...withApproval.intent,
+      templateHash: artifact.templateHash,
+      templateRef: {
+        ...withApproval.intent.templateRef,
+        uri: `artifact://sha256/${artifact.templateHash.slice("sha256:".length)}`,
+        sha256: artifact.templateHash,
+      },
+    },
+  });
+  const approvedTaskHash = await hashAgentTaskApprovalPayload(withTemplate);
+  const approved = agentTaskV1Schema.parse({
+    ...withTemplate,
+    approval: { ...withTemplate.approval, approvedTaskHash },
+  });
+  if (lifecycle === "approved") return approved;
+  const runId = deriveIntendedRunId(
+    approved.workItemId,
+    approved.taskVersion,
+    approvedTaskHash,
+  );
+  return agentTaskV1Schema.parse({
+    ...approved,
+    lifecycle,
+    timestamps: {
+      ...approved.timestamps,
+      dispatchClaimedAt: OLD,
+      ...(lifecycle === "running" ? { runBoundAt: OLD } : {}),
+      updatedAt: OLD,
+    },
+    ...(lifecycle === "running" ? { bindings: { harnessRunId: runId } } : {}),
+  });
+}
+
+function dispatchDeps(
+  alerts: Array<Record<string, unknown>>,
+  submitted: string[],
+): DispatchDeps {
+  return {
+    now: () => NOW,
+    dispatcherId: "d0-backpressure",
+    leaseTtlSeconds: 30,
+    isDispatchEnabled: () => true,
+    isHalted: () => false,
+    listDispatchable: () => listDispatchableAgentTasks(deps()),
+    saveTask: (task) => putAgentTask(task, deps()),
+    acquireLease: (input) => acquireDispatchLease(input, deps()),
+    renewLease: (input) => renewDispatchLease(input, deps()),
+    releaseLease: (holder) => releaseDispatchLease(holder, deps()),
+    claimDispatch: (input) => claimDispatch(input, deps()),
+    getRunBinding: (workItemId) => getRunBinding(workItemId, deps()),
+    bindRun: (input) => bindRunToWorkItem(input, deps()),
+    loadProfileManifest: async (profileId) => ({
+      profileId,
+      strategies: ["direct_execution"],
+      capabilities: CAPABILITIES,
+    }),
+    prepareWorkspace: async (task) =>
+      workspacePathForTask(task.workItemId, task.taskVersion),
+    writeIntentArtifact: async (_bytes, workItemId) => `/tmp/${workItemId}.json`,
+    controlPort: {
+      submit: async (runId) => {
+        submitted.push(runId);
+        return runId;
+      },
+      cancel: async () => undefined,
+    },
+    recordDecision: async (record) => {
+      await pool.query(
+        `insert into hermes_decision_records (
+           decision_id, correlation_id, work_item_id, decision_type, generated_at, record
+         ) values ($1, $2, $3, $4, $5, $6::jsonb)`,
+        [
+          record.decisionId,
+          record.correlationId,
+          record.workItemId ?? null,
+          record.decisionType,
+          record.generatedAt,
+          JSON.stringify(record),
+        ],
+      );
+    },
+    alertSink: async (alert) => {
+      alerts.push(alert);
+    },
+    logger: { warn: vi.fn() },
+  };
+}
+
+function processConfig(dispatcherId: string) {
+  return {
+    dispatcherId,
+    pollIntervalMs: 5_000,
+    leaseTtlSeconds: 30,
+    readTimeoutMs: 1_000,
+    poisonThreshold: 5,
+    intentDir: "/tmp/int4c-d0-intents",
+    heartbeatPath: "/tmp/int4c-d0-heartbeat.json",
+    harnessBin: "harness",
+  };
+}
+
+function unexpectedScheduler() {
+  return {
+    setTimeout: () => {
+      throw new Error("INT4C_D0 unexpected timer");
+    },
+    clearTimeout: vi.fn(),
+  };
+}
+
+function spawnLeaseProcess(holder: string, mode: "renew" | "contend") {
+  const child = spawn(
+    process.execPath,
+    [
+      "test/fixtures/agent-integration/int4c-d0-lease-process.mjs",
+      holder,
+      mode,
+      "1",
+    ],
+    {
+      cwd: process.cwd(),
+      env: { ...process.env, DATABASE_URL },
+      stdio: ["ignore", "pipe", "pipe"],
+    },
+  );
+  const record = { child, output: "" };
+  child.stdout.on("data", (chunk) => {
+    record.output += String(chunk);
+  });
+  child.stderr.on("data", (chunk) => {
+    record.output += String(chunk);
+  });
+  return record;
+}
+
+async function waitForHolder(holder: string, timeoutMs: number): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const row = await leaseRow().catch(() => undefined);
+    if (row?.holder === holder) return;
+    await delay(50);
+  }
+  throw new Error(`INT4C_D0 lease holder ${holder} was not observed`);
+}
+
+async function leaseRow(): Promise<{ holder: string; expires_at: Date }> {
+  const result = await pool.query<{ holder: string; expires_at: Date }>(
+    "select holder, expires_at from dispatch_lease where lease_id = 'global'",
+  );
+  const row = result.rows[0];
+  if (!row) throw new Error("INT4C_D0 global lease row missing");
+  return row;
+}
+
+async function stopChild(child: ChildProcessWithoutNullStreams): Promise<void> {
+  if (child.exitCode !== null || child.signalCode !== null) return;
+  child.kill("SIGTERM");
+  await Promise.race([
+    new Promise<void>((resolve) => child.once("exit", () => resolve())),
+    delay(1_000).then(() => {
+      child.kill("SIGKILL");
+    }),
+  ]);
+}


### PR DESCRIPTION
## Status: blocked after adjudicated D0

This remains an evidence-only draft. No incomplete D1–D7 source changes are present.

## D0 evidence

Against exact main `4164549b146ec87e57d093a926588ea82e17b3e6`:

- the orphaned per-item claim remained `dispatching` with no expiry, binding, alert, or retry while a fresh dispatcher completed three reconciliation cycles
- with one live bound task, exact main dispatched another approved task and emitted no named `backpressure` refusal or operator signal
- the original two-process run stopped because concurrent start let the contender win the empty lease before the intended holder was observed; that failed run remains in the record
- after the operator adjudicated that race as an instrument defect, the corrected probe was committed before execution and only the two-process baseline was rerun
- the corrected baseline proved a healthy renewing holder was not stolen from across three TTL windows and a contender acquired after the dead holder expired

The backpressure baseline's `active_bound=1` is probe input, not an existing configured bound. Exact main has no in-flight bound at any level; D2 would introduce the bound.

## Blocking contract contradiction

D4 requires the holder to crash at `after-claim-before-submit`, then requires a fresh-UUID retry mutation to produce two runs in the Harness store. At that crash point the first process has submitted no run, so Harness contains zero runs. One retry produces one run with either the derived ID or a fresh ID; the required two-run signature is impossible.

Two coherent amendments are recorded for operator choice:

1. apply the fresh-UUID mutation to the existing after-submit restart-resume drill; or
2. authorize an additional `after-submit-before-binding` crash point for that mutation.

No acceptance check was weakened, and no dispatcher-intention/log substitute was used.

## Checks and observed runs

- `npm install` — exit 0
- `npm run typecheck` on unmodified main — exit 0
- original D0 run — 2 passed, 1 failed due to the preserved concurrent-start instrument race
- corrected two-process baseline — 1 passed, 2 skipped, exit 0
- `git diff --check` — exit 0

## Surfaces

Test probe and evidence documentation only. No dispatcher/store behavior, migration, watchdog, kernel, pin, Compose, lifecycle, credential, production database, or deployment change.
