### PR TITLE
fix(harness): fail closed on unarmed INT-4 drills (#773)

### DIFF
--- a/scripts/ceremony/lib/int4-mutation-contract.mjs
+++ b/scripts/ceremony/lib/int4-mutation-contract.mjs
@@ -1,0 +1,15 @@
+export function assertKnownMutation(suite, mutation, validMutations) {
+  if (!mutation || validMutations.includes(mutation)) return;
+  throw new Error(
+    `${suite}_UNKNOWN_MUTATION name=${mutation} valid=${validMutations.join(",")}`,
+  );
+}
+
+export function assertMutationApplied(suite, mutation, output) {
+  if (!mutation) return;
+  const marker = `${suite}_MUTATION_APPLIED=${mutation}`;
+  if (output.includes(marker)) return;
+  throw new Error(
+    `${suite}_MUTATION_NOT_APPLIED name=${mutation} expected=${marker}`,
+  );
+}

--- a/scripts/ceremony/run-int4b-drills.mjs
+++ b/scripts/ceremony/run-int4b-drills.mjs
@@ -2,11 +2,23 @@ import { spawnSync } from "node:child_process";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
+import {
+  assertKnownMutation,
+  assertMutationApplied,
+} from "./lib/int4-mutation-contract.mjs";
+
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
 const suffix = `${process.pid}-${Date.now()}`;
 const reference = `int4b-reference-${suffix}`;
 const harness = `int4b-harness-${suffix}`;
 const mutation = argument("--mutation");
+const validMutations = [
+  "timestamp-fingerprint",
+  "skip-marker-write",
+  "count-transient",
+  "drop-orphan-class",
+];
+assertKnownMutation("INT4B", mutation, validMutations);
 
 try {
   startDatabase(reference, "reference_int4b");
@@ -34,8 +46,10 @@ try {
       encoding: "utf8",
     },
   );
+  const output = `${result.stdout ?? ""}${result.stderr ?? ""}`;
   process.stdout.write(result.stdout ?? "");
   process.stderr.write(result.stderr ?? "");
+  assertMutationApplied("INT4B", mutation, output);
   process.exitCode = result.status ?? 1;
 } finally {
   removeDatabase(reference);

--- a/scripts/ceremony/run-int4c-drills.mjs
+++ b/scripts/ceremony/run-int4c-drills.mjs
@@ -2,12 +2,23 @@ import { spawnSync } from "node:child_process";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
+import {
+  assertKnownMutation,
+  assertMutationApplied,
+} from "./lib/int4-mutation-contract.mjs";
+
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
 const suffix = `${process.pid}-${Date.now()}`;
 const reference = `int4c-reference-${suffix}`;
 const harness = `int4c-harness-${suffix}`;
 const mutation = argument("--mutation");
 const filter = argument("--filter");
+const validMutations = [
+  "disable-renewal",
+  "remove-retry-bound",
+  "alert-dedup",
+];
+assertKnownMutation("INT4C", mutation, validMutations);
 
 try {
   startDatabase(reference, "reference_int4c");
@@ -41,8 +52,10 @@ try {
       encoding: "utf8",
     },
   );
+  const output = `${result.stdout ?? ""}${result.stderr ?? ""}`;
   process.stdout.write(result.stdout ?? "");
   process.stderr.write(result.stderr ?? "");
+  assertMutationApplied("INT4C", mutation, output);
   process.exitCode = result.status ?? 1;
 } finally {
   removeDatabase(reference);

--- a/scripts/ceremony/run-int4d-drills.mjs
+++ b/scripts/ceremony/run-int4d-drills.mjs
@@ -4,6 +4,11 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
+import {
+  assertKnownMutation,
+  assertMutationApplied,
+} from "./lib/int4-mutation-contract.mjs";
+
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
 const pin = "3355f4906864b0f0e0fe5fd5eb5220172e174206";
 const suffix = `${process.pid}-${Date.now()}`;
@@ -11,6 +16,14 @@ const reference = `int4d-reference-${suffix}`;
 const harness = `int4d-harness-${suffix}`;
 const mutation = argument("--mutation");
 const filter = argument("--filter");
+const validMutations = [
+  "non-idempotent-projection",
+  "duplicate-worker-effect",
+  "board-replay-write",
+  "skip-policy-recheck",
+  "disable-size-gate",
+];
+assertKnownMutation("INT4D", mutation, validMutations);
 const scratch = mkdtempSync(path.join(tmpdir(), "int4d-runner-"));
 const suppliedCheckout = process.env.HARNESS_CHECKOUT?.trim();
 const harnessCheckout = suppliedCheckout || path.join(scratch, "agent-harness");
@@ -53,8 +66,10 @@ try {
       timeout: 240_000,
     },
   );
+  const output = `${result.stdout ?? ""}${result.stderr ?? ""}`;
   process.stdout.write(result.stdout ?? "");
   process.stderr.write(result.stderr ?? "");
+  assertMutationApplied("INT4D", mutation, output);
   process.exitCode = result.status ?? 1;
 } finally {
   removeDatabase(reference);

--- a/test/integration/int4c-lease-takeover.test.ts
+++ b/test/integration/int4c-lease-takeover.test.ts
@@ -190,6 +190,7 @@ RUN("INT-4c lease takeover and backpressure drills", () => {
       await waitForLeaseHolder("live-holder", 5_000);
       contender = spawnLease("live-contender", "contender");
       await delay(3_200);
+      expectMutationApplied(holder.output, "disable-renewal");
       const row = await leaseRow();
       expect(row.holder, "INT4C_LIVE_HOLDER_WAS_STOLEN").toBe("live-holder");
       expect(contender.output).not.toContain("holder=live-contender acquired=true");
@@ -233,6 +234,7 @@ RUN("INT-4c lease takeover and backpressure drills", () => {
     await waitForClaimExpiry(task);
     const third = spawnDispatcher("retry-holder-three", undefined, MUTATION);
     await waitForExit(third.child, 8_000);
+    expectMutationApplied(third.output, "remove-retry-bound");
 
     const stored = await getAgentTask(task.workItemId, 1, refDeps());
     const claim = await getDispatchClaim(task.workItemId, 1, refDeps());
@@ -260,6 +262,10 @@ RUN("INT-4c lease takeover and backpressure drills", () => {
     expect((await waitForExit(first.child, 8_000)).code).toBe(0);
     const second = spawnDispatcher("backpressure-two", undefined, MUTATION);
     expect((await waitForExit(second.child, 8_000)).code).toBe(0);
+    expectMutationApplied(
+      `${first.output}\n${second.output}`,
+      "alert-dedup",
+    );
 
     const decisions = await listHermesDecisions({
       workItemId: queued.workItemId,
@@ -472,6 +478,14 @@ function spawnLease(holder: string, mode: "holder" | "contender") {
     record.output += String(chunk);
   });
   return record;
+}
+
+function expectMutationApplied(output: string, name: string): void {
+  if (MUTATION !== name) return;
+  const marker = `INT4C_MUTATION_APPLIED=${name}`;
+  expect(output, `requested mutation did not reach its seam: ${name}`)
+    .toContain(marker);
+  print(marker);
 }
 
 async function expectFaultStamp(

--- a/test/unit/int4-drill-mutation-contract.test.ts
+++ b/test/unit/int4-drill-mutation-contract.test.ts
@@ -1,0 +1,58 @@
+import { spawnSync } from "node:child_process";
+
+import { describe, expect, it } from "vitest";
+
+import {
+  assertMutationApplied,
+} from "../../scripts/ceremony/lib/int4-mutation-contract.mjs";
+
+const CASES = [
+  {
+    suite: "INT4B",
+    runner: "scripts/ceremony/run-int4b-drills.mjs",
+    valid:
+      "timestamp-fingerprint,skip-marker-write,count-transient,drop-orphan-class",
+  },
+  {
+    suite: "INT4C",
+    runner: "scripts/ceremony/run-int4c-drills.mjs",
+    valid: "disable-renewal,remove-retry-bound,alert-dedup",
+  },
+  {
+    suite: "INT4D",
+    runner: "scripts/ceremony/run-int4d-drills.mjs",
+    valid:
+      "non-idempotent-projection,duplicate-worker-effect,board-replay-write,skip-policy-recheck,disable-size-gate",
+  },
+] as const;
+
+describe("INT-4 drill mutation contracts", () => {
+  it("refuses a recognized mutation that never reports reaching its seam", () => {
+    expect(() => assertMutationApplied(
+      "INT4C",
+      "remove-retry-bound",
+      "six green drills with no mutation marker",
+    )).toThrow(
+      "INT4C_MUTATION_NOT_APPLIED name=remove-retry-bound expected=INT4C_MUTATION_APPLIED=remove-retry-bound",
+    );
+  });
+
+  it.each(CASES)(
+    "$suite refuses an unknown mutation before starting its drill",
+    ({ suite, runner, valid }) => {
+      const result = spawnSync(process.execPath, [
+        runner,
+        "--mutation",
+        "not-a-real-name",
+      ], {
+        cwd: process.cwd(),
+        encoding: "utf8",
+      });
+
+      expect(result.status).not.toBe(0);
+      expect(`${result.stdout}${result.stderr}`).toContain(
+        `${suite}_UNKNOWN_MUTATION name=not-a-real-name valid=${valid}`,
+      );
+    },
+  );
+});


### PR DESCRIPTION
## What changed
- Reject unknown INT-4 mutation names before database, Docker, or Harness setup, naming the bad value and the full valid vocabulary.
- Require child output to contain the exact requested INT4x_MUTATION_APPLIED marker before a runner can report its result.
- Assert all three INT-4c child seams and surface the marker only after the exact seam executed.
- Apply the same runner contract to the audited 4b and 4d harnesses without changing drill counts or the Harness pin.

## Local evidence
- npm run typecheck: exit 0.
- npm test: exit 0; 195 files passed, 6 skipped; 2885 tests passed, 40 skipped.
- npm run build: exit 0.
- Focused mutation-contract tests: exit 0; 1 file and 4 tests passed.
- Unknown INT-4c name: exit 1 with Error: INT4C_UNKNOWN_MUTATION name=not-a-real-name valid=disable-renewal,remove-retry-bound,alert-dedup.
- Recognized mutation with no seam marker: exit 1 with Error: INT4C_MUTATION_NOT_APPLIED name=remove-retry-bound expected=INT4C_MUTATION_APPLIED=remove-retry-bound.

## 4b and 4d audit
- INT-4b shared the unsafe shape: markers existed, but unknown names were silently ignored and the runner never required a marker. It now rejects unknown names and requires the exact child marker.
- INT-4d partially guarded unknown names inside the test, but its error omitted the valid vocabulary and its runner never required a marker. The runner now performs both checks before the pinned checkout and the pin remains unchanged.

## Preserved blocked evidence
The Docker-backed valid-mutation drills were not run because the local daemon readiness check exited 1 verbatim:

failed to connect to the docker API at unix:///Users/pascalkuriger/.colima/default/docker.sock; check if the path is correct and if the daemon is running: dial unix /Users/pascalkuriger/.colima/default/docker.sock: connect: no such file or directory

Per the work order, I did not start Colima or retry. Therefore this draft does not claim fresh disable-renewal, remove-retry-bound, or alert-dedup drill-red evidence; CI and a Docker-capable reviewer still need that gate.

## Affected surfaces
Ceremony runners and tests only. No production runtime, kernel code, Harness pin, quarantine, lease, claim, policy, watchdog import surface, ops, compose, environment, secret, database, merge, or deployment change.

## Rollout and rollback
No provisioning or rollout step. Revert this commit to restore the previous runner behavior.

Closes #773