### PR TITLE
fix(harness): distinguish invalid projections (#764)

### DIFF
--- a/services/harness-dispatcher/src/reconcile-run.ts
+++ b/services/harness-dispatcher/src/reconcile-run.ts
@@ -33,6 +33,7 @@ import {
   buildHermesDecisionRecordV2,
 } from "@avg/averray-mcp/decision-records";
 import {
+  HarnessProjectionError,
   projectHarnessRun,
   type HarnessProjectionBinding,
 } from "@avg/averray-mcp/harness-run-projection";
@@ -535,6 +536,23 @@ async function reconcileTask(
       { now: deps.now() },
     );
   } catch (error) {
+    if (
+      error instanceof HarnessProjectionError
+      && error.code === "projection_invalid"
+    ) {
+      return forceCancelTask(deps, task, harnessRunId, {
+        lifecycle: "blocked",
+        decisionType: "dispatch_refusal",
+        reason: `projection_invalid: ${safeErrorMessage(error)}`,
+        alert: {
+          severity: "critical",
+          code: "projection_invalid",
+          message:
+            "Harness projection could not be read or validated; the run was cancelled and blocked.",
+        },
+        outboxBinding,
+      });
+    }
     return observePoisonFailure(deps, task, harnessRunId, error);
   }
   try {

--- a/test/unit/harness-pilot-cli.test.ts
+++ b/test/unit/harness-pilot-cli.test.ts
@@ -291,7 +291,7 @@ describe("Harness pilot CLI", () => {
         }
         return `${JSON.stringify({
           severity: "critical",
-          code: "pilot_alert",
+          code: "projection_invalid",
           message: "Bearer alert-token and password=alert-secret",
           at: "2026-07-25T12:00:00.000Z",
         })}\n`;
@@ -342,6 +342,10 @@ describe("Harness pilot CLI", () => {
         observedInflight: 1,
         maxInflight: 1,
       },
+      alerts: [{
+        severity: "critical",
+        code: "projection_invalid",
+      }],
       submissionAttemptedByCli: false,
     });
     expect(rendered).not.toContain("postgresql://");

--- a/test/unit/harness-watchdog.test.ts
+++ b/test/unit/harness-watchdog.test.ts
@@ -93,9 +93,9 @@ describe("the standalone Harness watchdog", () => {
     });
     await harness.process.tick();
     const source = {
-      severity: "warn",
-      code: "dispatcher_source_alert",
-      message: "source record",
+      severity: "critical",
+      code: "projection_invalid",
+      message: "Harness projection could not be read or validated.",
       at: "2026-08-05T10:00:01.000Z",
     };
     await writeFile(harness.config.alertsPath, `${JSON.stringify(source)}\n`, "utf8");

--- a/test/unit/reconcile-run.test.ts
+++ b/test/unit/reconcile-run.test.ts
@@ -412,6 +412,43 @@ describe("dispatched Harness run reconciliation", () => {
     );
   });
 
+  it("cancels and blocks a malformed projection as projection_invalid", async () => {
+    const task = await runningTask();
+    const read = snapshot("executing");
+    const malformedRead = {
+      ...read,
+      status: {
+        ...read.status,
+        attempt: -1,
+      },
+    } as HarnessRunReadSnapshot;
+    const deps = reconcileDeps(task, malformedRead);
+
+    const [reconciled] = await reconcileDispatchedRuns(deps);
+
+    expect(reconciled).toMatchObject({
+      outcome: "advanced",
+      lifecycle: "blocked",
+      healthy: false,
+      reason: expect.stringContaining("projection_invalid"),
+    });
+    expect(savedTasks(deps).at(-1)?.lifecycle).toBe("blocked");
+    expect(recordedDecisions(deps).at(-1)).toMatchObject({
+      decisionType: "dispatch_refusal",
+      next: { owner: "operator" },
+    });
+    expect(deps.controlPort.cancel).toHaveBeenCalledWith(RUN_ID);
+    expect(deps.alertSink).toHaveBeenCalledOnce();
+    expect(deps.alertSink).toHaveBeenCalledWith(
+      expect.objectContaining({
+        code: "projection_invalid",
+        severity: "critical",
+        message:
+          "Harness projection could not be read or validated; the run was cancelled and blocked.",
+      }),
+    );
+  });
+
   it("cancels and fails an overdue non-terminal task with one alert", async () => {
     const task = agentTaskV1Schema.parse({
       ...await runningTask(),


### PR DESCRIPTION
## What changed
- Route typed projection parse and schema failures to the new critical projection_invalid alert.
- Preserve the existing cancel, blocked lifecycle, dispatch-refusal decision, severity, and operator ownership.
- Keep true authority assertion failures on containment_expansion.
- Exercise projection_invalid through pilot status and watchdog forwarding without code rewriting.

## Local evidence
- npm run typecheck: exit 0.
- npm test: exit 0; 194 files passed, 6 skipped; 2882 tests passed, 40 skipped.
- npm run build: exit 0.
- Focused consumer and branch tests: exit 0; 3 files and 89 tests passed.
- Required swapped-code mutation: exit 1; all three containment variants failed after receiving projection_invalid, and the malformed-projection test failed after receiving containment_expansion.

## Consumer sweep
- Dispatch-attempt severity handling is not a code allowlist; reconciliation emits both codes with explicit critical severity.
- Pilot status preserves projection_invalid as an arbitrary alert code, now asserted directly.
- The watchdog forwards projection_invalid without rewriting code, severity, message, or timestamp, now asserted directly.
- The drill ledger does not route alert codes; its cited capability-expansion and malformed-event cases remain valid, so no ledger row or citation changed.

## Affected surfaces
Backend Harness reconciliation and unit tests only. No kernel pin, monitor behavior, watchdog import surface, workflow, ops, compose, environment, secret, database, or deployment changes.

## Rollout and rollback
No provisioning or rollout step. Revert this commit to restore the prior label behavior.

Closes #764