### PR TITLE
fix(monitor): close announced alarms, and stop calling an unreachable probe a red product

### DIFF
--- a/ops/.env.mainnet-monitor.example
+++ b/ops/.env.mainnet-monitor.example
@@ -18,6 +18,14 @@ OPS_AUTOREMEDIATE_ENABLED=true
 PRODUCT_HEALTH_INTERVAL_MINUTES=5
 PRODUCT_HEALTH_ALERT_COOLDOWN_MINUTES=30
 
+# The transport hold is counted in CYCLES, so its wall-clock length follows the
+# cadence above. The generic default of 3 is calibrated for the 2-minute testnet
+# cadence (~4-6 minutes); at 5-minute sampling the same 3 would leave the board
+# blind for 10-15 minutes before saying so. Two cycles restores roughly the
+# intended ~5-minute hold — long enough that a single DNS blip does not page,
+# short enough that a real outage is not sat on.
+PRODUCT_HEALTH_TRANSPORT_FAIL_THRESHOLD=2
+
 # Mainnet payouts use the signer reward-bank position in AgentAccountCore. The
 # owner/treasury multisig intentionally carries no USDC float. The reason is
 # required: a zero floor without it remains degraded rather than silently green.

--- a/ops/compose.yml
+++ b/ops/compose.yml
@@ -506,6 +506,14 @@ services:
       PRODUCT_HEALTH_API_PATH: ${PRODUCT_HEALTH_API_PATH:-/health}
       PRODUCT_HEALTH_CHAIN_MAX_STALE_SECONDS: ${PRODUCT_HEALTH_CHAIN_MAX_STALE_SECONDS:-600}
       PRODUCT_HEALTH_HALT_SEVERITY: ${PRODUCT_HEALTH_HALT_SEVERITY:-auto}
+      # Consecutive cycles the /health TRANSPORT must fail (DNS, connect, TLS —
+      # no HTTP response at all) before product_api reds. On 2026-08-06 the
+      # container's resolver died for five minutes and paged on-call about a
+      # product that was serving 200s from outside the whole time. Below this
+      # count the probe reports "unreachable from here, product state unknown"
+      # and stays quiet; at it, it pages — whichever side of the wire is broken.
+      # At the default 2-minute cadence, 3 is ~4-6 minutes of sustained failure.
+      PRODUCT_HEALTH_TRANSPORT_FAIL_THRESHOLD: ${PRODUCT_HEALTH_TRANSPORT_FAIL_THRESHOLD:-3}
       # 0-based word index of `rejectedAt` in the EscrowCore job struct, for the
       # external_funnel probe's dispute-window countdown. Defaults to 17, which
       # was CALIBRATED against the chain rather than taken from an ABI: word[17]

--- a/packages/monitor-ui/src/components/ops/ops-frame.test.ts
+++ b/packages/monitor-ui/src/components/ops/ops-frame.test.ts
@@ -156,3 +156,62 @@ describe("pillarStatuses", () => {
     expect(byLabel.Availability).toBe("ok");
   });
 });
+
+// ── The banner that got it wrong on 2026-08-06 ──────────────────────────────
+//
+// "Product API red — … / Settlement-affecting — on-call is paged." was the
+// largest sentence on the board for five hours, about a product that never
+// stopped serving 200s. The only thing established was that this container
+// could not resolve the host.
+describe("opsBannerData — a red the probe could not read", () => {
+  const unreachable = (over: Partial<ProductHealth> = {}): ProductHealth => ({
+    enabled: true,
+    at: FIXTURE_NOW,
+    status: "red",
+    checks: 10,
+    network: "mainnet",
+    probes: [
+      {
+        name: "product_api",
+        status: "red",
+        reading: "unknown",
+        detail: "probe cannot reach https://api.averray.com/health — DNS resolution failed (ENOTFOUND) · 3 consecutive checks",
+        sparkline: [],
+      },
+    ],
+    ...over,
+  });
+
+  test("says unreachable, not red", () => {
+    const b = opsBannerData(unreachable(), FIXTURE_NOW);
+    expect(b.headline).toContain("unreachable from the monitor");
+    expect(b.headline).not.toMatch(/\bred\b/);
+  });
+
+  test("does not claim settlement is affected", () => {
+    const b = opsBannerData(unreachable(), FIXTURE_NOW);
+    expect(b.sub).not.toContain("Settlement-affecting");
+    expect(b.sub).toContain("whether the product is affected is unknown");
+    expect((b.mostUrgentReasons ?? []).map((r) => r.label)).toEqual(["unreachable", "mainnet"]);
+  });
+
+  test("still carries the cause code, so it is diagnosable from the banner", () => {
+    expect(opsBannerData(unreachable(), FIXTURE_NOW).headline).toContain("ENOTFOUND");
+  });
+
+  test("agrees with the shared verdict headline rather than contradicting it", () => {
+    // deriveOpsVerdict says PRODUCT API UNREACHABLE. Two derivations disagreeing
+    // on one screen is worse than either being wrong alone.
+    const b = opsBannerData(unreachable(), FIXTURE_NOW);
+    expect(b.headline.toLowerCase()).toContain("unreachable");
+  });
+
+  test("an observed red still reads as page-worthy", () => {
+    const answered = unreachable({
+      probes: [{ name: "money_path", status: "red", detail: "6 jobs stuck (submitted, unsettled ≥ 5)", sparkline: [] }],
+    });
+    const b = opsBannerData(answered, FIXTURE_NOW);
+    expect(b.headline).toContain("red");
+    expect(b.sub).toContain("Settlement-affecting");
+  });
+});

--- a/packages/monitor-ui/src/components/ops/ops-frame.ts
+++ b/packages/monitor-ui/src/components/ops/ops-frame.ts
@@ -96,14 +96,27 @@ export function opsBannerData(health: ProductHealth, nowMs: number): BannerData 
   if (reds.length > 0) {
     const lead = reds[0];
     const extra = reds.length > 1 ? ` +${reds.length - 1}` : "";
+    // A red we could not READ is page-worthy unreachability, not a settlement
+    // finding. This banner is the largest sentence on the board, and on
+    // 2026-08-06 it is the one that told an operator the product was down while
+    // it was serving 200s. It must also agree with `verdict.headline`, which now
+    // says UNREACHABLE — two derivations contradicting each other on one screen
+    // is worse than either being wrong alone.
+    const unreadable = lead.reading === "unknown";
     return {
       tone: "degraded",
       eyebrow,
-      headline: `${probeLabel(lead.name)} red${extra} — ${shortDetail(lead.detail)}`,
-      sub: mainnet ? "Settlement-affecting — on-call is paged." : "On mainnet this pages; on testnet it does not.",
+      headline: unreadable
+        ? `${probeLabel(lead.name)} unreachable from the monitor${extra} — ${shortDetail(lead.detail)}`
+        : `${probeLabel(lead.name)} red${extra} — ${shortDetail(lead.detail)}`,
+      sub: unreadable
+        ? "The probe cannot reach it — whether the product is affected is unknown."
+        : mainnet
+          ? "Settlement-affecting — on-call is paged."
+          : "On mainnet this pages; on testnet it does not.",
       primaryActionId: undefined,
       mostUrgentReasons: [
-        { label: "page-worthy", tone: "risk" },
+        { label: unreadable ? "unreachable" : "page-worthy", tone: "risk" },
         ...(net ? ([{ label: net, tone: "neutral" }] as const) : []),
       ],
     };

--- a/packages/monitor-ui/src/lib/monitor/ops-model.ts
+++ b/packages/monitor-ui/src/lib/monitor/ops-model.ts
@@ -11,6 +11,7 @@ import type {
   OpsIncident,
   HealthHistory,
   ProbeStatus,
+  ProbeReading,
 } from "./product-health.js";
 import { OPS_PILLARS, OPS_PILLAR_LABELS, probePillar } from "./product-health.js";
 
@@ -29,11 +30,13 @@ export type OpsTone = "ok" | "degraded" | "red" | "awaiting";
 // on both sides (the service carried a comment reading "mirrors the frontend's
 // awaiting regex", which is a drift bug waiting to happen). Re-exported here so
 // existing frontend imports keep working.
-import { isAcknowledgedProbe, isAwaitingProbe } from "@avg/schemas/ops-verdict";
-export { isAcknowledgedProbe, isAwaitingProbe };
+import { isAcknowledgedProbe, isAwaitingProbe, isUnknownReadingProbe } from "@avg/schemas/ops-verdict";
+export { isAcknowledgedProbe, isAwaitingProbe, isUnknownReadingProbe };
 
-/** Resolve a probe to its ops tone (awaiting overrides a bare degraded). */
-export function probeOpsTone(probe: { status: ProbeStatus; detail: string }): OpsTone {
+/** Resolve a probe to its ops tone (awaiting overrides a bare degraded; a probe
+ *  with no reading is grey too — telemetry we could not take, not a fault we
+ *  observed). `isAwaitingProbe` covers both, and leaves `red` alone. */
+export function probeOpsTone(probe: { status: ProbeStatus; detail: string; reading?: ProbeReading }): OpsTone {
   return isAwaitingProbe(probe) ? "awaiting" : probe.status;
 }
 

--- a/packages/monitor-ui/src/lib/monitor/ops-suggestions.test.ts
+++ b/packages/monitor-ui/src/lib/monitor/ops-suggestions.test.ts
@@ -266,3 +266,62 @@ describe("bank — an overdue venue request", () => {
     expect(s).toBeUndefined();
   });
 });
+
+// ── A red the probe could not READ ──────────────────────────────────────────
+//
+// 2026-08-06: the monitor's container lost DNS for five minutes. The suggestion
+// drafted from that red would have told a worker to tail the product's logs and
+// roll back a deploy — over a fault on our own side of the wire, against a
+// product that was serving 200s throughout.
+describe("opsSuggestions — product_api unreachable", () => {
+  const unreachable: ProductHealth = {
+    enabled: true,
+    at: 1,
+    status: "red",
+    checks: 10,
+    probes: [
+      {
+        name: "product_api",
+        status: "red",
+        reading: "unknown",
+        detail: "probe cannot reach https://api.averray.com/health — DNS resolution failed (ENOTFOUND) · 3 consecutive checks · unreachable from the monitor; whether the product is up is unknown from here",
+        sparkline: [],
+      },
+    ],
+  };
+
+  test("does not claim the product is down", () => {
+    const byId = Object.fromEntries(opsSuggestions(unreachable).map((s) => [s.id, s]));
+    expect(byId["product-api-down"]).toBeUndefined();
+    expect(byId["product-api-unreachable"]).toBeTruthy();
+    expect(byId["product-api-unreachable"].text).toContain("unreachable from the monitor");
+  });
+
+  test("drafts a task that diagnoses the wire, and forbids a blind rollback", () => {
+    const suggestion = opsSuggestions(unreachable).find((s) => s.id === "product-api-unreachable")!;
+    expect(suggestion.task?.prompt).toContain("REACHABILITY fault");
+    expect(suggestion.task?.prompt).toContain("DNS resolution and egress");
+    expect(suggestion.task?.prompt).toContain("Do not roll back");
+  });
+
+  test("a product_api red that DID get a response still drafts the down task", () => {
+    const answered: ProductHealth = {
+      ...unreachable,
+      probes: [{ name: "product_api", status: "red", detail: "https://api.averray.com/health → HTTP 503", sparkline: [] }],
+    };
+    const byId = Object.fromEntries(opsSuggestions(answered).map((s) => [s.id, s]));
+    expect(byId["product-api-down"]).toBeTruthy();
+    expect(byId["product-api-unreachable"]).toBeUndefined();
+  });
+
+  test("dependent probes with no reading raise no suggestions at all", () => {
+    const blind: ProductHealth = {
+      ...unreachable,
+      probes: [
+        { name: "money_path", status: "degraded", reading: "unknown", detail: "settlement state unknown, not stalled — product /health not readable from here — DNS resolution failed (ENOTFOUND)", sparkline: [] },
+        { name: "api_latency", status: "degraded", reading: "unknown", detail: "round-trip latency unknown, not slow — product /health not readable from here — DNS resolution failed (ENOTFOUND)", sparkline: [] },
+      ],
+    };
+    expect(opsSuggestions(blind)).toEqual([]);
+  });
+});

--- a/packages/monitor-ui/src/lib/monitor/ops-suggestions.ts
+++ b/packages/monitor-ui/src/lib/monitor/ops-suggestions.ts
@@ -66,9 +66,24 @@ export function opsSuggestions(health: ProductHealth | undefined): OpsSuggestion
   // worker can help, or a PREPARE-only task for anything touching funds (compute +
   // draft, never a transfer). Ordered most-actionable first.
 
-  // 1. Product API down — the product itself is failing its health check.
+  // 1. Product API — two different incidents wearing the same `red`.
+  //
+  // A red we could not READ is not the product failing its health check; it is
+  // us failing to ask. Drafting the "down" task for it hands a worker an
+  // instruction to tail the product's logs and roll back a deploy over a fault
+  // that is on our side of the wire — which is what 2026-08-06 would have
+  // produced, on top of paging on-call about a product serving 200s.
   const api = live("product_api");
-  if (api && api.status === "red") {
+  if (api && api.status === "red" && api.reading === "unknown") {
+    out.push({
+      id: "product-api-unreachable",
+      tone: "act",
+      text: `Product API unreachable from the monitor — ${api.detail}.`,
+      task: proposeTask(
+        `The monitor cannot reach the live product API: "${api.detail}". This is a REACHABILITY fault as observed from the monitor's container, not an established product outage — establish which it is BEFORE touching the product. Curl /health from outside the container and from another network; check the monitor container's DNS resolution and egress; only if the product is genuinely unreachable from everywhere should you investigate the product itself. Do not roll back a deploy on this evidence alone.`,
+      ),
+    });
+  } else if (api && api.status === "red") {
     out.push({
       id: "product-api-down",
       tone: "act",

--- a/packages/monitor-ui/src/lib/monitor/product-health.ts
+++ b/packages/monitor-ui/src/lib/monitor/product-health.ts
@@ -12,10 +12,16 @@ import type { OpsVerdict } from "@avg/schemas/ops-verdict";
 export type ProbeStatus = "ok" | "degraded" | "red";
 export type ProductHealthStatus = "healthy" | "degraded" | "red" | "unknown";
 
+/** Whether the probe observed its subject at all. Absent ⇒ observed. The
+ *  service owns this contract (@avg/schemas/ops-verdict); the board renders it.
+ *  `"unknown"` is grey — no reading is not a finding about the subject. */
+export type ProbeReading = "observed" | "unknown";
+
 export interface ProductHealthProbe {
   name: string;
   status: ProbeStatus;
   detail: string;
+  reading?: ProbeReading;
   /** Per-check statuses, oldest → newest (feeds the sparkline). */
   sparkline: ProbeStatus[];
 }

--- a/packages/schemas/src/ops-verdict.test.ts
+++ b/packages/schemas/src/ops-verdict.test.ts
@@ -4,6 +4,7 @@ import {
   deriveOpsVerdict,
   isAcknowledgedProbe,
   isAwaitingProbe,
+  isUnknownReadingProbe,
   payoutGap,
   probeCensus,
   type VerdictInput,
@@ -206,6 +207,76 @@ describe("deriveOpsVerdict — the hierarchy", () => {
     ];
     const reasons = cases.map((c) => deriveOpsVerdict(c).reason);
     expect(new Set(reasons).size).toBe(cases.length);
+  });
+});
+
+// ── A probe with no READING ────────────────────────────────────────────────
+//
+// 2026-08-06: container DNS failed for five minutes. The four probes that read
+// out of the product's /health had no reading of anything, and the board turned
+// that into "Product API is red" plus three corroborating degradations — a
+// unanimous verdict on a product that was serving 200s throughout.
+describe("unknown readings", () => {
+  const unknown = (over: Partial<VerdictProbe> = {}): VerdictProbe =>
+    probe({
+      name: "money_path",
+      status: "degraded",
+      reading: "unknown",
+      detail: "settlement state unknown, not stalled — product /health not readable from here — DNS resolution failed (ENOTFOUND)",
+      ...over,
+    });
+
+  test("is grey, not amber — no reading is not a finding", () => {
+    expect(isAwaitingProbe(unknown())).toBe(true);
+    expect(isUnknownReadingProbe(unknown())).toBe(true);
+  });
+
+  test("cannot take the DEGRADED headline", () => {
+    const v = deriveOpsVerdict(input({ probes: [probe(), unknown()] }));
+    expect(v.reason).not.toBe("probe-degraded");
+  });
+
+  test("but is never laundered into NOMINAL either", () => {
+    // The mirror-image failure, and the easier one to ship by accident: grey out
+    // the probes that could not read, and the rest of the board is green.
+    const v = deriveOpsVerdict(input({ probes: [probe(), unknown()] }));
+    expect(v.reason).toBe("probe-unknown");
+    expect(v.headline).toContain("UNKNOWN");
+    expect(v.tone).toBe("awaiting");
+  });
+
+  test("is counted in its own census bucket, apart from awaiting-data", () => {
+    // Different facts: awaiting means the product does not publish this yet,
+    // unknown means we could not read what it does publish.
+    const census = probeCensus([
+      probe(),
+      unknown(),
+      probe({ name: "capabilities", status: "degraded", detail: "not exposed by /health yet" }),
+    ]);
+    expect(census).toBe("1 ok / 1 awaiting data / 1 unknown / 0 red");
+  });
+
+  test("an observed degradation still outranks an unknown", () => {
+    // A fault you can see is more actionable than one you cannot.
+    const v = deriveOpsVerdict(input({
+      probes: [unknown(), probe({ name: "disk_headroom", status: "degraded", detail: "4.1GB free" })],
+    }));
+    expect(v.reason).toBe("probe-degraded");
+  });
+
+  test("a red with no reading is headlined UNREACHABLE, not RED", () => {
+    // Same alarm, truthfully named: what persisted is our inability to reach it.
+    const v = deriveOpsVerdict(input({
+      probes: [probe({ status: "red", reading: "unknown", detail: "probe cannot reach https://api.averray.com/health — DNS resolution failed (ENOTFOUND) · 3 consecutive checks" })],
+    }));
+    expect(v.reason).toBe("probe-red");
+    expect(v.headline).toBe("PRODUCT API UNREACHABLE");
+    expect(v.tone).toBe("red");
+  });
+
+  test("an ordinary red still says RED", () => {
+    const v = deriveOpsVerdict(input({ probes: [probe({ status: "red", detail: "→ HTTP 503" })] }));
+    expect(v.headline).toBe("PRODUCT API RED");
   });
 });
 

--- a/packages/schemas/src/ops-verdict.ts
+++ b/packages/schemas/src/ops-verdict.ts
@@ -21,10 +21,24 @@
 export type VerdictStatus = "ok" | "degraded" | "red";
 export type VerdictTone = "ok" | "degraded" | "red" | "awaiting";
 
+/**
+ * Whether the probe OBSERVED its subject — a second axis, orthogonal to status.
+ *
+ * `"unknown"` means it took no reading at all (the transport failed before any
+ * response arrived). That is never evidence the subject is degraded, so an
+ * unknown reading is greyed and cannot take the verdict — up until the probe
+ * itself decides the fault has persisted long enough to red, which is a claim
+ * about REACHABILITY and is worded as one.
+ *
+ * Absent ⇒ observed. Producers that predate the field are unaffected.
+ */
+export type VerdictReading = "observed" | "unknown";
+
 export interface VerdictProbe {
   name: string;
   status: VerdictStatus;
   detail: string;
+  reading?: VerdictReading;
 }
 
 export interface VerdictPool {
@@ -81,6 +95,7 @@ export type VerdictReason =
   | "probe-red"
   | "payout-shortfall"
   | "probe-degraded"
+  | "probe-unknown"
   | "pool-draining"
   | "nominal";
 
@@ -124,8 +139,32 @@ const AWAITING_RE = /awaiting|not expose|not wired|not configured|unconfigured|n
  * required `degraded` all along. They are siblings and should never have
  * differed.
  */
-export function isAwaitingProbe(probe: { status: VerdictStatus; detail: string }): boolean {
+export function isAwaitingProbe(probe: { status: VerdictStatus; detail: string; reading?: VerdictReading }): boolean {
+  // A probe that took no reading is grey by DECLARATION, not by prose. That is
+  // the whole point of the second axis: the paragraph above is a list of ways
+  // the string-matching version got it wrong, and every one of them is a bug
+  // this branch cannot have.
+  //
+  // `red` is excluded for the same reason it always was — a page-worthy probe
+  // leads the verdict whatever else is true of it. A red WITH an unknown reading
+  // is not silently downgraded; it is worded as unreachability instead of as a
+  // verdict on the subject (see deriveOpsVerdict).
+  if (probe.reading === "unknown") return probe.status !== "red";
   return probe.status === "degraded" && AWAITING_RE.test(probe.detail);
+}
+
+/**
+ * A probe with no reading of its subject — grey, and never a finding about it.
+ *
+ * `status` is typed loosely on purpose. Several consumers (the morning digest
+ * among them) carry probes with a bare `string` status, and the alternative to
+ * accepting them is a second copy of this predicate living somewhere else. This
+ * file already documents where that road goes: the awaiting classifier was
+ * duplicated once under a comment reading "mirrors the frontend's regex", and
+ * the two drifted. One classifier, slightly loose, beats two that agree today.
+ */
+export function isUnknownReadingProbe(probe: { status: string; reading?: string }): boolean {
+  return probe.reading === "unknown" && probe.status !== "red";
 }
 
 // A degradation the operator has already triaged and declared expected. On
@@ -155,17 +194,24 @@ function unacknowledgedDegraded(probes: readonly VerdictProbe[]): VerdictProbe[]
   );
 }
 
-/** Acknowledged degradations are COUNTED and LABELLED, never dropped. */
+/** Acknowledged degradations are COUNTED and LABELLED, never dropped.
+ *
+ *  "Unknown" gets its own bucket rather than being folded into "awaiting data".
+ *  They are different facts — awaiting means the product does not publish this
+ *  yet, unknown means we could not read what it does publish — and a reader
+ *  deciding whether to trust the rest of the board needs to tell them apart. */
 export function probeCensus(probes: readonly VerdictProbe[]): string {
-  const awaiting = probes.filter(isAwaitingProbe).length;
+  const unknown = probes.filter(isUnknownReadingProbe).length;
+  const awaiting = probes.filter((p) => isAwaitingProbe(p) && !isUnknownReadingProbe(p)).length;
   const red = probes.filter((p) => p.status === "red").length;
   const acked = probes.filter((p) => isAcknowledgedProbe(p) && !isAwaitingProbe(p)).length;
   const degraded = unacknowledgedDegraded(probes).length;
-  const ok = probes.length - red - degraded - acked - awaiting;
+  const ok = probes.length - red - degraded - acked - awaiting - unknown;
   const parts = [`${ok} ok`];
   if (degraded > 0) parts.push(`${degraded} degraded`);
   if (acked > 0) parts.push(`${acked} degraded (acknowledged)`);
   if (awaiting > 0) parts.push(`${awaiting} awaiting data`);
+  if (unknown > 0) parts.push(`${unknown} unknown`);
   parts.push(`${red} red`);
   return parts.join(" / ");
 }
@@ -265,8 +311,13 @@ export function deriveOpsVerdict(input: VerdictInput): OpsVerdict {
   if (reds.length > 0) {
     const lead = reds[0]!;
     const extra = reds.length > 1 ? ` +${reds.length - 1}` : "";
+    // A red we could not READ is a red about the path, not about the subject.
+    // "PRODUCT API RED" over a container DNS failure is the false alarm that
+    // cost an operator five hours of believing the product was down on
+    // 2026-08-06; "PRODUCT API UNREACHABLE" is the same alarm, truthfully named.
+    const unreadable = lead.reading === "unknown";
     return {
-      headline: `${verdictProbeLabel(lead.name).toUpperCase()} RED${extra}`,
+      headline: `${verdictProbeLabel(lead.name).toUpperCase()} ${unreadable ? "UNREACHABLE" : "RED"}${extra}`,
       tone: "red",
       sub: `${lead.detail} · ${census}`,
       census,
@@ -296,6 +347,34 @@ export function deriveOpsVerdict(input: VerdictInput): OpsVerdict {
       sub: `${lead.detail} · ${census}`,
       census,
       reason: "probe-degraded",
+    };
+  }
+
+  // NOTHING READ IS NOT NOTHING WRONG.
+  //
+  // Ranked below observed degradations on purpose: a fault you can see is more
+  // actionable than one you cannot, and burying it under "we could not read
+  // four probes" would be its own kind of blindness.
+  //
+  // But it MUST outrank nominal. During the 2026-08-06 DNS failure the four
+  // /health-derived probes had no reading at all, and with them correctly
+  // greyed out the remaining probes were green — so without this branch the
+  // board would answer a blind monitor with "NOMINAL". That is the fake green
+  // this whole file exists to prevent, arrived at from the opposite direction.
+  //
+  // Tone is `awaiting`, not `degraded`: grey says "we do not know", amber would
+  // say "something is wrong with the product", and the entire point is that we
+  // have not established that.
+  const unknown = probes.filter(isUnknownReadingProbe);
+  if (unknown.length > 0) {
+    const lead = unknown[0]!;
+    const extra = unknown.length > 1 ? ` +${unknown.length - 1}` : "";
+    return {
+      headline: `${verdictProbeLabel(lead.name).toUpperCase()} UNKNOWN${extra}`,
+      tone: "awaiting",
+      sub: `${lead.detail} · ${census}`,
+      census,
+      reason: "probe-unknown",
     };
   }
 

--- a/services/slack-operator/src/index.ts
+++ b/services/slack-operator/src/index.ts
@@ -195,6 +195,7 @@ import {
   type ProductHealthSnapshot,
   type ProductHealthSnapshotBlocks,
 } from "./product-health.js";
+import type { TransportFailureRun } from "./probe-transport.js";
 import { deriveOpsVerdict } from "@avg/schemas";
 import { appendIncidents, readIncidents, reconcileIncidents } from "./product-health-incidents.js";
 import {
@@ -311,6 +312,8 @@ let productHealthIncidentsHydrated = false;
 const PRODUCT_HEALTH_INCIDENT_MAX = 200;
 // Block-advance tracker so a frozen chain (static height) isn't read as green.
 let productHealthChainAdvance: ChainAdvance | undefined;
+// Consecutive /health transport failures, so one DNS blip cannot page on-call.
+let productHealthTransportRun: TransportFailureRun | undefined;
 // Structured snapshot blocks (chain id / network / solvency / flow) for the Ops board.
 let productHealthSnapshotBlocks: ProductHealthSnapshotBlocks | undefined;
 
@@ -849,6 +852,11 @@ async function handleHttpRequest(request: http.IncomingMessage, response: http.S
         name: p.name,
         status: p.status,
         detail: p.detail,
+        // Emitted only when it says something. An agent reading this endpoint
+        // must be able to tell "the money path is degraded" from "we could not
+        // read the money path" WITHOUT parsing the prose — that distinction is
+        // the whole reason the field exists.
+        ...(p.reading === "unknown" ? { reading: p.reading } : {}),
         sparkline: probeSparkline(productHealthHistory, p.name, 30),
       })),
       // Structured Ops-board blocks (chain id / network / solvency / flow),
@@ -1869,7 +1877,12 @@ function currentProductHealthForHermes(): HermesProductHealthSnapshot | undefine
   if (!last) return undefined;
   return {
     status: last.status ?? "unknown",
-    probes: (last.probes ?? []).map((p) => ({ name: p.name, status: p.status, detail: p.detail })),
+    probes: (last.probes ?? []).map((p) => ({
+      name: p.name,
+      status: p.status,
+      ...(p.reading === "unknown" ? { reading: p.reading } : {}),
+      detail: p.detail,
+    })),
   };
 }
 
@@ -3367,6 +3380,11 @@ function startOperatorRoutines() {
   // only on an edge across the red boundary (entered-red / recovered).
   let prevProductHealthStatus: OpsStatus = "unknown";
   let lastOpsNarrationPostedAtMs = 0;
+  // Is there an announced red still waiting on its all-clear? Threaded so a
+  // recovery can never be silenced by the cooldown that damps repeated reds.
+  // Starts undefined, not false: this process may have booted into an incident
+  // a previous one announced, and that alarm still deserves closing.
+  let opsNarrationRedAnnounced: boolean | undefined;
   // Per-probe edge detection. Held in memory on purpose: after a restart every
   // probe is "first sight" and says nothing, which is the correct behaviour —
   // a redeploy must not page the operator about states that have not changed.
@@ -3653,8 +3671,10 @@ function startOperatorRoutines() {
         nowMs: Date.now(),
         previousSubmittedNotSettled:
           productHealthSnapshotBlocks?.flow?.submittedNotSettled,
+        ...(productHealthTransportRun ? { transportRun: productHealthTransportRun } : {}),
       });
       productHealthChainAdvance = collection.chainAdvance;
+      productHealthTransportRun = collection.transportRun;
       productHealthSnapshotBlocks = collection.snapshot;
       // Decide + apply RPC auto-remediation from this cycle's read health. Pure
       // decision; the only effect is rotating which endpoint we read next tick
@@ -3814,8 +3834,10 @@ function startOperatorRoutines() {
         lastPostedAtMs: lastOpsNarrationPostedAtMs,
         nowMs: opsNarrationNowMs,
         cooldownMs: routineConfig.productHealth.cooldownMs,
+        ...(opsNarrationRedAnnounced === undefined ? {} : { redAnnounced: opsNarrationRedAnnounced }),
       });
       prevProductHealthStatus = result.status as OpsStatus;
+      opsNarrationRedAnnounced = opsNarration.redAnnounced;
       if (opsNarration.post && opsNarration.text) {
         try {
           recordCollaborationMessage({ author: "hermes", text: opsNarration.text, kind: "chat" });

--- a/services/slack-operator/src/monitor-hermes-voice.ts
+++ b/services/slack-operator/src/monitor-hermes-voice.ts
@@ -125,7 +125,11 @@ export interface HermesBoardCardSnapshot {
  */
 export interface HermesProductHealthSnapshot {
   status: string;
-  probes: ReadonlyArray<{ name: string; status: string; detail: string }>;
+  /** `reading: "unknown"` marks a probe that took NO reading of its subject.
+   *  Carried structurally rather than left to the detail prose: asked "is the
+   *  money path degraded?", a model shown only `status: degraded` will answer
+   *  yes about a subject nobody managed to observe. */
+  probes: ReadonlyArray<{ name: string; status: string; reading?: string; detail: string }>;
 }
 
 export interface HermesBoardSnapshot {

--- a/services/slack-operator/src/morning-digest.ts
+++ b/services/slack-operator/src/morning-digest.ts
@@ -43,6 +43,8 @@
 //
 // Kept pure — no clock, no I/O — so every rule is testable without a relay.
 
+import { isUnknownReadingProbe } from "@avg/schemas";
+
 import { greetingFor, probeLabel, statusGlyph } from "./ops-voice.js";
 
 export interface DigestSchedule {
@@ -142,6 +144,8 @@ export function digestDue(input: {
 export interface DigestProbe {
   name: string;
   status: string;
+  /** "unknown" ⇒ the probe took no reading at all. Absent ⇒ observed. */
+  reading?: string;
   detail: string;
 }
 
@@ -218,7 +222,16 @@ export function digestFactStrings(input: MorningDigestInput): string[] {
 export function buildMorningDigest(input: MorningDigestInput): string {
   const byName = new Map(input.probes.map((p) => [p.name, p] as const));
   const total = input.probes.length;
-  const attention = input.probes.filter((p) => p.status !== "ok");
+  // A probe that took NO READING is not a probe needing attention — it is an
+  // instrument that could not see. Counting them together turned one container
+  // DNS failure into "4 of 9 probes need attention" on 2026-08-06: four
+  // findings about a product nobody had managed to ask.
+  //
+  // They are still named, on their own line, because an unreadable instrument
+  // is exactly the thing the operator must know about before trusting the rest
+  // of the digest. Excluded from the count, never from the message.
+  const unreadable = input.probes.filter(isUnknownReadingProbe);
+  const attention = input.probes.filter((p) => p.status !== "ok" && !isUnknownReadingProbe(p));
   const reds = attention.filter((p) => p.status === "red").length;
 
   const greeting = greetingFor(input.localTime);
@@ -227,7 +240,9 @@ export function buildMorningDigest(input: MorningDigestInput): string {
     total === 0
       ? `${greeting} — no probes reporting on ${where}.`
       : attention.length === 0
-        ? `${greeting} — all ${total} probes green on ${where}.`
+        ? unreadable.length > 0
+          ? `${greeting} — ${total - unreadable.length} of ${total} probes green on ${where}; ${unreadable.length} could not be read.`
+          : `${greeting} — all ${total} probes green on ${where}.`
         : `${greeting} — ${attention.length} of ${total} probe${total === 1 ? "" : "s"} need${attention.length === 1 ? "s" : ""} attention on ${where}.`;
 
   const stamp =
@@ -253,6 +268,16 @@ export function buildMorningDigest(input: MorningDigestInput): string {
     lines.push("Needs attention:");
     for (const probe of redFirst) {
       lines.push(`${statusGlyph(probe.status)} ${probeLabel(probe.name)} — ${probe.detail}`);
+    }
+  }
+
+  // Its own heading, deliberately not "Needs attention". Nothing here is a
+  // finding about the product; the finding is that we could not look.
+  if (unreadable.length > 0) {
+    lines.push("");
+    lines.push("Could not be read (no evidence either way):");
+    for (const probe of unreadable) {
+      lines.push(`· ${probeLabel(probe.name)} — ${probe.detail}`);
     }
   }
 

--- a/services/slack-operator/src/ops-narration.ts
+++ b/services/slack-operator/src/ops-narration.ts
@@ -9,6 +9,36 @@
 // the operator is muted. Network tunes the wording: a mainnet red pages on-call;
 // a testnet red is informational.
 //
+// ── AN ANNOUNCED ALARM MUST BE CLOSED ───────────────────────────────────────
+//
+// The cooldown used to apply symmetrically, and on 2026-08-06 that produced the
+// worst possible outcome from a five-minute container DNS blip:
+//
+//   14:58  ⚠ Ops — Product API red …            posted, Buzz-published, paged
+//   15:03  (recovered)                          {"edge":"recovered",
+//                                                "suppressed":"cooldown"}
+//
+// The default cooldown is six hours, so the all-clear was not delayed — it was
+// deleted. For the rest of the day the last thing any human had heard was an
+// alarm about an outage that had already ended, and the board read as an
+// ongoing incident.
+//
+// The asymmetry is the fix, and it is not a special case — it follows from what
+// the two edges MEAN. A repeated red is redundant: the operator already knows,
+// which is exactly what a cooldown is for. A recovery is never redundant, and a
+// recovery that closes an announced alarm is the single most load-bearing
+// message this channel sends. Suppressing it does not reduce noise; it converts
+// a resolved incident into a permanent false alarm.
+//
+// So: the cooldown may silence reds. It may never silence the edge that closes
+// a red we announced.
+//
+// Mute is deliberately still honoured. It is an explicit operator action rather
+// than an automatic damper, it silences the opening red too (so in the ordinary
+// case there is no announced alarm left hanging), and the board and the Digest
+// both still show the state. That boundary is the same one probe-transitions.ts
+// draws, and the two should not disagree.
+//
 // Kept pure (no I/O, no @avg deps) so it runs in the local unit suite; the
 // caller (index.ts checkProductHealth) supplies prev/curr, the probes, the
 // resolved network, current mute state, and the last successful narration time.
@@ -35,6 +65,18 @@ export interface DecideOpsNarrationInput {
   nowMs?: number;
   /** Reuses PRODUCT_HEALTH_ALERT_COOLDOWN_MINUTES for transition narration. */
   cooldownMs?: number;
+  /**
+   * Was the currently-open red edge actually ANNOUNCED? Threaded across ticks by
+   * the caller from the previous decision's `redAnnounced`.
+   *
+   * `undefined` is NOT "no". It means nobody told us — a fresh process that
+   * booted into an ongoing red, or a standalone call — and the safe reading
+   * there is that the alarm WAS announced, so the all-clear still goes out.
+   * Silence is only correct when we have positive evidence we suppressed the
+   * red ourselves. probe-transitions.ts learned this the hard way: defaulting
+   * absent bookkeeping to "silent" swallowed every recovery it had.
+   */
+  redAnnounced?: boolean;
 }
 
 export interface OpsNarrationDecision {
@@ -44,7 +86,13 @@ export interface OpsNarrationDecision {
   /** The Hermes turn text — present only when `post` is true. */
   text?: string;
   /** Why a real edge did not post (for observability). */
-  suppressed?: "muted" | "cooldown";
+  suppressed?: "muted" | "cooldown" | "never-announced";
+  /**
+   * Whether an announced red is still open, to carry into the next tick. The
+   * caller stores this and hands it back as `redAnnounced`; it is the state
+   * that lets a recovery know whether it has an alarm to close.
+   */
+  redAnnounced: boolean;
 }
 
 // Probe naming lives in ops-voice.ts — one map for every chat surface.
@@ -56,31 +104,58 @@ function trim(detail: string, max = 160): string {
 
 export function decideOpsNarration(input: DecideOpsNarrationInput): OpsNarrationDecision {
   const { prev, curr, probes, network, muted } = input;
+  // Carried through every non-posting path so the caller's state never resets
+  // by accident — an announced red stays open until something closes it.
+  const carried = input.redAnnounced ?? false;
 
   // Never narrate the boot transition — a restart shouldn't spam the thread.
-  if (prev === "unknown") return { post: false };
+  if (prev === "unknown") return { post: false, redAnnounced: carried };
 
   const enteredRed = prev !== "red" && curr === "red";
   const recovered = prev === "red" && curr !== "red";
-  if (!enteredRed && !recovered) return { post: false };
+  if (!enteredRed && !recovered) return { post: false, redAnnounced: carried };
 
   const edge: "red" | "recovered" = enteredRed ? "red" : "recovered";
 
-  // Mute = quiet everywhere; the state still shows passively in the Digest ops line.
-  if (muted) return { post: false, edge, suppressed: "muted" };
+  // Was there an alarm to close? Absent bookkeeping means "we don't know", and
+  // the honest default is that there was — see `redAnnounced` on the input.
+  const closesAnAnnouncedRed = recovered && (input.redAnnounced ?? true);
+
+  // Mute = quiet everywhere; the state still shows passively in the Digest ops
+  // line. Applied to both edges, so a muted red is not announced and there is
+  // no dangling alarm for the matching recovery to owe an all-clear to.
+  if (muted) return { post: false, edge, suppressed: "muted", redAnnounced: recovered ? false : carried };
+
+  // A recovery for a red we KNOW we suppressed is an all-clear for an alarm
+  // nobody was ever given. Saying it is its own small lie — it implies there was
+  // something to be clear of. Same rule probe-transitions.ts applies per-probe.
+  //
+  // Decided BEFORE the cooldown so the log says why it was quiet. Both would be
+  // true here, and "never-announced" is the one that explains itself; "cooldown"
+  // would read as "delayed", which is what sent someone looking for a recovery
+  // message that was never coming.
+  if (recovered && !closesAnAnnouncedRed) {
+    return { post: false, edge, suppressed: "never-announced", redAnnounced: false };
+  }
 
   // A health probe can briefly cross red and recover when its upstream flakes.
   // Use the same operator-configured cooldown as D4 alerts so those edges remain
   // visible on the board without producing a red → recovered → red chat storm.
+  //
+  // This now governs RED EDGES ONLY. Every recovery that reaches this line
+  // closes an announced alarm, and a cooldown exists to stop repeating what the
+  // operator already heard — an all-clear is by definition something they
+  // have not.
   const lastPostedAtMs = input.lastPostedAtMs ?? 0;
   const nowMs = input.nowMs ?? Date.now();
   const cooldownMs = Math.max(0, input.cooldownMs ?? 0);
   if (
-    cooldownMs > 0
+    edge === "red"
+    && cooldownMs > 0
     && lastPostedAtMs > 0
     && nowMs - lastPostedAtMs < cooldownMs
   ) {
-    return { post: false, edge, suppressed: "cooldown" };
+    return { post: false, edge, suppressed: "cooldown", redAnnounced: carried };
   }
 
   if (edge === "red") {
@@ -93,6 +168,7 @@ export function decideOpsNarration(input: DecideOpsNarrationInput): OpsNarration
       post: true,
       edge,
       text: `⚠ Ops — ${lead ? probeLabel(lead.name) : "a probe"} red${detail}${extra}. ${tone}`,
+      redAnnounced: true,
     };
   }
 
@@ -100,5 +176,6 @@ export function decideOpsNarration(input: DecideOpsNarrationInput): OpsNarration
     post: true,
     edge,
     text: `✓ Ops recovered — product health back to ${curr}.`,
+    redAnnounced: false,
   };
 }

--- a/services/slack-operator/src/probe-transitions.ts
+++ b/services/slack-operator/src/probe-transitions.ts
@@ -144,9 +144,16 @@ export function reasonClass(probe: ProbeResult): string {
  * these land on a phone now — outranked grep, and the reason-class `key`
  * still carries the enum for anything programmatic.
  */
-function alertText(probe: ProbeResult, kind: "opened" | "recovered", before?: ProbeStatus): string {
+function alertText(probe: ProbeResult, kind: "opened" | "recovered", before?: ProbeResult): string {
   const label = probeLabel(probe.name);
-  if (kind === "recovered") return `✓ ${label} recovered — ${probe.detail}`;
+  if (kind === "recovered") {
+    // "recovered" claims the subject got better. When the alarm being closed was
+    // that we could not READ the subject, the honest verb is that it became
+    // readable again — we never established it was unwell in the first place.
+    return before?.reading === "unknown"
+      ? `✓ ${label} readable again — ${probe.detail}`
+      : `✓ ${label} recovered — ${probe.detail}`;
+  }
 
   // The next step rides ONLY on an opening alert. A recovery needs no advice,
   // and appending one would read as "it healed, now go do something".
@@ -156,12 +163,32 @@ function alertText(probe: ProbeResult, kind: "opened" | "recovered", before?: Pr
   const step = opsNextStep(probe.name);
   const next = step ? ` · next: ${step}` : "";
 
+  // A red with no reading is page-worthy UNREACHABILITY, not a verdict on the
+  // subject. "Product API is red — fetch failed" was the 2026-08-06 headline,
+  // and it was wrong twice: the product was up, and the actual fault (ENOTFOUND
+  // inside our own container) was nowhere in the sentence.
+  if (probe.status === "red" && probe.reading === "unknown") {
+    return `✗ ${label} unreachable from the monitor — ${probe.detail}${next}`;
+  }
   if (probe.status === "red") return `✗ ${label} is red — ${probe.detail}${next}`;
-  if (before === "red") return `⚠ ${label} eased to degraded — ${probe.detail}${next}`;
+  if (before?.status === "red") return `⚠ ${label} eased to degraded — ${probe.detail}${next}`;
   return `⚠ ${label} degraded — ${probe.detail}${next}`;
 }
 
-const isAlarm = (status: ProbeStatus): boolean => status === "degraded" || status === "red";
+/**
+ * Is this probe reporting something worth alerting on?
+ *
+ * A probe with no READING is not. It holds no evidence about its subject, so
+ * "money path degraded — settlement state unknown" is an alert about our own
+ * network, repeated once per dependent probe. On 2026-08-06 that would have
+ * been four of them for one DNS failure, on top of the false red.
+ *
+ * A red is always an alarm, unknown reading or not: by the time a probe reds on
+ * an unreadable subject it has decided the fault persisted long enough to need
+ * a human, and `alertText` words it as unreachability rather than as a verdict.
+ */
+const isAlarm = (probe: { status: ProbeStatus; reading?: ProbeResult["reading"] }): boolean =>
+  probe.status === "red" || (probe.status === "degraded" && probe.reading !== "unknown");
 
 /**
  * Decide which probes changed in a way worth saying out loud.
@@ -214,7 +241,7 @@ export function decideProbeTransitions(input: DecideProbeTransitionsInput): Prob
     // Production found this, not the tests: three deploys in one night produced
     // three duplicate money_path alerts, each one tick after a restart.
     if (!before) {
-      if (isAlarm(probe.status)) {
+      if (isAlarm(probe)) {
         // Marked ANNOUNCED on first sight, deliberately. An alarm that was
         // already burning when this process started is not news, and without
         // this it would simply re-earn its hold and page three ticks after every
@@ -226,11 +253,11 @@ export function decideProbeTransitions(input: DecideProbeTransitionsInput): Prob
       }
       continue;
     }
-    if (before.status === probe.status && !isAlarm(probe.status)) continue;
+    if (before.status === probe.status && !isAlarm(probe)) continue;
 
-    const recovered = !isAlarm(probe.status) && isAlarm(before.status);
+    const recovered = !isAlarm(probe) && isAlarm(before);
 
-    if (isAlarm(probe.status)) {
+    if (isAlarm(probe)) {
       const key = reasonClass(probe);
 
       // THE HOLD. A class that keeps flipping never accumulates a streak, so it
@@ -256,7 +283,7 @@ export function decideProbeTransitions(input: DecideProbeTransitionsInput): Prob
       keys.add(key);
       if (input.muted) continue;
 
-      alerts.push({ probe: probe.name, kind: "opened", from: before.status, to: probe.status, text: alertText(probe, "opened", before.status), key });
+      alerts.push({ probe: probe.name, kind: "opened", from: before.status, to: probe.status, text: alertText(probe, "opened", before), key });
       continue;
     }
 
@@ -284,7 +311,7 @@ export function decideProbeTransitions(input: DecideProbeTransitionsInput): Prob
       const heldBack = (input.streaks?.get(beforeClass) ?? Number.MAX_SAFE_INTEGER)
         < holdRequired(before.status, minDegradedTicks);
       if (!heldBack && !input.posted.has(key) && !input.muted) {
-        alerts.push({ probe: probe.name, kind: "recovered", from: before.status, to: probe.status, text: alertText(probe, "recovered"), key });
+        alerts.push({ probe: probe.name, kind: "recovered", from: before.status, to: probe.status, text: alertText(probe, "recovered", before), key });
       }
       // Recovery keys are NOT retained: the next time this probe breaks and
       // heals, that is genuinely new and must be sayable again.

--- a/services/slack-operator/src/probe-transport.ts
+++ b/services/slack-operator/src/probe-transport.ts
@@ -1,0 +1,192 @@
+// Transport-layer failure classification — telling "the product answered badly"
+// apart from "we never got to ask".
+//
+// ── WHY THIS EXISTS ─────────────────────────────────────────────────────────
+//
+// On 2026-08-06 container-local DNS failed for about five minutes. Every probe
+// that reaches out over the network failed at once, and the board said:
+//
+//   Product API is red — https://api.averray.com/health unreachable: fetch failed
+//
+// The product was up the whole time; 200s were served from outside throughout.
+// What the probe actually knew was that IT could not resolve the host from
+// inside its own container. Those are different claims, and only one of them
+// was true.
+//
+// The wording was not the only problem. "fetch failed" is undici's OUTER
+// message; the cause code — ENOTFOUND — was sitting one level down in
+// `err.cause` and never made it to a human. So the alert managed to be both
+// overconfident about the product and uninformative about the actual fault.
+//
+// ── WHAT THIS MODULE DECIDES ────────────────────────────────────────────────
+//
+// Two things, both pure:
+//
+//  1. Did this failure happen BELOW HTTP? A 503 is evidence about the product.
+//     A DNS failure, a refused connection, a TLS handshake error or a connect
+//     timeout is evidence about the path between us and the product — and says
+//     nothing about the product itself.
+//  2. How many consecutive cycles has it now been failing? A single-shot DNS
+//     blip must not page on-call; a sustained one must.
+//
+// No I/O, no clock, no config, so every rule here is unit-testable.
+
+/** What kind of thing went wrong below HTTP. Drives the human phrasing only —
+ *  the alert decision keys on `code` + the consecutive count. */
+export type TransportFailureKind = "dns" | "connect" | "tls" | "timeout" | "transport";
+
+export interface TransportFailure {
+  kind: TransportFailureKind;
+  /** The underlying cause code — ENOTFOUND, ECONNREFUSED, … "UNKNOWN" when the
+   *  error carried none. Never invented: UNKNOWN means we could not name it. */
+  code: string;
+  /** The deepest message in the cause chain — the one that says something. */
+  message: string;
+}
+
+/** Codes that mean the name never resolved. */
+const DNS_CODES = new Set(["ENOTFOUND", "EAI_AGAIN", "EAI_NODATA", "EAI_NONAME"]);
+/** Codes that mean we reached the network and it refused / vanished. */
+const CONNECT_CODES = new Set([
+  "ECONNREFUSED",
+  "ECONNRESET",
+  "EHOSTUNREACH",
+  "ENETUNREACH",
+  "ENETDOWN",
+  "EPIPE",
+  "EADDRNOTAVAIL",
+  "UND_ERR_SOCKET",
+  "UND_ERR_CONNECT_TIMEOUT",
+]);
+/** Codes that mean the handshake, not the request, failed. */
+const TLS_CODES = new Set([
+  "CERT_HAS_EXPIRED",
+  "DEPTH_ZERO_SELF_SIGNED_CERT",
+  "SELF_SIGNED_CERT_IN_CHAIN",
+  "UNABLE_TO_VERIFY_LEAF_SIGNATURE",
+  "ERR_TLS_CERT_ALTNAME_INVALID",
+  "ERR_SSL_WRONG_VERSION_NUMBER",
+  "EPROTO",
+]);
+/** Codes that mean we waited and nothing came back. */
+const TIMEOUT_CODES = new Set([
+  "ETIMEDOUT",
+  "UND_ERR_HEADERS_TIMEOUT",
+  "UND_ERR_BODY_TIMEOUT",
+  "ABORT_ERR",
+]);
+
+function kindFor(code: string, message: string): TransportFailureKind {
+  if (DNS_CODES.has(code)) return "dns";
+  if (TLS_CODES.has(code)) return "tls";
+  if (TIMEOUT_CODES.has(code)) return "timeout";
+  if (CONNECT_CODES.has(code)) return "connect";
+  // Codeless errors still say what they are in words often enough to be worth
+  // reading — but only as a fallback, never in preference to a real code.
+  if (/getaddrinfo|dns/i.test(message)) return "dns";
+  if (/timed? ?out|timeout/i.test(message)) return "timeout";
+  if (/tls|ssl|certificate/i.test(message)) return "tls";
+  if (/econnrefused|refused|socket|network/i.test(message)) return "connect";
+  return "transport";
+}
+
+/**
+ * Walk an error's `cause` chain and pull out the deepest thing that names
+ * itself.
+ *
+ * `fetch()` on undici throws `TypeError: fetch failed` and hangs the real error
+ * off `.cause` — sometimes two levels down (an AggregateError of per-address
+ * attempts). Reading only the top-level message is how "fetch failed" reached
+ * an operator's phone as the entire explanation of a five-minute incident.
+ */
+export function classifyTransportFailure(err: unknown): TransportFailure {
+  let code: string | undefined;
+  let message = "";
+  const seen = new Set<unknown>();
+  let current: unknown = err;
+
+  for (let depth = 0; current !== undefined && current !== null && depth < 8; depth += 1) {
+    if (seen.has(current)) break;
+    seen.add(current);
+    const node = current as { code?: unknown; message?: unknown; errors?: unknown; cause?: unknown };
+    // The DEEPEST code wins: undici's outer TypeError has none, and the socket
+    // error underneath is the one that names ENOTFOUND.
+    if (typeof node.code === "string" && node.code.trim()) code = node.code.trim();
+    if (typeof node.message === "string" && node.message.trim()) message = node.message.trim();
+    // AggregateError from a multi-address connect attempt — the individual
+    // failures carry the codes; take the first, they share a cause in practice.
+    const aggregated = Array.isArray(node.errors) ? node.errors[0] : undefined;
+    current = node.cause ?? aggregated;
+  }
+
+  if (!message) message = typeof err === "string" ? err : String(err ?? "");
+  const resolved = code ?? "UNKNOWN";
+  return { kind: kindFor(resolved, message), code: resolved, message };
+}
+
+/** Human phrasing for the fault, cause code included. "DNS resolution failed
+ *  (ENOTFOUND)" — the kind is for reading, the code is what you grep for. */
+export function describeTransportFailure(failure: TransportFailure): string {
+  const named =
+    failure.kind === "dns"
+      ? "DNS resolution failed"
+      : failure.kind === "tls"
+        ? "TLS handshake failed"
+        : failure.kind === "timeout"
+          ? "no response before the timeout"
+          : failure.kind === "connect"
+            ? "connection failed"
+            : "transport failed";
+  return failure.code === "UNKNOWN" ? `${named} (${failure.message})` : `${named} (${failure.code})`;
+}
+
+/**
+ * How many consecutive cycles the transport has now failed, and under what code.
+ *
+ * Threaded by the caller across ticks exactly like `trackChainAdvance` — pure
+ * in, pure out, nothing persisted here.
+ */
+export interface TransportFailureRun {
+  /** The most recent cause code seen in this run. */
+  code: string;
+  /** Consecutive failing cycles, including this one. Never zero. */
+  consecutive: number;
+}
+
+/**
+ * Advance the run.
+ *
+ * A success clears it — recovery is immediate, because the reason to hold is
+ * uncertainty and a successful read removes it.
+ *
+ * The count does NOT reset when the code changes. A real outage walks through
+ * codes (ENOTFOUND while the resolver is down, then ECONNREFUSED as it comes
+ * back on a dead port), and restarting the count on each one would keep the
+ * hold armed indefinitely — a way to never page at all.
+ */
+export function trackTransportFailure(
+  prev: TransportFailureRun | undefined,
+  failure: TransportFailure | undefined,
+): TransportFailureRun | undefined {
+  if (!failure) return undefined;
+  return { code: failure.code, consecutive: (prev?.consecutive ?? 0) + 1 };
+}
+
+/** Default consecutive failures before a transport fault is worth paging for.
+ *  At the default 2-minute cadence that is ~4–6 minutes of sustained failure. */
+export const DEFAULT_TRANSPORT_FAIL_THRESHOLD = 3;
+
+/**
+ * Has this run earned a page?
+ *
+ * Below the threshold the honest report is "we cannot see the product", which
+ * is not the same claim as "the product is down" and must not wake anyone. At
+ * the threshold it is still not the same claim — but it has persisted long
+ * enough that somebody has to go look, whichever side of the wire is broken.
+ */
+export function transportFailureIsPageWorthy(
+  run: TransportFailureRun | undefined,
+  threshold: number = DEFAULT_TRANSPORT_FAIL_THRESHOLD,
+): boolean {
+  return !!run && run.consecutive >= Math.max(1, threshold);
+}

--- a/services/slack-operator/src/product-health.ts
+++ b/services/slack-operator/src/product-health.ts
@@ -48,15 +48,51 @@ import { createGasSpendCache, type GasSpendCache, type GasSpendSnapshot, type Ga
 import { alertProvenance, decideMoneyAlert } from "./money-alert.js";
 import { decideSelfFreshness, fetchSelfCompare } from "./self-freshness.js";
 import type { SelfFreshness } from "./self-freshness.js";
+import {
+  classifyTransportFailure,
+  describeTransportFailure,
+  trackTransportFailure,
+  transportFailureIsPageWorthy,
+  DEFAULT_TRANSPORT_FAIL_THRESHOLD,
+  type TransportFailure,
+  type TransportFailureRun,
+} from "./probe-transport.js";
 import { isAwaitingProbe } from "@avg/schemas";
 
 export type ProbeStatus = "ok" | "degraded" | "red";
+
+/**
+ * Did the probe actually OBSERVE its subject?
+ *
+ * This is a second axis, deliberately separate from `status`. `status` says how
+ * bad it is; `reading` says whether we saw anything at all. Conflating them is
+ * what produced "Product API is red — fetch failed" during the 2026-08-06 DNS
+ * incident: the probe could not resolve the host from inside its own container
+ * and reported that as a verdict on the product, which was serving 200s
+ * throughout.
+ *
+ * `"unknown"` means the probe has NO reading of its subject. It is never
+ * evidence that the subject is degraded, and readers must render it grey.
+ *
+ * `status` is still populated alongside it — `degraded` while we hold, `red`
+ * once the fault has persisted long enough to page — so a reader that predates
+ * this field lands on amber-and-quiet rather than on a fake green.
+ */
+export type ProbeReading = "observed" | "unknown";
 
 export interface ProbeResult {
   /** Stable probe id, e.g. "product_api" | "chain_height" | "signer_liquidity". */
   name: string;
   status: ProbeStatus;
   detail: string;
+  /** Absent ⇒ "observed". Only ever set to "unknown", and only by a probe that
+   *  genuinely could not take a reading. See ProbeReading. */
+  reading?: ProbeReading;
+}
+
+/** The probe took no reading of its subject — grey, and never a claim about it. */
+export function isUnknownReading(probe: { reading?: ProbeReading }): boolean {
+  return probe.reading === "unknown";
 }
 
 export type ProductHealthStatus = "healthy" | "degraded" | "red";
@@ -129,8 +165,8 @@ export function probeSparkline(
  *  degradation. The classifier lives in @avg/schemas because the BOARD applies
  *  the same rule — it used to be copied here under a comment reading "mirrors
  *  the frontend's awaiting regex", which is a drift bug with a countdown on it. */
-function isAwaitingDetail(status: ProbeStatus, detail: string): boolean {
-  return isAwaitingProbe({ status, detail });
+function isAwaitingDetail(probe: ProbeResult): boolean {
+  return isAwaitingProbe(probe);
 }
 
 export interface ProductHealthIncident {
@@ -172,10 +208,15 @@ export interface ProductHealthHistoryBlock {
 
 /** Product reachability is deliberately independent from the overall monitor
  * status. RPC, GitHub, or balance-reader failures can degrade the monitor while
- * the product's own /health endpoint remains available. */
+ * the product's own /health endpoint remains available.
+ *
+ * A sample with no READING is indeterminate whatever its status — "we could not
+ * reach the host from this container" is not a downtime sample, and counting it
+ * as one would put our own DNS outage in the product's uptime figure. */
 function productAvailabilityTone(snapshot: ProductHealthSnapshot): ProbeStatus {
   const probe = snapshot.probes.find((p) => p.name === "product_api");
-  return probe?.status === "ok" || probe?.status === "red" ? probe.status : "degraded";
+  if (!probe || isUnknownReading(probe)) return "degraded";
+  return probe.status === "ok" || probe.status === "red" ? probe.status : "degraded";
 }
 
 /**
@@ -255,6 +296,11 @@ function isProductApiDependentFailure(
   if (!probe || !PRODUCT_API_DEPENDENT_PROBES.has(probe.name)) return false;
   const productApi = snapshot.probes.find((candidate) => candidate.name === "product_api");
   if (!productApi || productApi.status === "ok") return false;
+  // `reading` is the structural test and is preferred. The prose match stays
+  // for snapshots persisted before the field existed — history on disk outlives
+  // the code that wrote it, and dropping the fallback would silently reclassify
+  // every incident already in the log.
+  if (isUnknownReading(probe)) return true;
   return /product \/health not readable|no response after/i.test(probe.detail);
 }
 
@@ -281,7 +327,7 @@ function deriveIncidents(history: ReadonlyArray<ProductHealthSnapshot>): Product
       const bad =
         !!probe &&
         (probe.status === "red" ||
-          (probe.status === "degraded" && !isAwaitingDetail(probe.status, probe.detail)));
+          (probe.status === "degraded" && !isAwaitingDetail(probe)));
       if (bad) {
         if (startedAt === null) {
           startedAt = snap.at;
@@ -602,6 +648,10 @@ export interface ProductHealthConfig {
   /** Halt severity: "auto" (mainnet chainId → red, testnet → degraded) | "red" |
    *  "degraded". Env: PRODUCT_HEALTH_HALT_SEVERITY. */
   haltSeverity: string;
+  /** Consecutive cycles the /health transport must fail before product_api reds.
+   *  A one-off DNS blip is not an outage; five minutes of one needs a human.
+   *  Env: PRODUCT_HEALTH_TRANSPORT_FAIL_THRESHOLD. Default 3. */
+  transportFailThreshold?: number;
   /** 0-based word index of `rejectedAt` in the EscrowCore job struct.
    *  Defaults to the calibrated 17 — verified against the chain, not an ABI.
    *  See external-funnel.ts for the three confirmations. */
@@ -729,6 +779,10 @@ export function loadProductHealthConfig(env: NodeJS.ProcessEnv = process.env): P
     rpcUrl: env.PRODUCT_HEALTH_RPC_URL || networkEthRpc(env.WALLET_NETWORK),
     chainMaxStaleSeconds: num(env.PRODUCT_HEALTH_CHAIN_MAX_STALE_SECONDS, 600),
     haltSeverity: env.PRODUCT_HEALTH_HALT_SEVERITY || "auto",
+    transportFailThreshold: Math.max(
+      1,
+      num(env.PRODUCT_HEALTH_TRANSPORT_FAIL_THRESHOLD, DEFAULT_TRANSPORT_FAIL_THRESHOLD),
+    ),
     ...(env.PRODUCT_HEALTH_ESCROW_REJECTED_AT_WORD
       ? { escrowRejectedAtWord: Number(env.PRODUCT_HEALTH_ESCROW_REJECTED_AT_WORD) }
       : {}),
@@ -847,6 +901,12 @@ export interface ProductHealthFetch {
   url: string;
   body?: ProductHealthPayload;
   error?: string;
+  /**
+   * Set when the request died BELOW HTTP — no response ever arrived, so nothing
+   * here is evidence about the product. Carries the cause code (ENOTFOUND, …)
+   * dug out of undici's `cause` chain, which the outer "fetch failed" hides.
+   */
+  transport?: TransportFailure;
   /** Wall-clock ms for the /health GET round-trip. undefined when unconfigured. */
   latencyMs?: number;
 }
@@ -924,15 +984,120 @@ export async function fetchProductHealth(input: {
     }
     return { configured: true, reachable: true, httpOk: res.ok, status: res.status, url, body, latencyMs };
   } catch (err) {
-    return { configured: true, reachable: false, httpOk: false, status: 0, url, error: errMsg(err), latencyMs: Date.now() - startedAt };
+    // A throw here means no HTTP response arrived at all. Classify it so the
+    // probe can say WHICH layer failed and with what code, instead of relaying
+    // undici's uninformative outer "fetch failed".
+    const transport = classifyTransportFailure(err);
+    return {
+      configured: true,
+      reachable: false,
+      httpOk: false,
+      status: 0,
+      url,
+      error: errMsg(err),
+      transport,
+      latencyMs: Date.now() - startedAt,
+    };
   }
 }
 
-/** Is the Averray product API answering? REAL as soon as AVERRAY_API_BASE_URL is set. */
-export function deriveProductApiProbe(h: ProductHealthFetch): ProbeResult {
+/**
+ * The transport fault behind an unreadable /health, if there was one.
+ *
+ * `configured && !reachable` ALWAYS means no HTTP response arrived — that is
+ * what `reachable` records — so a fetch that failed without a classified error
+ * still resolves to a transport fault, just an unnamed one. Returning undefined
+ * there would quietly restore the old behaviour for exactly the callers that
+ * hand-build a fetch result.
+ */
+function transportFaultOf(h: ProductHealthFetch): TransportFailure | undefined {
+  if (!h.configured || h.reachable) return undefined;
+  return h.transport ?? { kind: "transport", code: "UNKNOWN", message: h.error ?? "fetch failed" };
+}
+
+/** "product /health not readable from here — DNS resolution failed (ENOTFOUND)" */
+function unreadableBecause(fault: TransportFailure): string {
+  return `product /health not readable from here — ${describeTransportFailure(fault)}`;
+}
+
+/**
+ * A dependent probe's reading when the one /health fetch they all share failed
+ * below HTTP.
+ *
+ * `unknown`, never `degraded`-as-a-verdict: chain height, capabilities,
+ * settlement counts and latency are all read OUT of that one response, so when
+ * it never arrives we hold no evidence about any of them. Saying "money path
+ * degraded" there is inventing a finding, and it was four of them at once on
+ * 2026-08-06.
+ *
+ * Phrasing follows external_funnel's "funnel state unknown, not empty", which
+ * has had this right all along: name the subject, say it is unknown, and say
+ * what it is NOT being claimed to be.
+ */
+function unknownDependent(name: string, subject: string, notClaim: string, fault: TransportFailure): ProbeResult {
+  return {
+    name,
+    // `degraded` is the compatibility floor for readers that predate `reading`
+    // — amber and quiet. Anything that understands `reading` renders grey.
+    status: "degraded",
+    reading: "unknown",
+    detail: `${subject} unknown, ${notClaim} — ${unreadableBecause(fault)}`,
+  };
+}
+
+/**
+ * Is the Averray product API answering? REAL as soon as AVERRAY_API_BASE_URL is set.
+ *
+ * ── TWO DIFFERENT CLAIMS ────────────────────────────────────────────────────
+ *
+ * An HTTP response — any HTTP response, including a 503 — is evidence about the
+ * product, and this probe reds on it immediately.
+ *
+ * No HTTP response is evidence about the PATH. The probe knows it could not
+ * reach the host from inside its own container; it does not know whether the
+ * product is up, and on 2026-08-06 it was (200s served from outside for the
+ * whole five-minute window in which this probe called it red).
+ *
+ * So a transport fault reports itself as what it is — unreachable from here,
+ * with the cause code — and holds `unknown` until it has failed
+ * `transportThreshold` consecutive cycles. Then it reds: not because we have
+ * learned the product is down, but because a fault that has persisted that long
+ * needs a human whichever side of the wire is broken. The claim stays honest at
+ * both ends; only the volume changes.
+ */
+export function deriveProductApiProbe(
+  h: ProductHealthFetch,
+  opts: {
+    /** Consecutive-failure run, threaded across ticks by the caller. */
+    transportRun?: TransportFailureRun;
+    /** Consecutive failing cycles before this pages. Default 3. */
+    transportThreshold?: number;
+  } = {},
+): ProbeResult {
   const name = "product_api";
   if (!h.configured) return { name, status: "degraded", detail: "AVERRAY_API_BASE_URL not configured" };
-  if (!h.reachable) return { name, status: "red", detail: `${h.url} unreachable: ${h.error ?? "fetch failed"}` };
+  const fault = transportFaultOf(h);
+  if (fault) {
+    const threshold = Math.max(1, opts.transportThreshold ?? DEFAULT_TRANSPORT_FAIL_THRESHOLD);
+    const run = opts.transportRun ?? { code: fault.code, consecutive: 1 };
+    const cause = describeTransportFailure(fault);
+    if (!transportFailureIsPageWorthy(run, threshold)) {
+      return {
+        name,
+        status: "degraded",
+        reading: "unknown",
+        detail: `probe cannot reach ${h.url} — ${cause} · check ${run.consecutive} of ${threshold} · product state unknown from here, not down`,
+      };
+    }
+    return {
+      name,
+      // RED, because it has persisted — but the reading is still unknown, so
+      // every renderer words it as unreachable rather than as a product verdict.
+      status: "red",
+      reading: "unknown",
+      detail: `probe cannot reach ${h.url} — ${cause} · ${run.consecutive} consecutive checks · unreachable from the monitor; whether the product is up is unknown from here`,
+    };
+  }
   if (!h.httpOk) return { name, status: "red", detail: `${h.url} → HTTP ${h.status}` };
   if (h.body?.serviceHealth?.ok === false) return { name, status: "red", detail: `${h.url} → service reports unhealthy` };
   const chainId = h.body?.auth?.chainId;
@@ -940,11 +1105,14 @@ export function deriveProductApiProbe(h: ProductHealthFetch): ProbeResult {
 }
 
 /** /health round-trip latency. Slow-but-reachable is degraded (working, just slow);
- *  ≥ redMs is red (effectively down). Unreachable / no sample → degraded (product_api
- *  carries the red for a hard outage). */
+ *  ≥ redMs is red (effectively down). No response at all → unknown: the elapsed
+ *  time before a DNS failure is not a latency measurement of anything, and
+ *  product_api carries the reachability claim. */
 export function deriveLatencyProbe(h: ProductHealthFetch, thresholds: { warnMs: number; redMs: number }): ProbeResult {
   const name = "api_latency";
   if (!h.configured) return { name, status: "degraded", detail: "AVERRAY_API_BASE_URL not configured" };
+  const fault = transportFaultOf(h);
+  if (fault) return unknownDependent(name, "round-trip latency", "not slow", fault);
   if (h.latencyMs === undefined) return { name, status: "degraded", detail: "no latency sample" };
   const ms = h.latencyMs;
   if (!h.reachable) return { name, status: "degraded", detail: `no response after ${ms}ms` };
@@ -971,6 +1139,8 @@ export function deriveMoneyPathProbe(
   },
 ): ProbeResult {
   const name = "money_path";
+  const fault = transportFaultOf(h);
+  if (fault) return unknownDependent(name, "settlement state", "not stalled", fault);
   if (!h.configured || !h.reachable || !h.httpOk) {
     return { name, status: "degraded", detail: "settlement status unavailable (product /health not readable)" };
   }
@@ -1054,6 +1224,8 @@ export function deriveCapabilityProbe(
   config: { requiredCapabilities: string[]; expectedWarnings: string[] },
 ): ProbeResult {
   const name = "capabilities";
+  const fault = transportFaultOf(h);
+  if (fault) return unknownDependent(name, "capability state", "not down", fault);
   if (!h.configured || !h.reachable || !h.httpOk) {
     return { name, status: "degraded", detail: "capability status unavailable (product /health not readable)" };
   }
@@ -1186,6 +1358,8 @@ export function deriveChainProbe(
   },
 ): ProbeResult {
   const name = "chain_height";
+  const fault = transportFaultOf(h);
+  if (fault) return unknownDependent(name, "chain height", "not halted", fault);
   if (!h.configured || !h.reachable || !h.httpOk) {
     return { name, status: "degraded", detail: "chain status unavailable (product /health not readable)" };
   }
@@ -2523,6 +2697,9 @@ export interface ProductHealthCollection {
   probes: ProbeResult[];
   /** Updated block-advance tracker — the caller persists it across ticks. */
   chainAdvance: ChainAdvance;
+  /** Updated /health transport-failure run; undefined once a read succeeds.
+   *  The caller persists it across ticks, same contract as `chainAdvance`. */
+  transportRun?: TransportFailureRun;
   /** Structured blocks for the Ops board (chain id / network / solvency / flow). */
   snapshot: ProductHealthSnapshotBlocks;
   /** GET /health round-trip latency (ms) — the caller records it on the history entry. */
@@ -2563,6 +2740,8 @@ export async function collectProductHealthProbes(
     advance?: ChainAdvance;
     nowMs: number;
     previousSubmittedNotSettled?: number | null;
+    /** Previous cycle's /health transport-failure run, for the retry hold. */
+    transportRun?: TransportFailureRun;
   } = { nowMs: 0 },
 ): Promise<ProductHealthCollection> {
   const h = await fetchProductHealth({
@@ -2570,6 +2749,9 @@ export async function collectProductHealthProbes(
     healthPath: config.apiHealthPath,
     fetchImpl,
   });
+  // Advance (or clear) the consecutive-failure run BEFORE the probes derive, so
+  // product_api sees this cycle counted. A successful read clears it outright.
+  const transportRun = trackTransportFailure(chainCtx.transportRun, transportFaultOf(h));
   const chainId = h.body?.auth?.chainId;
   const rewardBankLiquid = pickNum(h.body?.rewardBank?.liquid);
   const block = pickNum(h.body?.components?.blockchain?.blockNumber);
@@ -2865,7 +3047,10 @@ export async function collectProductHealthProbes(
 
   return {
     probes: [
-      deriveProductApiProbe(h),
+      deriveProductApiProbe(h, {
+        ...(transportRun ? { transportRun } : {}),
+        transportThreshold: config.transportFailThreshold,
+      }),
       deriveChainProbe(h, staleness),
       signer,
       deriveCapabilityProbe(h, {
@@ -2903,6 +3088,7 @@ export async function collectProductHealthProbes(
       externalFunnel.probe,
     ],
     chainAdvance,
+    ...(transportRun ? { transportRun } : {}),
     snapshot,
     latencyMs: h.latencyMs,
     rpcOk: signer.rpcOk,

--- a/services/slack-operator/test/unit/morning-digest.test.ts
+++ b/services/slack-operator/test/unit/morning-digest.test.ts
@@ -227,3 +227,69 @@ describe("digestFactStrings — the strings Hermes may not lose", () => {
     expect(facts).toContain("1 open request, staged on-chain");
   });
 });
+
+// ── The digest during a blind window ────────────────────────────────────────
+//
+// A container DNS failure straddling the send time used to open with "4 of 9
+// probes need attention" and list four findings — about a product none of those
+// four probes had managed to ask. One network fault, four accusations.
+describe("probes that took no reading are separated from probes needing attention", () => {
+  const unreadable = (name: string, subject: string): DigestProbe => ({
+    name,
+    status: "degraded",
+    reading: "unknown",
+    detail: `${subject} unknown — product /health not readable from here — DNS resolution failed (ENOTFOUND)`,
+  });
+
+  const base = {
+    localDate: "2026-08-06",
+    localTime: "08:00",
+    timeZone: ZURICH,
+    network: "mainnet",
+    verdictHeadline: "MONEY PATH UNKNOWN +3",
+    probes: [
+      { name: "signer_liquidity", status: "ok", detail: "gas 7.2018 DOT, reward bank 10.20 USDC" },
+      { name: "credential_expiry", status: "ok", detail: "3 TLS certs · no tokens watched, soonest expiry 37d" },
+      unreadable("money_path", "settlement state"),
+      unreadable("chain_height", "chain height"),
+    ] as DigestProbe[],
+  };
+
+  test("does not count them as needing attention", () => {
+    const text = buildMorningDigest(base);
+    expect(text).not.toContain("need attention");
+    expect(text.split("\n")[0]).toBe("Good morning — 2 of 4 probes green on Averray mainnet; 2 could not be read.");
+  });
+
+  test("names them anyway, under their own heading", () => {
+    // Excluded from the count, never from the message: an instrument that
+    // cannot see is the first thing the operator needs to know.
+    const text = buildMorningDigest(base);
+    expect(text).toContain("Could not be read (no evidence either way):");
+    expect(text).toContain("· Money path — settlement state unknown");
+    expect(text).toContain("ENOTFOUND");
+    expect(text).not.toContain("Needs attention");
+  });
+
+  test("an observed degradation still needs attention alongside them", () => {
+    const text = buildMorningDigest({
+      ...base,
+      probes: [...base.probes, { name: "disk_headroom", status: "degraded", detail: "4.1GB free" }],
+    });
+    expect(text.split("\n")[0]).toContain("1 of 5 probes needs attention");
+    expect(text).toContain("Needs attention:");
+    expect(text).toContain("Disk headroom — 4.1GB free");
+    expect(text).toContain("Could not be read (no evidence either way):");
+  });
+
+  test("a red we could not read is still a red — it is not filtered away", () => {
+    const text = buildMorningDigest({
+      ...base,
+      probes: [
+        { name: "product_api", status: "red", reading: "unknown", detail: "probe cannot reach https://api.averray.com/health — DNS resolution failed (ENOTFOUND) · 3 consecutive checks" },
+      ],
+    });
+    expect(text).toContain("Needs attention:");
+    expect(text).toContain("Product API — probe cannot reach");
+  });
+});

--- a/test/unit/compose-env.test.ts
+++ b/test/unit/compose-env.test.ts
@@ -41,6 +41,7 @@ describe("compose environment wiring", () => {
     expect(env?.PRODUCT_HEALTH_ALERT_COOLDOWN_MINUTES).toBe("${PRODUCT_HEALTH_ALERT_COOLDOWN_MINUTES:-360}");
     expect(env?.PRODUCT_HEALTH_CHAIN_MAX_STALE_SECONDS).toBe("${PRODUCT_HEALTH_CHAIN_MAX_STALE_SECONDS:-600}");
     expect(env?.PRODUCT_HEALTH_HALT_SEVERITY).toBe("${PRODUCT_HEALTH_HALT_SEVERITY:-auto}");
+    expect(env?.PRODUCT_HEALTH_TRANSPORT_FAIL_THRESHOLD).toBe("${PRODUCT_HEALTH_TRANSPORT_FAIL_THRESHOLD:-3}");
     expect(env?.PRODUCT_HEALTH_MIN_GAS_NATIVE).toBe("${PRODUCT_HEALTH_MIN_GAS_NATIVE:-0}");
     expect(env?.PRODUCT_HEALTH_MIN_REWARD_BANK).toBe("${PRODUCT_HEALTH_MIN_REWARD_BANK:-0}");
     expect(env?.PRODUCT_HEALTH_MIN_TREASURY_RESERVE).toBe("${PRODUCT_HEALTH_MIN_TREASURY_RESERVE:-5}");
@@ -55,6 +56,9 @@ describe("compose environment wiring", () => {
 
     expect(calibration).toContain("PRODUCT_HEALTH_INTERVAL_MINUTES=5");
     expect(calibration).toContain("PRODUCT_HEALTH_ALERT_COOLDOWN_MINUTES=30");
+    // The transport hold counts CYCLES, so the slower mainnet cadence needs a
+    // smaller count to keep the same ~5-minute wall-clock hold.
+    expect(calibration).toContain("PRODUCT_HEALTH_TRANSPORT_FAIL_THRESHOLD=2");
     expect(calibration).toContain("PRODUCT_HEALTH_MIN_TREASURY_RESERVE=0");
     expect(calibration).toContain(
       "PRODUCT_HEALTH_TREASURY_RESERVE_ZERO_REASON=Mainnet payouts are funded from the signer reward bank; the treasury multisig intentionally holds no USDC float.",

--- a/test/unit/ops-narration.test.ts
+++ b/test/unit/ops-narration.test.ts
@@ -56,23 +56,19 @@ describe("decideOpsNarration", () => {
     expect(d.suppressed).toBe("muted");
   });
 
-  it("uses the product-health cooldown to damp red/recovered narration thrash", () => {
+  it("uses the product-health cooldown to damp a REPEATED red", () => {
     const lastPostedAtMs = 1_000;
-    const recovered = decideOpsNarration({
-      prev: "red",
-      curr: "healthy",
-      probes: probes(),
+    const tooSoon = decideOpsNarration({
+      prev: "healthy",
+      curr: "red",
+      probes: probes({ money_path: "red" }),
       network: "mainnet",
       muted: false,
       lastPostedAtMs,
       nowMs: 2_000,
       cooldownMs: 60_000,
     });
-    expect(recovered).toMatchObject({
-      post: false,
-      edge: "recovered",
-      suppressed: "cooldown",
-    });
+    expect(tooSoon).toMatchObject({ post: false, edge: "red", suppressed: "cooldown" });
 
     const redAgain = decideOpsNarration({
       prev: "healthy",
@@ -86,5 +82,131 @@ describe("decideOpsNarration", () => {
     });
     expect(redAgain.post).toBe(true);
     expect(redAgain.edge).toBe("red");
+  });
+
+  // ── 2026-08-06 ────────────────────────────────────────────────────────────
+  // The red was announced, Buzz-published and paged. Five minutes later the
+  // probe recovered and the all-clear was dropped on the floor:
+  //   {"edge":"recovered","suppressed":"cooldown","msg":"ops_narration_suppressed"}
+  // The cooldown defaults to six hours, so this did not delay the recovery
+  // message — it deleted it. The last thing any human heard was a false alarm.
+  describe("an announced red is always closed", () => {
+    it("publishes the recovery INSIDE the cooldown window when the red was announced", () => {
+      const cooldownMs = 6 * 60 * 60 * 1000; // the shipped default
+      const red = decideOpsNarration({
+        prev: "healthy",
+        curr: "red",
+        probes: probes({ money_path: "red" }),
+        network: "mainnet",
+        muted: false,
+        lastPostedAtMs: 0,
+        nowMs: 1_000,
+        cooldownMs,
+      });
+      expect(red.post).toBe(true);
+      expect(red.redAnnounced).toBe(true);
+
+      // Recovery five minutes later — deep inside the six-hour cooldown.
+      const recovered = decideOpsNarration({
+        prev: "red",
+        curr: "healthy",
+        probes: probes(),
+        network: "mainnet",
+        muted: false,
+        lastPostedAtMs: 1_000,
+        nowMs: 1_000 + 5 * 60 * 1000,
+        cooldownMs,
+        redAnnounced: red.redAnnounced,
+      });
+      expect(recovered.post).toBe(true);
+      expect(recovered.suppressed).toBeUndefined();
+      expect(recovered.edge).toBe("recovered");
+      expect(recovered.text).toContain("Ops recovered");
+      // …and the incident is now closed, so nothing is left owed.
+      expect(recovered.redAnnounced).toBe(false);
+    });
+
+    it("stays quiet about a red it suppressed itself", () => {
+      const cooldownMs = 60_000;
+      const suppressedRed = decideOpsNarration({
+        prev: "healthy",
+        curr: "red",
+        probes: probes({ money_path: "red" }),
+        network: "mainnet",
+        muted: false,
+        lastPostedAtMs: 1_000,
+        nowMs: 2_000,
+        cooldownMs,
+      });
+      expect(suppressedRed).toMatchObject({ post: false, suppressed: "cooldown", redAnnounced: false });
+
+      const recovered = decideOpsNarration({
+        prev: "red",
+        curr: "healthy",
+        probes: probes(),
+        network: "mainnet",
+        muted: false,
+        lastPostedAtMs: 1_000,
+        nowMs: 3_000,
+        cooldownMs,
+        redAnnounced: suppressedRed.redAnnounced,
+      });
+      // An all-clear for an alarm nobody was given implies there was something
+      // to be clear of.
+      expect(recovered.post).toBe(false);
+      expect(recovered.suppressed).toBe("never-announced");
+    });
+
+    it("closes an incident inherited across a restart (no bookkeeping ≠ never announced)", () => {
+      // A fresh process booted into an ongoing red a previous one announced.
+      const recovered = decideOpsNarration({
+        prev: "red",
+        curr: "healthy",
+        probes: probes(),
+        network: "mainnet",
+        muted: false,
+        lastPostedAtMs: 1_000,
+        nowMs: 2_000,
+        cooldownMs: 60_000,
+        // redAnnounced deliberately absent
+      });
+      expect(recovered.post).toBe(true);
+    });
+
+    it("keeps the announced red open across ticks until something closes it", () => {
+      const stillRed = decideOpsNarration({
+        prev: "red",
+        curr: "red",
+        probes: probes({ money_path: "red" }),
+        network: "mainnet",
+        muted: false,
+        redAnnounced: true,
+      });
+      expect(stillRed.post).toBe(false);
+      expect(stillRed.redAnnounced).toBe(true);
+    });
+
+    it("mute silences both edges, and leaves no alarm owed", () => {
+      // Mute is an explicit operator action, not an automatic damper: it
+      // silences the opening red too, so nothing is left dangling.
+      const red = decideOpsNarration({
+        prev: "healthy",
+        curr: "red",
+        probes: probes({ money_path: "red" }),
+        network: "mainnet",
+        muted: true,
+      });
+      expect(red).toMatchObject({ post: false, suppressed: "muted", redAnnounced: false });
+
+      const recovered = decideOpsNarration({
+        prev: "red",
+        curr: "healthy",
+        probes: probes(),
+        network: "mainnet",
+        muted: true,
+        redAnnounced: red.redAnnounced,
+      });
+      expect(recovered).toMatchObject({ post: false, suppressed: "muted", redAnnounced: false });
+    });
   });
 });

--- a/test/unit/probe-transitions.test.ts
+++ b/test/unit/probe-transitions.test.ts
@@ -230,3 +230,85 @@ describe("decideProbeTransitions", () => {
     expect([...first.keys]).toEqual([]);
   });
 });
+
+// ── Probes that took no reading ─────────────────────────────────────────────
+//
+// On 2026-08-06 one container DNS failure made five probes fail at once. Four
+// of them read out of the product's /health and so knew nothing at all — but
+// under the old rules each would have queued its own "degraded" alert about a
+// subject none of them had observed.
+describe("unknown readings", () => {
+  const unknown = (name: string, status: ProbeResult["status"] = "degraded"): ProbeResult => ({
+    name,
+    status,
+    reading: "unknown",
+    detail: "settlement state unknown, not stalled — product /health not readable from here — DNS resolution failed (ENOTFOUND)",
+  });
+
+  it("does not alert when a probe merely stops being able to read", () => {
+    const before = new Map([["money_path", p("money_path", "ok", "settled24h 42")]]);
+    const d = decide({ previous: before, current: [unknown("money_path")] });
+    expect(d.alerts).toEqual([]);
+  });
+
+  it("stays quiet for as long as the reading is missing", () => {
+    let state = decide({ previous: new Map([["money_path", p("money_path", "ok", "settled24h 42")]]), current: [unknown("money_path")] });
+    for (let tick = 0; tick < 5; tick += 1) {
+      state = decide({ previous: state.next, current: [unknown("money_path")], posted: state.keys, streaks: state.streaks });
+      expect(state.alerts).toEqual([]);
+    }
+  });
+
+  it("says nothing on the way back either — there was no alarm to close", () => {
+    const blind = decide({ previous: new Map([["money_path", p("money_path", "ok", "settled24h 42")]]), current: [unknown("money_path")] });
+    const back = decide({
+      previous: blind.next,
+      current: [p("money_path", "ok", "settled24h 42")],
+      posted: blind.keys,
+      streaks: blind.streaks,
+    });
+    expect(back.alerts).toEqual([]);
+  });
+
+  it("DOES alert when the probe itself reds on sustained unreachability", () => {
+    // The hold is product_api's to decide; once it reds, this must page.
+    const before = new Map([["product_api", unknown("product_api")]]);
+    const red: ProbeResult = {
+      name: "product_api",
+      status: "red",
+      reading: "unknown",
+      detail: "probe cannot reach https://api.averray.com/health — DNS resolution failed (ENOTFOUND) · 3 consecutive checks · unreachable from the monitor; whether the product is up is unknown from here",
+    };
+    const d = decide({ previous: before, current: [red] });
+    expect(d.alerts).toHaveLength(1);
+    // …worded as unreachability, not as a verdict on the product. The line that
+    // actually reached a phone on 2026-08-06 was "Product API is red".
+    expect(d.alerts[0]?.text).toContain("unreachable from the monitor");
+    expect(d.alerts[0]?.text).not.toContain("is red");
+    expect(d.alerts[0]?.text).toContain("ENOTFOUND");
+  });
+
+  it("closes an unreachability alert with 'readable again', not 'recovered'", () => {
+    const red: ProbeResult = { name: "product_api", status: "red", reading: "unknown", detail: "probe cannot reach … · 3 consecutive checks" };
+    const opened = decide({ previous: new Map([["product_api", unknown("product_api")]]), current: [red] });
+    const back = decide({
+      previous: opened.next,
+      current: [p("product_api", "ok", "https://api.averray.com/health → 200 · chain 420420419")],
+      posted: opened.keys,
+      streaks: opened.streaks,
+    });
+    expect(back.alerts).toHaveLength(1);
+    // We never established the product was unwell, so it did not "recover".
+    expect(back.alerts[0]?.text).toContain("readable again");
+    expect(back.alerts[0]?.text).not.toContain("recovered");
+  });
+
+  it("an observed degradation still alerts normally", () => {
+    // The guard must key on the reading, not on the status.
+    const before = new Map([["money_path", p("money_path", "ok", "settled24h 42")]]);
+    const observed = p("money_path", "red", "6 jobs stuck (submitted, unsettled ≥ 5)");
+    const d = decide({ previous: before, current: [observed] });
+    expect(d.alerts).toHaveLength(1);
+    expect(d.alerts[0]?.text).toContain("is red");
+  });
+});

--- a/test/unit/probe-transport.test.ts
+++ b/test/unit/probe-transport.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  classifyTransportFailure,
+  describeTransportFailure,
+  trackTransportFailure,
+  transportFailureIsPageWorthy,
+} from "../../services/slack-operator/src/probe-transport.js";
+
+/** The shape undici actually throws: a useless outer message, the truth inside. */
+const undiciFetchFailure = (code: string, message: string): Error => {
+  const inner = Object.assign(new Error(message), { code });
+  return Object.assign(new TypeError("fetch failed"), { cause: inner });
+};
+
+describe("classifyTransportFailure", () => {
+  it("digs the cause code out from under undici's 'fetch failed'", () => {
+    // This is the entire reason a five-minute DNS incident was reported to a
+    // human as "fetch failed": the code was one level down and nobody looked.
+    const f = classifyTransportFailure(undiciFetchFailure("ENOTFOUND", "getaddrinfo ENOTFOUND api.averray.com"));
+    expect(f.code).toBe("ENOTFOUND");
+    expect(f.kind).toBe("dns");
+    expect(f.message).toContain("api.averray.com");
+  });
+
+  it("reaches through an AggregateError of per-address attempts", () => {
+    const attempt = Object.assign(new Error("connect ECONNREFUSED 10.0.0.1:443"), { code: "ECONNREFUSED" });
+    const aggregate = Object.assign(new AggregateError([attempt], "all attempts failed"), {});
+    const outer = Object.assign(new TypeError("fetch failed"), { cause: aggregate });
+    expect(classifyTransportFailure(outer)).toMatchObject({ code: "ECONNREFUSED", kind: "connect" });
+  });
+
+  it("classifies TLS and timeout faults distinctly from DNS", () => {
+    expect(classifyTransportFailure(undiciFetchFailure("CERT_HAS_EXPIRED", "certificate has expired")).kind).toBe("tls");
+    expect(classifyTransportFailure(undiciFetchFailure("UND_ERR_CONNECT_TIMEOUT", "Connect Timeout Error")).kind).toBe("connect");
+    expect(classifyTransportFailure(undiciFetchFailure("ETIMEDOUT", "timed out")).kind).toBe("timeout");
+  });
+
+  it("says UNKNOWN rather than inventing a code", () => {
+    const f = classifyTransportFailure(new Error("something went sideways"));
+    expect(f.code).toBe("UNKNOWN");
+    // …and then the message carries what little there is, rather than nothing.
+    expect(describeTransportFailure(f)).toContain("something went sideways");
+  });
+
+  it("does not loop on a self-referential cause chain", () => {
+    const err = new Error("round and round") as Error & { cause?: unknown };
+    err.cause = err;
+    expect(classifyTransportFailure(err).message).toBe("round and round");
+  });
+
+  it("names the layer and the code, for reading and for grepping", () => {
+    const f = classifyTransportFailure(undiciFetchFailure("ENOTFOUND", "getaddrinfo ENOTFOUND api.averray.com"));
+    expect(describeTransportFailure(f)).toBe("DNS resolution failed (ENOTFOUND)");
+  });
+});
+
+describe("trackTransportFailure", () => {
+  const dns = { kind: "dns" as const, code: "ENOTFOUND", message: "getaddrinfo ENOTFOUND api.averray.com" };
+
+  it("counts consecutive failures", () => {
+    let run = trackTransportFailure(undefined, dns);
+    expect(run).toEqual({ code: "ENOTFOUND", consecutive: 1 });
+    run = trackTransportFailure(run, dns);
+    run = trackTransportFailure(run, dns);
+    expect(run?.consecutive).toBe(3);
+  });
+
+  it("clears the moment a read succeeds", () => {
+    const run = trackTransportFailure(trackTransportFailure(undefined, dns), dns);
+    expect(trackTransportFailure(run, undefined)).toBeUndefined();
+  });
+
+  it("keeps counting when the code changes mid-outage", () => {
+    // A real outage walks through codes. Restarting the count on each one would
+    // keep the hold armed forever, which is a way to never page at all.
+    const first = trackTransportFailure(undefined, dns);
+    const second = trackTransportFailure(first, { kind: "connect", code: "ECONNREFUSED", message: "refused" });
+    expect(second).toEqual({ code: "ECONNREFUSED", consecutive: 2 });
+  });
+});
+
+describe("transportFailureIsPageWorthy", () => {
+  it("does not page on a single-shot failure", () => {
+    expect(transportFailureIsPageWorthy({ code: "ENOTFOUND", consecutive: 1 }, 3)).toBe(false);
+    expect(transportFailureIsPageWorthy({ code: "ENOTFOUND", consecutive: 2 }, 3)).toBe(false);
+  });
+
+  it("pages once the fault has persisted", () => {
+    expect(transportFailureIsPageWorthy({ code: "ENOTFOUND", consecutive: 3 }, 3)).toBe(true);
+    expect(transportFailureIsPageWorthy({ code: "ENOTFOUND", consecutive: 9 }, 3)).toBe(true);
+  });
+
+  it("never pages with no run at all", () => {
+    expect(transportFailureIsPageWorthy(undefined, 3)).toBe(false);
+  });
+
+  it("treats a threshold below 1 as 1 rather than as 'never'", () => {
+    expect(transportFailureIsPageWorthy({ code: "ENOTFOUND", consecutive: 1 }, 0)).toBe(true);
+  });
+});

--- a/test/unit/product-health.test.ts
+++ b/test/unit/product-health.test.ts
@@ -129,6 +129,14 @@ function throwingFetch(): typeof fetch {
   }) as unknown as typeof fetch;
 }
 
+/** What undici actually throws when the container's resolver is down. */
+function dnsFailingFetch(host = "api.averray.com"): typeof fetch {
+  return (async () => {
+    const inner = Object.assign(new Error(`getaddrinfo ENOTFOUND ${host}`), { code: "ENOTFOUND" });
+    throw Object.assign(new TypeError("fetch failed"), { cause: inner });
+  }) as unknown as typeof fetch;
+}
+
 const probe = (name: string, status: ProbeResult["status"], detail = ""): ProbeResult => ({ name, status, detail });
 
 // A realistic slice of the live Averray /health payload (testnet chainId 420420417).
@@ -157,6 +165,19 @@ const fetched = (body: ProductHealthPayload, over: Partial<ProductHealthFetch> =
   status: 200,
   url: "https://api.x/health",
   body,
+  ...over,
+});
+
+/** A /health read that died below HTTP — no response ever arrived. */
+const unreachable = (over: Partial<ProductHealthFetch> = {}): ProductHealthFetch => ({
+  configured: true,
+  reachable: false,
+  httpOk: false,
+  status: 0,
+  url: "https://api.x/health",
+  error: "fetch failed",
+  transport: { kind: "dns", code: "ENOTFOUND", message: "getaddrinfo ENOTFOUND api.x" },
+  latencyMs: 12,
   ...over,
 });
 
@@ -237,9 +258,60 @@ describe("deriveProductApiProbe", () => {
     expect(deriveProductApiProbe({ configured: false, reachable: false, httpOk: false, status: 0, url: "" }).status).toBe("degraded");
   });
 
-  it("red when unreachable", () => {
-    const r = deriveProductApiProbe({ configured: true, reachable: false, httpOk: false, status: 0, url: "https://api.x/health", error: "ENOTFOUND" });
+  // ── 2026-08-06: five minutes of container-local DNS failure, paged as an
+  // outage of a product that was serving 200s from outside the whole time. ──
+
+  it("holds unknown — not red — on the FIRST unreachable cycle", () => {
+    const r = deriveProductApiProbe(unreachable(), { transportRun: { code: "ENOTFOUND", consecutive: 1 } });
+    expect(r.status).not.toBe("red");
+    expect(r.reading).toBe("unknown");
+  });
+
+  it("names the cause code and the layer, never bare 'fetch failed'", () => {
+    const r = deriveProductApiProbe(unreachable(), { transportRun: { code: "ENOTFOUND", consecutive: 1 } });
+    expect(r.detail).toContain("ENOTFOUND");
+    expect(r.detail).toContain("DNS resolution failed");
+    expect(r.detail).not.toContain("fetch failed");
+  });
+
+  it("claims only what it knows: unreachable FROM HERE, product state unknown", () => {
+    const r = deriveProductApiProbe(unreachable(), { transportRun: { code: "ENOTFOUND", consecutive: 1 } });
+    expect(r.detail).toContain("probe cannot reach");
+    expect(r.detail).toContain("unknown from here");
+    // The claim it must never make on transport evidence alone.
+    expect(r.detail).not.toMatch(/\bis down\b|\bunavailable\b/);
+  });
+
+  it("reds once the fault has persisted for the threshold — still worded as unreachability", () => {
+    const r = deriveProductApiProbe(unreachable(), { transportRun: { code: "ENOTFOUND", consecutive: 3 } });
     expect(r.status).toBe("red");
+    // Red is the volume, not a new claim: the reading is still unknown, so every
+    // renderer words this as "unreachable", not as a verdict on the product.
+    expect(r.reading).toBe("unknown");
+    expect(r.detail).toContain("3 consecutive checks");
+    expect(r.detail).toContain("unreachable from the monitor");
+  });
+
+  it("respects a configured threshold", () => {
+    const at2 = { transportRun: { code: "ENOTFOUND", consecutive: 2 }, transportThreshold: 2 };
+    expect(deriveProductApiProbe(unreachable(), at2).status).toBe("red");
+    expect(deriveProductApiProbe(unreachable(), { ...at2, transportRun: { code: "ENOTFOUND", consecutive: 1 } }).status)
+      .toBe("degraded");
+  });
+
+  it("treats an unclassified unreachable as a transport fault too (never silently red on cycle 1)", () => {
+    // A caller that hand-builds the fetch result carries no `transport`. That is
+    // an absence of classification, not evidence the product answered.
+    const r = deriveProductApiProbe({ configured: true, reachable: false, httpOk: false, status: 0, url: "https://api.x/health", error: "boom" });
+    expect(r.status).toBe("degraded");
+    expect(r.reading).toBe("unknown");
+  });
+
+  it("an HTTP response is evidence about the PRODUCT — reds immediately, no hold", () => {
+    // The distinction the whole change rests on: 503 means it answered.
+    const r = deriveProductApiProbe(fetched(HEALTHY_BODY, { httpOk: false, status: 503 }));
+    expect(r.status).toBe("red");
+    expect(r.reading).toBeUndefined();
   });
 
   it("red on a non-2xx and on a self-reported unhealthy service", () => {
@@ -251,6 +323,53 @@ describe("deriveProductApiProbe", () => {
     const r = deriveProductApiProbe(fetched(HEALTHY_BODY));
     expect(r.status).toBe("ok");
     expect(r.detail).toContain("420420417");
+  });
+});
+
+describe("probes that read OUT of /health, when /health never arrived", () => {
+  // All four derive from the same one fetch. When it fails below HTTP they hold
+  // no evidence about their subjects — so on 2026-08-06 one DNS failure
+  // manufactured four simultaneous findings about a product nobody had reached.
+  const dependents = (): Array<[string, ProbeResult]> => [
+    ["chain_height", deriveChainProbe(unreachable())],
+    ["capabilities", deriveCapabilityProbe(unreachable(), { requiredCapabilities: ["blockchain"], expectedWarnings: [] })],
+    ["api_latency", deriveLatencyProbe(unreachable(), { warnMs: 2000, redMs: 8000 })],
+    ["money_path", deriveMoneyPathProbe(unreachable(), { maxStuck: 5, maxFailed24h: 3, maxStaleMinutes: 30, nowMs: 0 })],
+  ];
+
+  it("reads unknown, not degraded — no reading is not a finding", () => {
+    for (const [name, probe] of dependents()) {
+      expect(probe.reading, name).toBe("unknown");
+    }
+  });
+
+  it("never reds, however long the fault persists — product_api owns that claim", () => {
+    for (const [name, probe] of dependents()) {
+      expect(probe.status, name).not.toBe("red");
+    }
+  });
+
+  it("says the subject is unknown AND what it is not being claimed to be", () => {
+    // external_funnel's "funnel state unknown, not empty" is the model.
+    const byName = new Map(dependents());
+    expect(byName.get("money_path")!.detail).toContain("settlement state unknown, not stalled");
+    expect(byName.get("chain_height")!.detail).toContain("chain height unknown, not halted");
+    expect(byName.get("capabilities")!.detail).toContain("capability state unknown, not down");
+    expect(byName.get("api_latency")!.detail).toContain("round-trip latency unknown, not slow");
+  });
+
+  it("carries the cause code so the fault is diagnosable from the line alone", () => {
+    for (const [name, probe] of dependents()) {
+      expect(probe.detail, name).toContain("ENOTFOUND");
+    }
+  });
+
+  it("still reports a plain 503 as a degraded READING, not as unknown", () => {
+    // The product answered. That is evidence, and it must keep its old meaning.
+    const served503 = fetched(HEALTHY_BODY, { httpOk: false, status: 503 });
+    const money = deriveMoneyPathProbe(served503, { maxStuck: 5, maxFailed24h: 3, maxStaleMinutes: 30, nowMs: 0 });
+    expect(money.reading).toBeUndefined();
+    expect(money.detail).toContain("settlement status unavailable");
   });
 });
 
@@ -2095,5 +2214,83 @@ describe("a payout shortfall pages even with every probe green", () => {
     expect(lines[3]).toContain("api_latency");             // latency last
     expect(text).toContain("9 commits behind main");       // provenance
     expect(text).toContain("3 money-blocking signals");
+  });
+});
+
+// ── THE 2026-08-06 INCIDENT, END TO END ─────────────────────────────────────
+//
+// Container-local DNS failed 14:58:33–15:03:34 UTC. The product was never down;
+// 200s were served from outside throughout. What shipped to a human was
+// "Product API is red — https://api.averray.com/health unreachable: fetch
+// failed", and on-call was paged.
+//
+// This drives the real collector across cycles, because the hold only works if
+// the run state is actually threaded — a correct decision function wired to a
+// state that resets every tick reproduces the incident exactly.
+describe("a container DNS failure, cycle by cycle", () => {
+  const cycle = async (transportRun: Awaited<ReturnType<typeof collectProductHealthProbes>>["transportRun"]) =>
+    collectProductHealthProbes(cfg(), dnsFailingFetch(), {
+      nowMs: 10_000_000,
+      ...(transportRun ? { transportRun } : {}),
+    });
+
+  it("does not page on the first two cycles, and pages on the third", async () => {
+    const first = await cycle(undefined);
+    const api1 = first.probes.find((p) => p.name === "product_api")!;
+    expect(api1.status).not.toBe("red");
+    expect(api1.reading).toBe("unknown");
+    expect(first.transportRun).toEqual({ code: "ENOTFOUND", consecutive: 1 });
+
+    const second = await cycle(first.transportRun);
+    expect(second.probes.find((p) => p.name === "product_api")!.status).not.toBe("red");
+
+    const third = await cycle(second.transportRun);
+    const api3 = third.probes.find((p) => p.name === "product_api")!;
+    expect(api3.status).toBe("red");
+    expect(api3.detail).toContain("3 consecutive checks");
+  });
+
+  it("names ENOTFOUND rather than relaying undici's 'fetch failed'", async () => {
+    const { probes } = await cycle(undefined);
+    const api = probes.find((p) => p.name === "product_api")!;
+    expect(api.detail).toContain("ENOTFOUND");
+    expect(api.detail).not.toContain("fetch failed");
+  });
+
+  it("leaves every /health-derived probe UNKNOWN, not degraded", async () => {
+    const { probes } = await cycle(undefined);
+    const byName = new Map(probes.map((p) => [p.name, p] as const));
+    for (const name of ["chain_height", "capabilities", "api_latency", "money_path"]) {
+      expect(byName.get(name)!.reading, name).toBe("unknown");
+      expect(byName.get(name)!.status, name).not.toBe("red");
+    }
+  });
+
+  it("clears the run the instant a read succeeds", async () => {
+    const blind = await cycle(undefined);
+    const recovered = await collectProductHealthProbes(
+      cfg(),
+      combinedFetch({ healthBody: HEALTHY_BODY, chainIdHex: CHAIN_ID_HEX, blockTimestampHex: tsHex(10_000_000, 12), gasHex: "0xDE0B6B3A7640000", usdcHex: "0x989680" }),
+      { nowMs: 10_000_000, ...(blind.transportRun ? { transportRun: blind.transportRun } : {}) },
+    );
+    expect(recovered.transportRun).toBeUndefined();
+    const api = recovered.probes.find((p) => p.name === "product_api")!;
+    expect(api.status).toBe("ok");
+    expect(api.reading).toBeUndefined();
+  });
+
+  it("does not count our own blindness as product downtime", async () => {
+    // uptime% is over DETERMINATE product_api samples. A window in which we
+    // could not reach the host contains no evidence either way, and folding it
+    // in would publish our DNS outage as the product's availability figure.
+    const blind = await cycle(undefined);
+    const api = blind.probes.find((p) => p.name === "product_api")!;
+    const history = [
+      { at: 1_000, status: "healthy" as ProductHealthStatus, probes: [probe("product_api", "ok", "200")] },
+      { at: 2_000, status: "degraded" as ProductHealthStatus, probes: [api] },
+    ];
+    const derived = deriveProductHealthHistory(history, 3_000);
+    expect(derived.uptimePct24h).toBe(100);
+    expect(derived.uptimeSamples).toBe(1);
   });
 });


### PR DESCRIPTION
## The incident

2026-08-06, container-local DNS failed for ~5 minutes (14:58:33–15:03:34 UTC). `getaddrinfo ENOTFOUND api.averray.com` for api/monitor/buzz simultaneously. **The product was never down** — 200s verified from outside throughout. The probe recovered on its own.

Two defects fell out of it.

## Defect 1 — the alert was announced, the all-clear was not

The red was fully announced: `ops_narration_posted`, `ops_narration_buzz_published`, `probe_transition_published`, on-call paged. The recovery was not:

```
{"edge":"recovered","suppressed":"cooldown","msg":"ops_narration_suppressed"}
```

`PRODUCT_HEALTH_ALERT_COOLDOWN_MINUTES` defaults to **360**. So the all-clear was not delayed — it was deleted. For the rest of the day the last thing any human had heard was an alarm about an outage that had already ended, and the board read as an ongoing incident.

**Fix.** The cooldown now governs **red edges only**. A repeated red is redundant — that is what a cooldown is for. An all-clear is by definition something the operator has *not* heard, so suppressing it does not reduce noise; it converts a resolved incident into a permanent false alarm.

`decideOpsNarration` threads a `redAnnounced` flag so a recovery knows whether it has an alarm to close:

| red edge | recovery |
|---|---|
| posted → `redAnnounced: true` | posts, **cooldown never applies** |
| suppressed by cooldown → `false` | quiet, `suppressed: "never-announced"` |
| no bookkeeping (`undefined`) | **posts** — a restart mid-incident still closes it |

That last row mirrors the lesson already written into `probe-transitions.ts`: absent bookkeeping is not evidence of suppression, and defaulting it to silence swallowed every recovery that module had.

Mute still silences both edges. It is an explicit operator action rather than an automatic damper, it silences the opening red too (so nothing is left dangling), and it matches the boundary `probe-transitions.ts` already draws.

## Defect 2 — "unreachable from here" reported as "the product is red"

The headline said `Product API is red — https://api.averray.com/health unreachable: fetch failed`. Two things wrong: the product was up, and `fetch failed` is undici's *outer* message — `ENOTFOUND` was one level down in `err.cause` and never reached a human.

**Fix.** Probes gain a `reading` axis alongside `status` — *what we observed*, kept separate from *how bad it is*.

New pure module `probe-transport.ts` walks the cause chain (including `AggregateError` from multi-address connects) and classifies dns / connect / tls / timeout with the code. Then:

- **`product_api`** names the layer and code — `DNS resolution failed (ENOTFOUND)` — and **holds `unknown` for N consecutive cycles before reding**. When it does red it says *unreachable from the monitor*, not *the product is red*; `reading` stays `unknown`, so red is the volume, not a new claim.
- **The four probes that read out of that same response** (`chain_height`, `capabilities`, `api_latency`, `money_path`) go **`unknown`, not `degraded`**. They hold no evidence about their subjects. Phrasing follows the model in the issue — `external_funnel`'s "funnel state unknown, not empty" — so each says its subject *and* what is not being claimed: `settlement state unknown, not stalled — product /health not readable from here — DNS resolution failed (ENOTFOUND)`.
- **An HTTP response is unchanged.** A 503 *is* evidence about the product and still reds immediately, no hold. That distinction is the whole change.

`PRODUCT_HEALTH_TRANSPORT_FAIL_THRESHOLD` defaults to **3** (~4–6 min at the 2-minute cadence). The mainnet calibration sets **2**, because the hold counts cycles and mainnet samples every 5 minutes — 3 there would leave the board blind for 10–15 minutes before saying so.

### Why `reading` and not a new `ProbeStatus`

Widening `ProbeStatus` to include `"unknown"` touches ~70 branch sites across 17 files, most of them ternaries that would silently fall through to `degraded`. The two axes are genuinely orthogonal anyway. `status` stays `degraded` under an unknown reading as the compatibility floor — amber and quiet — so a reader that predates the field lands somewhere safe rather than on a fake green. Readers that understand it render grey.

### Not laundered into NOMINAL

The mirror-image failure, and the easier one to ship by accident: grey out the four probes that could not read, and the rest of the board is green. `deriveOpsVerdict` gains a `probe-unknown` branch — ranked *below* observed degradations (a fault you can see is more actionable) and *above* nominal. `probeCensus` gets its own `N unknown` bucket, distinct from `awaiting data`: the product not publishing something yet and us failing to read what it does publish are different facts.

## What the truth-boundary review caught

Three **parallel derivations** were still making the old claim after the core fix. All three are in this PR:

1. **`ops-suggestions.ts`** — highest severity. A red-with-unknown-reading produced `Product API down` plus a one-click agent task: *"check whether a recent deploy regressed it, tail the product logs… roll back if a deploy caused it."* An operator acting on that rolls back a healthy deploy over their own container's DNS. Now emits a distinct `product-api-unreachable` suggestion whose task diagnoses the wire first and explicitly forbids a blind rollback.
2. **`ops-frame.ts`** — the board's largest sentence still read `Product API red — … / Settlement-affecting — on-call is paged`, contradicting `verdict.headline` on the same screen. Now `unreachable from the monitor` / *"whether the product is affected is unknown."*
3. **`morning-digest.ts`** — counted the four unreadable probes as four things needing attention. Now excluded from the count and given their own heading, `Could not be read (no evidence either way):` — excluded from the count, never from the message.

Also threaded `reading` into the Hermes reply snapshot: asked "is the money path degraded?", a model shown only `status: degraded` will answer yes about a subject nobody managed to observe.

## Tests

`+13` transport classification/hold · `+7` narration (incl. the exact regression: **announce red → recover 5 min into a 6-hour cooldown → recovery still published**) · `+12` probe derivation · `+6` cross-cycle through the real collector · `+7` verdict · `+6` transitions · `+4` suggestions · `+5` banner · `+4` digest.

Two pre-existing tests changed, both of which encoded a defect:
- `ops-narration.test.ts` asserted `recovered → suppressed: "cooldown"`.
- `product-health.test.ts` asserted `red when unreachable` on the first cycle.

Full suite: **2871 passed, 34 skipped**. Typecheck clean.

Cadence unchanged. No new alert channels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)