### PR TITLE
fix(monitor): render paused bank subjects honestly

### DIFF
--- a/packages/monitor-ui/src/components/ops/BankLane.test.tsx
+++ b/packages/monitor-ui/src/components/ops/BankLane.test.tsx
@@ -81,6 +81,23 @@ describe("the subject sits above the numbers it qualifies", () => {
     );
   });
 
+  test("an administratively paused subject stays visible and calm", () => {
+    const { getByTestId } = render(
+      <BankLane
+        bank={lane({
+          tone: "paused",
+          subject: {
+            text: "lane administratively paused (configured generation v2.2.1) — reason: administratively_paused",
+            tone: "paused",
+          },
+        })}
+      />,
+    );
+    expect(getByTestId("ops-bank").getAttribute("data-tone")).toBe("paused");
+    expect(getByTestId("ops-bank-subject").textContent).toContain("configured generation v2.2.1");
+    expect(getByTestId("ops-bank-subject").getAttribute("data-tone")).toBe("paused");
+  });
+
   test("a payload without the field still renders the lane", () => {
     // Optional on the wire so a board deployed ahead of the monitor that fills
     // it in does not crash on a payload that predates it.

--- a/packages/monitor-ui/src/lib/monitor/product-health.ts
+++ b/packages/monitor-ui/src/lib/monitor/product-health.ts
@@ -245,7 +245,9 @@ export interface CrossCheckView {
  */
 export interface BankLine {
   text: string;
-  tone: "ok" | "degraded" | "red" | "awaiting";
+  tone: "ok" | "degraded" | "red" | "awaiting" | "paused" | "neutral";
+  status?: string;
+  reason?: string | null;
 }
 
 export interface BankLaneView {
@@ -263,7 +265,7 @@ export interface BankLaneView {
    * "cannot confirm" is one of its answers.
    */
   subject?: BankLine;
-  tone: "ok" | "degraded" | "red" | "awaiting";
+  tone: "ok" | "degraded" | "red" | "awaiting" | "paused" | "neutral";
 }
 
 export interface BankBlock {

--- a/packages/monitor-ui/src/styles/hermes4-mobile.css
+++ b/packages/monitor-ui/src/styles/hermes4-mobile.css
@@ -23,6 +23,8 @@
 .hm-ph [data-tone="degraded"] { --tone: var(--h4-warn); }
 .hm-ph [data-tone="red"]      { --tone: var(--h4-act); }
 .hm-ph [data-tone="awaiting"] { --tone: var(--h4-tel); }
+.hm-ph [data-tone="paused"],
+.hm-ph [data-tone="neutral"]  { --tone: var(--h4-muted); }
 
 .hm-ph-bar {
   display: flex;

--- a/packages/monitor-ui/src/styles/hermes4-ops.css
+++ b/packages/monitor-ui/src/styles/hermes4-ops.css
@@ -103,6 +103,8 @@ body,
 .ops-board [data-tone="degraded"] { --tone: var(--h4-warn); }
 .ops-board [data-tone="red"]      { --tone: var(--h4-act); }
 .ops-board [data-tone="awaiting"] { --tone: var(--h4-tel); }
+.ops-board [data-tone="paused"],
+.ops-board [data-tone="neutral"]  { --tone: var(--h4-muted); }
 
 /* ---- meta line ------------------------------------------------ */
 .ops-meta {

--- a/services/slack-operator/src/bank-feed-fetch.ts
+++ b/services/slack-operator/src/bank-feed-fetch.ts
@@ -21,7 +21,14 @@
 // and the board stays quiet. Only a CONFIGURED feed that fails is a problem
 // worth a line on screen.
 
-import type { BankFeed, BankRequest, BankRequests, BankSubject, SourcedRead } from "./bank-feed.js";
+import type {
+  BankFeed,
+  BankRequest,
+  BankRequests,
+  BankSubject,
+  BankSubjectCandidate,
+  SourcedRead,
+} from "./bank-feed.js";
 
 export interface BankFeedRead {
   feed?: BankFeed;
@@ -96,18 +103,59 @@ export function normalizeBankFeed(body: unknown): BankFeedRead {
  * about an abandoned account this field exists to prevent, and a fabricated
  * mismatch is a RED that stops a lane which is actually fine.
  *
- * Both halves are required together — a subject that names only what it read,
- * with nothing to compare against, cannot answer the one question it is for.
+ * Both generations remain accepted during rollout. The current generation's
+ * `status` is OPEN vocabulary: structural validation protects the money
+ * subject while an unfamiliar status crosses intact and renders verbatim.
  */
 function subjectRecord(raw: unknown): BankSubject | undefined {
   if (!raw || typeof raw !== "object") return undefined;
   const s = raw as Record<string, unknown>;
-  if (typeof s.derivedFrom !== "string" || !s.derivedFrom.trim()) return undefined;
-  if (typeof s.declared !== "string" || !s.declared.trim()) return undefined;
+  if (typeof s.derivedFrom === "string" || typeof s.declared === "string") {
+    if (typeof s.derivedFrom !== "string" || !s.derivedFrom.trim()) return undefined;
+    if (typeof s.declared !== "string" || !s.declared.trim()) return undefined;
+    return {
+      derivedFrom: s.derivedFrom,
+      declared: s.declared,
+      ...(typeof s.label === "string" && s.label ? { label: s.label } : {}),
+    };
+  }
+
+  if (typeof s.configuredWrapper !== "string" || !s.configuredWrapper.trim()) return undefined;
+  if (typeof s.status !== "string" || !s.status.trim()) return undefined;
+  if (s.uniqueArmedWrapper !== null && typeof s.uniqueArmedWrapper !== "string") return undefined;
+  if (s.matches !== null && typeof s.matches !== "boolean") return undefined;
+  if (!Array.isArray(s.candidates)) return undefined;
+  if (s.readAtMs !== null && typeof s.readAtMs !== "number") return undefined;
+  if (s.reason !== null && typeof s.reason !== "string") return undefined;
+  if (s.lastError !== null && typeof s.lastError !== "string") return undefined;
+
+  const candidates: BankSubjectCandidate[] = [];
+  for (const rawCandidate of s.candidates) {
+    if (!rawCandidate || typeof rawCandidate !== "object") return undefined;
+    const candidate = rawCandidate as Record<string, unknown>;
+    if (typeof candidate.version !== "string" || !candidate.version.trim()) return undefined;
+    if (typeof candidate.wrapper !== "string" || !candidate.wrapper.trim()) return undefined;
+    if (candidate.dispatchPaused !== null && typeof candidate.dispatchPaused !== "boolean") return undefined;
+    if (candidate.lastError !== null && candidate.lastError !== undefined && typeof candidate.lastError !== "string") {
+      return undefined;
+    }
+    candidates.push({
+      version: candidate.version,
+      wrapper: candidate.wrapper,
+      dispatchPaused: candidate.dispatchPaused as boolean | null,
+      lastError: (candidate.lastError as string | null) ?? null,
+    });
+  }
+
   return {
-    derivedFrom: s.derivedFrom,
-    declared: s.declared,
-    ...(typeof s.label === "string" && s.label ? { label: s.label } : {}),
+    configuredWrapper: s.configuredWrapper,
+    uniqueArmedWrapper: (s.uniqueArmedWrapper as string | null) ?? null,
+    matches: (s.matches as boolean | null) ?? null,
+    status: s.status,
+    reason: (s.reason as string | null) ?? null,
+    candidates,
+    readAtMs: (s.readAtMs as number | null) ?? null,
+    lastError: (s.lastError as string | null) ?? null,
   };
 }
 

--- a/services/slack-operator/src/bank-feed.ts
+++ b/services/slack-operator/src/bank-feed.ts
@@ -194,7 +194,7 @@ export interface BankRequests {
  * producer that computed both from one source would agree with itself forever,
  * which is precisely the failure this exists to detect.
  */
-export interface BankSubject {
+export interface LegacyBankSubject {
   /** The wrapper generation the feed's ENV targets belong to. */
   derivedFrom: string;
   /** The wrapper generation `deployments/<profile>.json` declares current. */
@@ -203,8 +203,47 @@ export interface BankSubject {
   label?: string | null;
 }
 
+/** One wrapper generation observed by the producer's sole-armed check. */
+export interface BankSubjectCandidate {
+  version: string;
+  wrapper: string;
+  /** null means the producer could not read the pause bit. */
+  dispatchPaused: boolean | null;
+  lastError: string | null;
+}
+
+/**
+ * The producer's current subject contract.
+ *
+ * `status` deliberately remains a string. The producer and consumer deploy on
+ * different clocks; dropping a future status would turn an honest new state
+ * into the old, false "subject not declared" line. Rendering owns the known
+ * statuses and shows every stranger verbatim in a neutral tone.
+ */
+export interface EvaluatedBankSubject {
+  configuredWrapper: string;
+  uniqueArmedWrapper: string | null;
+  matches: boolean | null;
+  status: string;
+  reason: string | null;
+  candidates: BankSubjectCandidate[];
+  readAtMs: number | null;
+  lastError: string | null;
+}
+
+/** Rollback-safe across the producer's old and current subject contracts. */
+export type BankSubject = LegacyBankSubject | EvaluatedBankSubject;
+
+export function isLegacyBankSubject(subject: BankSubject): subject is LegacyBankSubject {
+  return "derivedFrom" in subject;
+}
+
+export function isEvaluatedBankSubject(subject: BankSubject): subject is EvaluatedBankSubject {
+  return "status" in subject;
+}
+
 /** Do the readings describe the generation the manifest says is live? */
-export function bankSubjectIsCurrent(subject: BankSubject): boolean {
+export function bankSubjectIsCurrent(subject: LegacyBankSubject): boolean {
   // Case-insensitive: these are hex addresses, and EIP-55 checksum casing
   // differs between a manifest written by a deploy script and an env var typed
   // by a human. Casing is not a retarget, and reporting it as one would make

--- a/services/slack-operator/src/bank-lane.ts
+++ b/services/slack-operator/src/bank-lane.ts
@@ -17,6 +17,7 @@ import {
   PLANCK_PER_DOT,
   POSTAGE_FLOOR_DOT,
   bankSubjectIsCurrent,
+  isEvaluatedBankSubject,
   isKnownPhase,
   type BankFeed,
   type BankRequest,
@@ -26,11 +27,15 @@ import {
 } from "./bank-feed.js";
 import { decidePositionDisplay, type PositionView } from "./position-display.js";
 
-export type BankTone = "ok" | "degraded" | "red" | "awaiting";
+export type BankTone = "ok" | "degraded" | "red" | "awaiting" | "paused" | "neutral";
 
 export interface BankLine {
   text: string;
   tone: BankTone;
+  /** Machine-readable producer state when this is the subject line. */
+  status?: string;
+  /** Machine-readable producer reason when this is the subject line. */
+  reason?: string | null;
 }
 
 export interface BankLaneView {
@@ -215,7 +220,9 @@ export function bankLaneView(input: {
           postage.tone === "degraded" ||
           requests.tone === "degraded"
         ? "degraded"
-        : "ok";
+        : subject.tone === "paused" || subject.tone === "neutral"
+          ? subject.tone
+          : "ok";
 
   return { position, float, postage, requests, subject, overdueRequestId: overdue?.id ?? null, tone };
 }
@@ -238,6 +245,9 @@ function subjectLine(feed: BankFeed): BankLine {
       tone: "awaiting",
     };
   }
+  if (isEvaluatedBankSubject(subject)) {
+    return evaluatedSubjectLine(subject);
+  }
   if (!bankSubjectIsCurrent(subject)) {
     // Both addresses in full. Shortened, two generations of the same deploy
     // script can share a prefix and a suffix, and the one line whose entire job
@@ -254,6 +264,61 @@ function subjectLine(feed: BankFeed): BankLine {
     text: `subject ${subject.label ?? shortSource(subject.declared)} — matches the deployment manifest`,
     tone: "ok",
   };
+}
+
+function evaluatedSubjectLine(subject: Extract<BankFeed["subject"], { status: string }>): BankLine {
+  const generation = configuredGeneration(subject);
+  const context = `configured generation ${generation}`;
+  if (subject.status === "paused") {
+    return {
+      text: `lane administratively paused (${context}) — reason: ${subject.reason ?? "not supplied"}`,
+      tone: "paused",
+      status: subject.status,
+      reason: subject.reason,
+    };
+  }
+  if (subject.status === "error") {
+    return {
+      text: `lane error (${context}) — ${subjectDetail(subject)}`,
+      tone: "red",
+      status: subject.status,
+      reason: subject.reason,
+    };
+  }
+  if (subject.status === "ok" && subject.matches === true) {
+    return {
+      text: `lane active (${context}) — unique armed wrapper ${subject.uniqueArmedWrapper ?? "not reported"}`,
+      tone: "ok",
+      status: subject.status,
+      reason: subject.reason,
+    };
+  }
+
+  // Status vocabulary belongs to the producer and can grow independently.
+  // Show a stranger exactly as received. Neutral is neither an endorsement nor
+  // a failure, and most importantly it is never made invisible.
+  return {
+    text: `lane status ${subject.status} (${context}) — ${subjectDetail(subject)}`,
+    tone: "neutral",
+    status: subject.status,
+    reason: subject.reason,
+  };
+}
+
+function configuredGeneration(subject: Extract<BankFeed["subject"], { status: string }>): string {
+  const candidate = subject.candidates.find(
+    (entry) => entry.wrapper.trim().toLowerCase() === subject.configuredWrapper.trim().toLowerCase(),
+  );
+  if (!candidate) return shortSource(subject.configuredWrapper);
+  return candidate.version.startsWith("v") ? candidate.version : `v${candidate.version}`;
+}
+
+function subjectDetail(subject: Extract<BankFeed["subject"], { status: string }>): string {
+  const details = [
+    subject.reason ? `reason: ${subject.reason}` : null,
+    subject.lastError && subject.lastError !== subject.reason ? `last error: ${subject.lastError}` : null,
+  ].filter(Boolean);
+  return details.length > 0 ? details.join(" · ") : "reason: not supplied";
 }
 
 /**

--- a/services/slack-operator/test/unit/bank-subject.test.ts
+++ b/services/slack-operator/test/unit/bank-subject.test.ts
@@ -20,6 +20,22 @@ import { normalizeBankFeed } from "../../src/bank-feed-fetch.js";
 const NOW = 1_785_900_000_000;
 const V21 = "0x2AF394fA95f75D3ca1C786128f4dfA1eB0c9675D";
 const V20 = "0x8d1a1De9F5C4C8b4C0eB1a3f2D9a7B6c5E4d3C2b";
+const V221 = "0xF20b35A3f85EC864127B551ce8A64446fC0ed2Bc";
+
+const evaluatedSubject = (over: Record<string, unknown> = {}) => ({
+  configuredWrapper: V221,
+  uniqueArmedWrapper: null,
+  matches: true,
+  status: "paused",
+  reason: "administratively_paused",
+  candidates: [
+    { version: "2.2", wrapper: V21, dispatchPaused: true, lastError: null },
+    { version: "2.2.1", wrapper: V221, dispatchPaused: true, lastError: null },
+  ],
+  readAtMs: NOW,
+  lastError: null,
+  ...over,
+});
 
 /** The retired generation's numbers, exactly as the board showed them. */
 const feed = (over: Partial<BankFeed> = {}): BankFeed => ({
@@ -29,6 +45,14 @@ const feed = (over: Partial<BankFeed> = {}): BankFeed => ({
   requests: { items: [], readAtMs: NOW - 30_000 },
   ...over,
 });
+
+const feedThroughNetwork = (subject: unknown): BankFeed => {
+  const base = feed();
+  const parsed = normalizeBankFeed({ ...base, subject });
+  expect(parsed.reason).toBeUndefined();
+  expect(parsed.feed?.subject).toBeDefined();
+  return parsed.feed!;
+};
 
 describe("the subject line is decided, never blank", () => {
   test("silence is NOT agreement — an undeclared subject says so out loud", () => {
@@ -70,6 +94,75 @@ describe("the subject line is decided, never blank", () => {
     expect(v.subject.tone).toBe("ok");
     expect(v.subject.text).toContain("bank-xcm-v2.1");
     expect(v.float.tone).toBe("ok");
+  });
+});
+
+describe("the producer's evaluated subject contract", () => {
+  const calibrated = {
+    provenAtMs: NOW - 86_400_000,
+    provenRaw: "100000",
+    provenSource: "erc20:0x2ec4…fa93.balanceOf(0x98f0…b68e)",
+  };
+
+  test("paused is a calm third state, with the configured generation and reason", () => {
+    const parsed = normalizeBankFeed({
+      position: feed().position,
+      float: feed().float,
+      postage: feed().postage,
+      requests: feed().requests,
+      calibration: calibrated,
+      subject: evaluatedSubject(),
+    });
+    expect(parsed.feed?.subject).toMatchObject({
+      status: "paused",
+      reason: "administratively_paused",
+      matches: true,
+      uniqueArmedWrapper: null,
+    });
+
+    const view = bankLaneView({ feed: parsed.feed!, nowMs: NOW })!;
+    expect(view.subject).toEqual({
+      text: "lane administratively paused (configured generation v2.2.1) — reason: administratively_paused",
+      tone: "paused",
+      status: "paused",
+      reason: "administratively_paused",
+    });
+    expect(view.tone).toBe("paused");
+  });
+
+  test("an unknown status survives verbatim and renders neutral with its reason", () => {
+    const view = bankLaneView({
+      feed: {
+        ...feedThroughNetwork(evaluatedSubject({ status: "future_custody_handoff", reason: "governance_window" })),
+        calibration: calibrated,
+      },
+      nowMs: NOW,
+    })!;
+    expect(view.subject.text).toContain("future_custody_handoff");
+    expect(view.subject.text).toContain("reason: governance_window");
+    expect(view.subject.tone).toBe("neutral");
+    expect(view.subject.status).toBe("future_custody_handoff");
+    expect(view.subject.reason).toBe("governance_window");
+    expect(view.tone).toBe("neutral");
+  });
+
+  test("a producer error passes through as red with its reason", () => {
+    const view = bankLaneView({
+      feed: {
+        ...feedThroughNetwork(evaluatedSubject({
+          status: "error",
+          matches: false,
+          reason: "multiple_armed_wrappers",
+          lastError: "multiple_armed_wrappers",
+        })),
+        calibration: calibrated,
+      },
+      nowMs: NOW,
+    })!;
+    expect(view.subject.text).toContain("lane error");
+    expect(view.subject.text).toContain("reason: multiple_armed_wrappers");
+    expect(view.subject.tone).toBe("red");
+    expect(view.tone).toBe("red");
   });
 });
 
@@ -167,7 +260,6 @@ describe("a malformed subject is dropped, never guessed at", () => {
 
   test("a good subject survives the network boundary intact", () => {
     const r = normalizeBankFeed({ ...payload, subject: { derivedFrom: V20, declared: V21, label: "bank-xcm-v2.1" } });
-    expect(r.feed!.subject!.derivedFrom).toBe(V20);
-    expect(r.feed!.subject!.label).toBe("bank-xcm-v2.1");
+    expect(r.feed!.subject).toMatchObject({ derivedFrom: V20, declared: V21, label: "bank-xcm-v2.1" });
   });
 });


### PR DESCRIPTION
## What changed

- accept both the legacy Bank subject and the producer's evaluated sole-armed-wrapper shape
- preserve unknown producer statuses and render them verbatim as neutral rather than dropping the subject
- render an administratively paused configured generation as a distinct calm state, with machine-readable status and reason
- pass producer error states through as red and keep legacy subject matching rollback-safe
- teach desktop and mobile Bank UI contracts/styles about paused and neutral tones

## Checks

- npm run typecheck
- npm test (2,795 passed; 23 skipped)
- post-rebase focused suite: 44 passed

## Surfaces

- slack-operator product-health Bank subject parsing and view model
- desktop and mobile monitor Bank lane
- no backend product mutation, contracts, indexer, Caddy, or public-site change

## Deployment

- normal reference-agent VPS deployment after human merge
- no environment or secret changes
- post-deploy acceptance: /monitor/product-health renders Bank subject status paused, reason administratively_paused, and configured generation v2.2.1 instead of subject not declared

## Compatibility

- producer rollback is safe: the old derivedFrom/declared shape remains accepted
- future producer status vocabulary is open: unfamiliar statuses remain visible and neutral
- deriveOpsVerdict does not currently consume the Bank lane, so there is no shared-verdict mapping to alter in this PR
