### PR TITLE
fix(int4c): repair three independent drill rots and remove their causes

### DIFF
--- a/test/fixtures/agent-integration/int4c-dispatch-process.mjs
+++ b/test/fixtures/agent-integration/int4c-dispatch-process.mjs
@@ -89,6 +89,14 @@ const transitionBackpressure = async (input) => {
   return result;
 };
 
+function requireEnv(name) {
+  const value = process.env[name]?.trim();
+  if (!value) {
+    throw new Error(`INT4C drill child requires ${name} to be set by the parent`);
+  }
+  return value;
+}
+
 const dispatchDeps = {
   now: () => new Date(),
   dispatcherId,
@@ -96,6 +104,14 @@ const dispatchDeps = {
   claimTtlMs,
   maxInflight: Number(process.env.HARNESS_DISPATCH_MAX_INFLIGHT ?? "1"),
   isDispatchEnabled: () => true,
+  // INT-4d requires an active policy identity whenever dispatch is enabled.
+  // The parent passes the fixture's identity: no default here, because a
+  // wrong-but-plausible default refuses every task with policy_drift, which
+  // reads as a real drift finding rather than a misconfigured drill.
+  activePolicyIdentity: {
+    version: requireEnv("INT4C_ACTIVE_POLICY_VERSION"),
+    hash: requireEnv("INT4C_ACTIVE_POLICY_HASH"),
+  },
   isHalted: () => false,
   listDispatchable: listDispatchableAgentTasks,
   getTask: getAgentTask,
@@ -192,7 +208,10 @@ dispatcher = createDispatcherProcess({
       }
       return result;
     } catch (error) {
-      process.stdout.write(`INT4C_CHILD_ATTEMPT_ERROR dispatcher=${dispatcherId} name=${error instanceof Error ? error.name : "UnknownError"}\n`);
+      const detail = error instanceof Error
+        ? `${error.name}: ${error.message}${error.stack ? `\n${error.stack.split("\n").slice(1, 4).join("\n")}` : ""}`
+        : `UnknownError: ${String(error)}`;
+      process.stdout.write(`INT4C_CHILD_ATTEMPT_ERROR dispatcher=${dispatcherId} ${detail.replace(/\n/gu, " | ")}\n`);
       setTimeout(() => void finish(), 0);
       throw error;
     }

--- a/test/integration/int4c-lease-takeover.test.ts
+++ b/test/integration/int4c-lease-takeover.test.ts
@@ -6,6 +6,7 @@ import {
 import {
   mkdir,
   mkdtemp,
+  readdir,
   readFile,
   rm,
 } from "node:fs/promises";
@@ -54,7 +55,10 @@ const MUTATION = process.env.INT4C_MUTATION?.trim();
 const PRINT_EVIDENCE = process.env.INT4C_PRINT_EVIDENCE === "1";
 const CLAIM_TTL_MS = 250;
 const OLD = "2026-08-06T10:00:00.000Z";
-const DEADLINE = "2026-08-07T12:00:00.000Z";
+// Relative, not absolute: a hardcoded wall-clock deadline silently expires and
+// takes the whole drill suite with it — this one died on 2026-08-07 and every
+// run after it refused with deadline_expired regardless of the code under test.
+const DEADLINE = new Date(Date.now() + 86_400_000).toISOString();
 const PLACEHOLDER_HASH = `sha256:${"f".repeat(64)}`;
 const CAPABILITIES: PilotProfileManifest["capabilities"] = [
   { id: "fs.read_file", effectClass: "none", delegable: false },
@@ -81,15 +85,18 @@ RUN("INT-4c lease takeover and backpressure drills", () => {
       "utf8",
     )));
     scratchRoot = await mkdtemp(path.join(tmpdir(), "int4c-drill-"));
-    for (const migration of [
-      "001_init.sql",
-      "002_agent_tasks.sql",
-      "003_dispatch_claims_outbox_decisions.sql",
-      "004_dispatch_quarantines.sql",
-      "005_dispatch_claim_expiry_backpressure.sql",
-    ]) {
+    // Read the directory rather than hardcoding a list: a hand-maintained list
+    // silently falls behind (006_dispatch_policy_drift.sql was added by INT-4d
+    // and never landed here, reddening this drill with a missing-relation error
+    // that looked nothing like its cause).
+    const migrationsDir = new URL("../../ops/migrations/", import.meta.url);
+    const migrations = (await readdir(migrationsDir))
+      .filter((name) => name.endsWith(".sql"))
+      .sort();
+    expect(migrations.length, "no migrations found").toBeGreaterThan(0);
+    for (const migration of migrations) {
       await referencePool.query(await readFile(
-        new URL(`../../ops/migrations/${migration}`, import.meta.url),
+        new URL(migration, migrationsDir),
         "utf8",
       ));
     }
@@ -436,6 +443,10 @@ function spawnDispatcher(
       HARNESS_DISPATCH_MAX_INFLIGHT: "1",
       HARNESS_DISPATCH_ALERTS_PATH: alertsPath(),
       HARNESS_DISPATCH_HEARTBEAT_PATH: heartbeatPath,
+      // Derive the child's active policy identity from the same fixture the
+      // tasks are built from, so the two can never silently disagree.
+      INT4C_ACTIVE_POLICY_VERSION: fixture.approval.policyVersion!,
+      INT4C_ACTIVE_POLICY_HASH: fixture.approval.policyHash!,
       ...(crashPoint
         ? {
             HARNESS_DISPATCH_FAULT_INJECTION: "enabled",


### PR DESCRIPTION
## What

The six INT-4c drills were **5/6 red on main**. Investigating found **three independent causes**, none visible from the failure output — the child logged only `error.name`, so all three presented as the same opaque wall.

| # | Cause | Fix |
|---|---|---|
| 1 | INT-4d made `activePolicyIdentity` required when dispatch is enabled; the drill child builds its dispatcher from an **explicit config object**, so the new field never reached it | Parent passes it, derived from the fixture |
| 2 | `DEADLINE` was a hardcoded wall-clock timestamp (`2026-08-07T12:00:00Z`) — every run after that instant refused with `deadline_expired` regardless of the code under test | Relative deadline |
| 3 | The drill applied a hand-maintained list of 5 migrations; INT-4d added `006_dispatch_policy_drift.sql` and never landed here | Migrations read from the directory |

Causes 2 and 3 are the same defect shape — **a manually maintained constant that silently falls behind**. Both are now derived rather than declared, so neither can recur.

Cause 2 is worth naming separately: it was **not** a regression from any merge. It was a time bomb that fired on a calendar date. The drills were green when written and green when gated; they died 20 hours before anyone looked.

## Why the diagnosis took three wrong guesses

The child reported `INT4C_CHILD_ATTEMPT_ERROR name=Error` and nothing else. A message-less failure is indistinguishable across causes, so each fix revealed the next cause rather than the whole picture. The child now logs `error.message` and the top stack frames — which turned the remaining work from guessing into reading.

Relatedly, the child no longer *defaults* its policy identity. A wrong-but-plausible default refuses every task with `policy_drift`, which reads as a **real drift finding** rather than a broken drill. It now fails loudly and names the missing variable.

## Verification

- 6/6 drills green
- All three mutations still red **their own distinct drill** and carry the applied marker (so none is an unarmed run):
  - `disable-renewal` → *does not take over while a healthy holder renews*
  - `remove-retry-bound` → *blocks after the one takeover retry*
  - `alert-dedup` → *refuses at the introduced in-flight bound*
- Removing the identity from the parent was **seen red**: the failure now names `INT4C_ACTIVE_POLICY_HASH` rather than reporting `policy_drift`
- `typecheck: 0`

## Note on scope

This repairs the drills. It does **not** address the finding in #787 — that **no CI job runs any INT-4 drill**, which is why three separate rots accumulated undetected. That decision (CI inclusion vs. marking `executed` ledger rows as point-in-time) is still open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)