### PR TITLE
Pushed alerts carry their next step

### DIFF
--- a/packages/monitor-ui/src/lib/monitor/ops-suggestions.test.ts
+++ b/packages/monitor-ui/src/lib/monitor/ops-suggestions.test.ts
@@ -16,6 +16,29 @@ describe("opsSuggestions", () => {
     expect(byId["money-stuck"].task?.repo).toContain("averray-reference-agent");
   });
 
+  test("the rendered text is EXACTLY what it was before the next-step map was shared", () => {
+    // These three strings now come from @avg/schemas/ops-next-step, which the
+    // pushed #Ops alerts read too — one source, two surfaces. Pinning them here
+    // is what makes that refactor provable: if the shared phrase changes, the
+    // board's wording changes with it, and this test says so out loud rather
+    // than letting the two drift into disagreeing about the same incident.
+    const health: ProductHealth = {
+      enabled: true,
+      at: 1,
+      status: "red",
+      checks: 10,
+      probes: [
+        { name: "signer_liquidity", status: "red", detail: "USDC 1.00 below floor 1.00", sparkline: [] },
+        { name: "treasury_liquidity", status: "red", detail: "reserve 2.00 USDC", sparkline: [] },
+        { name: "capabilities", status: "degraded", detail: "external posting staged", sparkline: [] },
+      ],
+    };
+    const byId = Object.fromEntries(opsSuggestions(health).map((s) => [s.id, s]));
+    expect(byId["signer-floor"].text).toBe("Reward bank below floor — top up before the next payout.");
+    expect(byId["treasury-floor"].text).toBe("Treasury reserve low — reserve 2.00 USDC. Refill (operator action).");
+    expect(byId["capabilities"].text).toBe("Capabilities — external posting staged. Check config.");
+  });
+
   test("live board → chain-frozen (informational); awaiting probes produce nothing", () => {
     const suggestions = opsSuggestions(OPS_FIXTURE_LIVE);
     const ids = suggestions.map((s) => s.id);

--- a/packages/monitor-ui/src/lib/monitor/ops-suggestions.ts
+++ b/packages/monitor-ui/src/lib/monitor/ops-suggestions.ts
@@ -16,6 +16,8 @@
 // specifics), so it works today without the structured solvency/flow blocks.
 // Awaiting-data probes never produce a suggestion (telemetry, not an incident).
 
+import { opsNextStep } from "@avg/schemas/ops-next-step";
+
 import type { ProductHealth } from "./product-health.js";
 import type { CreateTaskInput } from "./card-types.js";
 import { isAwaitingProbe } from "./ops-model.js";
@@ -39,6 +41,12 @@ function runwayEta(hoursToFloor: number): string {
   if (hoursToFloor <= 0) return "at floor";
   if (hoursToFloor < 48) return `~${Math.round(hoursToFloor)}h`;
   return `~${Math.round(hoursToFloor / 24)}d`;
+}
+
+/** Lowercase the first letter so a shared sentence can follow an em dash. */
+function lower(phrase: string | undefined): string {
+  if (!phrase) return "";
+  return phrase[0]!.toLowerCase() + phrase.slice(1);
 }
 
 export function opsSuggestions(health: ProductHealth | undefined): OpsSuggestion[] {
@@ -78,7 +86,7 @@ export function opsSuggestions(health: ProductHealth | undefined): OpsSuggestion
     out.push({
       id: "signer-floor",
       tone: signer.status === "red" ? "act" : "warn",
-      text: "Reward bank below floor — top up before the next payout.",
+      text: `Reward bank below floor — ${lower(opsNextStep("signer_liquidity"))}`,
       task: proposeTask(
         `Prepare a reward-bank top-up — do NOT move funds, PREPARE ONLY. The in-contract reward bank is at/below its floor: "${signer.detail}". Compute how much to add to restore a safe buffer (≈ 5× floor) and draft the exact brokered deposit steps/command for the operator to execute.`,
       ),
@@ -110,7 +118,7 @@ export function opsSuggestions(health: ProductHealth | undefined): OpsSuggestion
     out.push({
       id: "treasury-floor",
       tone: "act",
-      text: `Treasury reserve low — ${treasury.detail}. Refill (operator action).`,
+      text: `Treasury reserve low — ${treasury.detail}. ${opsNextStep("treasury_liquidity")}`,
       task: proposeTask(
         `Prepare a treasury refill — do NOT move funds, PREPARE ONLY. Treasury probe: "${treasury.detail}". Compute how much to move to restore a safe reserve and draft the exact steps for the operator to execute.`,
       ),
@@ -161,7 +169,7 @@ export function opsSuggestions(health: ProductHealth | undefined): OpsSuggestion
     out.push({
       id: "capabilities",
       tone: "warn",
-      text: `Capabilities — ${caps.detail}. Check config.`,
+      text: `Capabilities — ${caps.detail}. ${opsNextStep("capabilities")}`,
       task: proposeTask(
         `A product capability is degraded: "${caps.detail}". Identify which capability dropped and why (missing/expired cred, config, or upstream) and propose the config fix.`,
       ),

--- a/packages/schemas/package.json
+++ b/packages/schemas/package.json
@@ -12,6 +12,10 @@
     "./ops-verdict": {
       "types": "./dist/ops-verdict.d.ts",
       "import": "./dist/ops-verdict.js"
+    },
+    "./ops-next-step": {
+      "types": "./dist/ops-next-step.d.ts",
+      "import": "./dist/ops-next-step.js"
     }
   },
   "scripts": {

--- a/packages/schemas/src/index.ts
+++ b/packages/schemas/src/index.ts
@@ -5,6 +5,7 @@ export * from "./agent-task.js";
 export * from "./hermes-decision-record.js";
 export * from "./legacy-agent-task.js";
 export * from "./ops-verdict.js";
+export * from "./ops-next-step.js";
 export * from "./pull-request-payload.js";
 export * from "./task-intent.js";
 export * from "./verified-handoff.js";

--- a/packages/schemas/src/ops-next-step.test.ts
+++ b/packages/schemas/src/ops-next-step.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+
+import { OPS_NEXT_STEP, opsNextStep } from "./ops-next-step.js";
+
+describe("opsNextStep", () => {
+  it("returns the step for a probe that has one", () => {
+    expect(opsNextStep("signer_liquidity")).toBe("Top up before the next payout.");
+    expect(opsNextStep("money_path")).toBe("Trace the stuck settlements.");
+  });
+
+  it("returns undefined for a probe with no considered step", () => {
+    // Absence is the safe default: inventing a plausible action for an incident
+    // class nobody has thought through is how an operator gets sent down the
+    // wrong path at 3am.
+    expect(opsNextStep("external_funnel")).toBeUndefined();
+    expect(opsNextStep("chain_height")).toBeUndefined();
+    expect(opsNextStep("not_a_probe")).toBeUndefined();
+  });
+
+  it("never diagnoses a cause — every step is a pointer, not a verdict", () => {
+    // The bank-overdue suggestion already paid for this lesson: its first
+    // wording asserted "check whether leg 2 landed", and the first live overdue
+    // had never dispatched a leg at all.
+    for (const [probe, step] of Object.entries(OPS_NEXT_STEP)) {
+      expect(step, `${probe} must not assert a cause`).not.toMatch(
+        /\b(because|caused by|due to|is failing because)\b/i,
+      );
+    }
+  });
+
+  it("stays short enough for a lock screen, and reads as one instruction", () => {
+    for (const [probe, step] of Object.entries(OPS_NEXT_STEP)) {
+      expect(step.length, `${probe} step is too long for a phone alert`).toBeLessThanOrEqual(56);
+      expect(step.endsWith("."), `${probe} step should be one closed sentence`).toBe(true);
+    }
+  });
+
+  it("never suggests moving money automatically — funds stay operator-only", () => {
+    // The money rail is a hard boundary. A step that reads like an instruction
+    // to a machine, rather than to the operator, is the wrong shape entirely.
+    expect(OPS_NEXT_STEP.signer_liquidity).toMatch(/top up/i);
+    expect(OPS_NEXT_STEP.treasury_liquidity).toMatch(/operator action/i);
+    for (const step of Object.values(OPS_NEXT_STEP)) {
+      expect(step).not.toMatch(/\b(transfer|send|withdraw|sweep) \d/i);
+    }
+  });
+});

--- a/packages/schemas/src/ops-next-step.ts
+++ b/packages/schemas/src/ops-next-step.ts
@@ -1,0 +1,60 @@
+// What to DO about a probe — the one place the answer is written.
+//
+// The board's co-pilot has always computed a pre-drafted remediation for each
+// incident class (`opsSuggestions`), but that lives on a screen. Since mobile
+// pairing landed, the alerts reach a phone at 3am — and they carried the
+// problem without the next move, so the operator had to open a laptop to learn
+// what the board already knew.
+//
+// ── WHY THIS IS A SEPARATE MODULE, AND NOT COPIED INTO THE ALERT ──────────
+//
+// Two surfaces now answer "what should I do about money_path?": the board's
+// suggestion box and the pushed alert. Written twice they drift, and the first
+// time they disagree is the last time either is believed — the same rule that
+// put deriveOpsVerdict here rather than in each renderer. So the phrase lives
+// once, in the package both sides already import, and each surface decides
+// only how to present it.
+//
+// ── THESE ARE POINTERS, NOT INSTRUCTIONS ──────────────────────────────────
+//
+// Every phrase names what to FIND OUT or what to DO, and deliberately asserts
+// no cause. "Check the last deploy" would be a diagnosis, and a wrong one
+// shouted at 3am is worse than silence — the bank-overdue suggestion already
+// learned this the hard way, when its first wording said "check whether leg 2
+// landed" and the first live overdue had never dispatched a leg at all.
+//
+// Absence is meaningful: a probe with no entry gets NO appended step, because
+// inventing a plausible-sounding action for an incident class nobody has
+// thought through is exactly how an operator is sent down the wrong path.
+
+/**
+ * Short imperative next step per probe, or undefined when we have nothing
+ * honest to add. Kept to one clause — this renders on a lock screen.
+ */
+export const OPS_NEXT_STEP: Readonly<Record<string, string>> = {
+  // Funds. Both are operator-only: the step is to top up, never to move money
+  // automatically. Wording matches the board's suggestion box verbatim.
+  signer_liquidity: "Top up before the next payout.",
+  treasury_liquidity: "Refill (operator action).",
+  // Settlement. Names the object to trace, not a suspected cause.
+  money_path: "Trace the stuck settlements.",
+  // Config-shaped by construction: a capability drops when a credential or
+  // setting is missing, so this one can be specific without diagnosing.
+  capabilities: "Check config.",
+  // Latency: the useful first move is measuring where the time goes.
+  api_latency: "Profile the slow path.",
+  // The product's own health check failing is the one case where confirming
+  // from outside comes first — the probe itself may be what is wrong.
+  product_api: "Confirm from outside, then check recent deploys.",
+} as const;
+
+/**
+ * The next step for a probe, or undefined when none is defined.
+ *
+ * Deliberately keyed on the probe NAME only, not its detail: a step that
+ * changes with the wording of a detail string is a step nobody can test, and
+ * the detail is already carried verbatim beside it.
+ */
+export function opsNextStep(probeName: string): string | undefined {
+  return OPS_NEXT_STEP[probeName];
+}

--- a/services/slack-operator/src/probe-transitions.ts
+++ b/services/slack-operator/src/probe-transitions.ts
@@ -26,6 +26,8 @@
 // Kept pure — no clock, no I/O, no config — so every rule here is testable
 // without a relay or a heartbeat.
 
+import { opsNextStep } from "@avg/schemas";
+
 import { probeLabel } from "./ops-voice.js";
 import type { ProbeResult, ProbeStatus } from "./product-health.js";
 
@@ -145,9 +147,18 @@ export function reasonClass(probe: ProbeResult): string {
 function alertText(probe: ProbeResult, kind: "opened" | "recovered", before?: ProbeStatus): string {
   const label = probeLabel(probe.name);
   if (kind === "recovered") return `✓ ${label} recovered — ${probe.detail}`;
-  if (probe.status === "red") return `✗ ${label} is red — ${probe.detail}`;
-  if (before === "red") return `⚠ ${label} eased to degraded — ${probe.detail}`;
-  return `⚠ ${label} degraded — ${probe.detail}`;
+
+  // The next step rides ONLY on an opening alert. A recovery needs no advice,
+  // and appending one would read as "it healed, now go do something".
+  // opsNextStep returns undefined for any probe we have not thought through;
+  // that appends nothing rather than inventing a plausible-sounding action
+  // (@avg/schemas/ops-next-step explains why absence is the safe default).
+  const step = opsNextStep(probe.name);
+  const next = step ? ` · next: ${step}` : "";
+
+  if (probe.status === "red") return `✗ ${label} is red — ${probe.detail}${next}`;
+  if (before === "red") return `⚠ ${label} eased to degraded — ${probe.detail}${next}`;
+  return `⚠ ${label} degraded — ${probe.detail}${next}`;
 }
 
 const isAlarm = (status: ProbeStatus): boolean => status === "degraded" || status === "red";

--- a/test/unit/probe-transitions.test.ts
+++ b/test/unit/probe-transitions.test.ts
@@ -60,6 +60,7 @@ describe("decideProbeTransitions", () => {
     });
     expect(r.alerts).toHaveLength(1);
     expect(r.alerts[0]).toMatchObject({ probe: "external_funnel", kind: "opened", from: "ok", to: "red" });
+    // external_funnel has no considered next step, so nothing is appended.
     expect(r.alerts[0]?.text).toBe("✗ External funnel is red — rejected 0xaa4b… slashes in 9h");
   });
 
@@ -100,6 +101,36 @@ describe("decideProbeTransitions", () => {
       current: [p("x", "degraded", "b")],
     });
     expect(down.alerts).toHaveLength(1);
+  });
+
+  it("carries the next step on an OPENING alert, so a 3am page is actionable", () => {
+    // The board's co-pilot always knew what to do about a red money path; the
+    // pushed alert did not carry it, so the operator had to open a laptop to
+    // learn what the board already knew.
+    const r = decide({
+      previous: new Map([["money_path", p("money_path", "ok", "settled 14")]]),
+      current: [p("money_path", "red", "settlement stalled")],
+    });
+    expect(r.alerts[0]?.text).toBe(
+      "✗ Money path is red — settlement stalled · next: Trace the stuck settlements.",
+    );
+  });
+
+  it("appends NOTHING for a probe with no considered step", () => {
+    const r = decide({
+      previous: new Map([["external_funnel", p("external_funnel", "ok", "0 in window")]]),
+      current: [p("external_funnel", "red", "bond slashable now")],
+    });
+    expect(r.alerts[0]?.text).not.toContain("next:");
+  });
+
+  it("never appends a next step to a RECOVERY — it healed, nothing to do", () => {
+    const r = decide({
+      previous: new Map([["money_path", p("money_path", "red", "stalled")]]),
+      current: [p("money_path", "ok", "settled 14, backlog 0")],
+    });
+    expect(r.alerts[0]?.kind).toBe("recovered");
+    expect(r.alerts[0]?.text).not.toContain("next:");
   });
 
   it("posts one recovery when a probe returns to ok", () => {


### PR DESCRIPTION
Improvement #4 from the queue — the last self-contained piece before the phone-approvals design.

**The gap:** `opsSuggestions` has always computed a specific, probe-cited remediation for each incident class, and it renders on the board. The alerts that reach your phone carried the *problem* without the *next move*, so a 3am page meant opening a laptop to read something the system already knew.

**One source, two surfaces.** The phrase now lives in `@avg/schemas/ops-next-step` — the package both sides already import, the same path `deriveOpsVerdict` took, and for the same reason: written twice, they drift, and the first time the board and the alert disagree about the same incident is the last time either is believed.

`✗ Money path is red — settlement stalled · next: Trace the stuck settlements.`

**Three rules make it safe rather than noisy:**
- **Pointers, never diagnoses.** Every phrase names what to do or find out and asserts no cause. "Check the last deploy" would be a diagnosis, and a wrong one shouted at 3am is worse than silence — the bank-overdue suggestion already learned this when its first wording asserted "check whether leg 2 landed" and the first live overdue had never dispatched a leg at all.
- **Absence is meaningful.** A probe with no considered step appends nothing. Inventing a plausible action for an incident class nobody has thought through is how an operator gets sent down the wrong path.
- **Recoveries carry nothing.** "It healed, now go do something" is not a message worth sending.

**Verify:** 37 + 249 tests green, `tsc -b` clean across schemas/monitor-ui/slack-operator. The board's three affected strings render **byte-identical** — and I added the test that proves it, because the existing suite asserted task prompts but never the rendered text, so "unchanged" would otherwise have been my word rather than a check.

Deploy is the usual `ops/deploy-monitor.sh`; no new env.

🤖 Generated with [Claude Code](https://claude.com/claude-code)