### PR TITLE
fix(ci): fail INT-4 runners when drills skip

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,3 +147,78 @@ jobs:
           name: int2-supervised-dispatch-evidence
           path: ${{ runner.temp }}/int2-suite-evidence
           if-no-files-found: error
+
+  int4-mechanism-drills:
+    name: INT-4 mechanism drill (${{ matrix.id }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - id: int4b
+            runner: scripts/ceremony/run-int4b-drills.mjs
+            expected: 5
+            needs_harness: false
+          - id: int4c
+            runner: scripts/ceremony/run-int4c-drills.mjs
+            expected: 6
+            needs_harness: false
+          - id: int4c-d0
+            runner: scripts/ceremony/run-int4c-d0.mjs
+            expected: 3
+            needs_harness: false
+          - id: int4d
+            runner: scripts/ceremony/run-int4d-drills.mjs
+            expected: 6
+            needs_harness: true
+    steps:
+      - name: Checkout full history
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Setup uv
+        if: matrix.needs_harness
+        uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+
+      - name: Install reference dependencies
+        run: npm ci
+
+      - name: Build drill package imports
+        # npm ci has no lifecycle build. The drill children import the
+        # workspace package through exports that point at dist/.
+        run: npx tsc -b packages/averray-mcp
+
+      - name: Run INT-4 mechanism drill
+        if: ${{ !matrix.needs_harness }}
+        env:
+          INT4_DRILL_EVIDENCE_DIR: ${{ runner.temp }}/int4-${{ matrix.id }}-evidence
+        run: node ${{ matrix.runner }}
+
+      - name: Run INT-4 mechanism drill with pinned Harness
+        if: matrix.needs_harness
+        env:
+          INT2_HARNESS_DEPLOY_KEY: ${{ secrets.INT2_HARNESS_DEPLOY_KEY }}
+          INT4_DRILL_EVIDENCE_DIR: ${{ runner.temp }}/int4-${{ matrix.id }}-evidence
+        run: node ${{ matrix.runner }}
+
+      - name: Prove the drill suite did not skip
+        if: always()
+        run: test "$(tr -d '[:space:]' < '${{ runner.temp }}/int4-${{ matrix.id }}-evidence/executed-count.txt')" = "${{ matrix.expected }}"
+
+      - name: Upload INT-4 drill evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: int4-${{ matrix.id }}-drill-evidence
+          path: ${{ runner.temp }}/int4-${{ matrix.id }}-evidence
+          if-no-files-found: error

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -195,8 +195,8 @@ jobs:
 
       - name: Build drill package imports
         # npm ci has no lifecycle build. The drill children import the
-        # workspace package through exports that point at dist/.
-        run: npx tsc -b packages/averray-mcp
+        # workspace packages and dispatcher through exports that point at dist/.
+        run: npm run build
 
       - name: Run INT-4 mechanism drill
         if: ${{ !matrix.needs_harness }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,6 +155,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # INT-4c D0 is a completed pre-implementation baseline, not a current
+        # mechanism drill. Preserve its truthful local guard, but do not run
+        # the fossil against current main. See
+        # docs/evidence/INT4C_D0_PARTIAL_2026-08-06.md and issue #790.
         include:
           - id: int4b
             runner: scripts/ceremony/run-int4b-drills.mjs
@@ -163,10 +167,6 @@ jobs:
           - id: int4c
             runner: scripts/ceremony/run-int4c-drills.mjs
             expected: 6
-            needs_harness: false
-          - id: int4c-d0
-            runner: scripts/ceremony/run-int4c-d0.mjs
-            expected: 3
             needs_harness: false
           - id: int4d
             runner: scripts/ceremony/run-int4d-drills.mjs

--- a/scripts/ceremony/drill-int4-runner-execution.mjs
+++ b/scripts/ceremony/drill-int4-runner-execution.mjs
@@ -1,0 +1,258 @@
+#!/usr/bin/env node
+
+import { spawnSync } from "node:child_process";
+import {
+  chmodSync,
+  copyFileSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+const mutation = argument("--mutation");
+if (mutation && mutation !== "remove-guard") {
+  throw new Error(
+    `INT4_RUNNER_EXECUTION_UNKNOWN_MUTATION name=${mutation} valid=remove-guard`,
+  );
+}
+
+const cases = [
+  {
+    suite: "INT4B",
+    runner: "run-int4b-drills.mjs",
+    testFile: "int4b-quarantine.test.ts",
+    coupling: "INT4B_REFERENCE_DATABASE_URL",
+    expected: 5,
+  },
+  {
+    suite: "INT4C",
+    runner: "run-int4c-drills.mjs",
+    testFile: "int4c-lease-takeover.test.ts",
+    coupling: "INT4C_REFERENCE_DATABASE_URL",
+    expected: 6,
+  },
+  {
+    suite: "INT4C_D0",
+    runner: "run-int4c-d0.mjs",
+    testFile: "int4c-d0-baseline.test.ts",
+    coupling: "INT4C_REFERENCE_DATABASE_URL",
+    expected: 3,
+  },
+  {
+    suite: "INT4D",
+    runner: "run-int4d-drills.mjs",
+    testFile: "int4d-drill-matrix.test.ts",
+    coupling: "INT4D_REFERENCE_DATABASE_URL",
+    expected: 6,
+  },
+];
+
+let failed = false;
+for (const drill of cases) {
+  const broken = runRunner(drill, { breakCoupling: true, removeGuard: mutation });
+  if (mutation) {
+    console.info(
+      `INT4_RUNNER_EXECUTION_MUTATION_APPLIED suite=${drill.suite} name=${mutation}`,
+    );
+    if (broken.status === 0) {
+      failed = true;
+      console.error(
+        `INT4_RUNNER_EXECUTION_DRILL_FAILED suite=${drill.suite} `
+          + "expected=nonzero actual=0 reason=all_skipped_was_accepted",
+      );
+    } else {
+      console.info(
+        `INT4_RUNNER_EXECUTION_MUTATION_SURVIVED suite=${drill.suite} `
+          + `exit=${broken.status}`,
+      );
+    }
+    continue;
+  }
+
+  const expectedReason = `${drill.suite}_DRILLS_SKIPPED passed=0 `
+    + `skipped=${drill.expected} total=${drill.expected}`;
+  if (broken.status === 0 || !combinedOutput(broken).includes(expectedReason)) {
+    failed = true;
+    console.error(
+      `INT4_RUNNER_EXECUTION_COUPLING_CHECK_FAILED suite=${drill.suite} `
+        + `exit=${broken.status ?? "null"} expected_reason=${expectedReason} `
+        + `detail=${oneLine(combinedOutput(broken))}`,
+    );
+  } else {
+    console.info(
+      `INT4_RUNNER_EXECUTION_COUPLING_RED suite=${drill.suite} `
+        + `exit=${broken.status} reason=${expectedReason}`,
+    );
+  }
+
+  const intact = runRunner(drill, { breakCoupling: false, removeGuard: false });
+  const expectedGreen = `${drill.suite}_DRILLS_EXECUTED passed=${drill.expected} `
+    + `skipped=0 failed=0 total=${drill.expected}`;
+  if (intact.status !== 0 || !combinedOutput(intact).includes(expectedGreen)) {
+    failed = true;
+    console.error(
+      `INT4_RUNNER_EXECUTION_INTACT_CHECK_FAILED suite=${drill.suite} `
+        + `exit=${intact.status ?? "null"} expected=${expectedGreen} `
+        + `detail=${oneLine(combinedOutput(intact))}`,
+    );
+  } else {
+    console.info(
+      `INT4_RUNNER_EXECUTION_GREEN suite=${drill.suite} exit=0 `
+        + `executed=${drill.expected}`,
+    );
+  }
+}
+
+if (failed) process.exitCode = 1;
+
+function runRunner(drill, options) {
+  const scratch = mkdtempSync(path.join(tmpdir(), "int4-runner-drill-"));
+  try {
+    const ceremony = path.join(scratch, "scripts/ceremony");
+    const library = path.join(ceremony, "lib");
+    const fakeBin = path.join(scratch, "fake-bin");
+    const evidence = path.join(scratch, "evidence");
+    const harnessCheckout = path.join(scratch, "agent-harness");
+    const probeTest = path.join(scratch, "test/integration/runner-probe.test.mjs");
+    mkdirSync(library, { recursive: true });
+    mkdirSync(fakeBin, { recursive: true });
+    mkdirSync(evidence, { recursive: true });
+    mkdirSync(harnessCheckout, { recursive: true });
+    mkdirSync(path.dirname(probeTest), { recursive: true });
+    symlinkSync(path.join(root, "node_modules"), path.join(scratch, "node_modules"));
+    writeFileSync(probeTest, `
+import { describe, expect, it } from "vitest";
+const RUN = process.env.${drill.coupling} ? describe : describe.skip;
+RUN("${drill.suite} coupling probe", () => {
+  for (let index = 1; index <= ${drill.expected}; index += 1) {
+    it("executes drill " + index, () => expect(index).toBeGreaterThan(0));
+  }
+});
+`, "utf8");
+
+    copyFileSync(
+      path.join(root, "scripts/ceremony/lib/int4-mutation-contract.mjs"),
+      path.join(library, "int4-mutation-contract.mjs"),
+    );
+    copyFileSync(
+      path.join(root, "scripts/ceremony/lib/int4-vitest-execution.mjs"),
+      path.join(library, "int4-vitest-execution.mjs"),
+    );
+
+    const runnerSource = path.join(root, "scripts/ceremony", drill.runner);
+    let source = readFileSync(runnerSource, "utf8");
+    if (options.breakCoupling) {
+      source = replaceExactlyOnce(
+        source,
+        `${drill.coupling}:`,
+        `${drill.coupling}_BROKEN:`,
+        `${drill.suite} coupling`,
+      );
+    }
+    if (options.removeGuard) {
+      source = replaceExactlyOnce(
+        source,
+        "  vitestExecution.assert(result.status);\n",
+        "",
+        `${drill.suite} guard`,
+      );
+    }
+    const runnerPath = path.join(ceremony, drill.runner);
+    writeFileSync(runnerPath, source, "utf8");
+
+    writeFakeCommands(fakeBin);
+    return spawnSync(process.execPath, [runnerPath], {
+      cwd: scratch,
+      env: {
+        ...process.env,
+        PATH: `${fakeBin}${path.delimiter}${process.env.PATH ?? ""}`,
+        HARNESS_CHECKOUT: harnessCheckout,
+        INT4_DRILL_EVIDENCE_DIR: evidence,
+        INT4_RUNNER_DRILL_TEST_FILE: drill.testFile,
+        INT4_RUNNER_DRILL_PROBE_TEST: path.relative(scratch, probeTest),
+        INT4_RUNNER_DRILL_VITEST:
+          path.join(root, "node_modules/vitest/vitest.mjs"),
+      },
+      encoding: "utf8",
+    });
+  } finally {
+    rmSync(scratch, { recursive: true, force: true });
+  }
+}
+
+function writeFakeCommands(directory) {
+  writeExecutable(directory, "docker", `
+const args = process.argv.slice(2);
+if (args[0] === "exec") process.stdout.write("1\\n");
+if (args[0] === "port") process.stdout.write("127.0.0.1:54321\\n");
+`);
+  writeExecutable(directory, "git", `
+const args = process.argv.slice(2);
+if (args.includes("rev-parse")) {
+  process.stdout.write(args.includes("-C")
+    ? "3355f4906864b0f0e0fe5fd5eb5220172e174206\\n"
+    : "bd6133220d0e9991a5700e7313ec7dd5da3b7434\\n");
+} else if (args.includes("merge-base")) {
+  process.stdout.write("bd6133220d0e9991a5700e7313ec7dd5da3b7434\\n");
+}
+`);
+  writeExecutable(directory, "uv", "");
+  writeExecutable(directory, "npx", `
+import { spawnSync } from "node:child_process";
+
+const args = process.argv.slice(2);
+const expectedFile = process.env.INT4_RUNNER_DRILL_TEST_FILE;
+const testIndex = args.findIndex((value) => value.endsWith(expectedFile));
+if (testIndex === -1) process.exit(90);
+const result = spawnSync(
+  process.execPath,
+  [
+    process.env.INT4_RUNNER_DRILL_VITEST,
+    "run",
+    process.env.INT4_RUNNER_DRILL_PROBE_TEST,
+    ...args.slice(testIndex + 1),
+  ],
+  { cwd: process.cwd(), env: process.env, encoding: "utf8" },
+);
+process.stdout.write(result.stdout ?? "");
+process.stderr.write(result.stderr ?? "");
+process.exit(result.status ?? 92);
+`);
+}
+
+function writeExecutable(directory, name, body) {
+  const target = path.join(directory, name);
+  writeFileSync(target, `#!/usr/bin/env node\n${body.trimStart()}`, "utf8");
+  chmodSync(target, 0o755);
+}
+
+function replaceExactlyOnce(source, before, after, label) {
+  const first = source.indexOf(before);
+  if (first === -1 || source.indexOf(before, first + before.length) !== -1) {
+    throw new Error(`INT4_RUNNER_EXECUTION_PROBE_INVALID label=${label}`);
+  }
+  return source.slice(0, first) + after + source.slice(first + before.length);
+}
+
+function combinedOutput(result) {
+  return `${result.stdout ?? ""}${result.stderr ?? ""}`;
+}
+
+function oneLine(value) {
+  return value.replace(/\s+/gu, " ").trim().slice(0, 1_000);
+}
+
+function argument(name) {
+  const index = process.argv.indexOf(name);
+  if (index === -1) return undefined;
+  const value = process.argv[index + 1];
+  if (!value || value.startsWith("--")) throw new Error(`${name} requires a value`);
+  return value;
+}

--- a/scripts/ceremony/lib/int4-vitest-execution.mjs
+++ b/scripts/ceremony/lib/int4-vitest-execution.mjs
@@ -1,0 +1,114 @@
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+const EVIDENCE_ENV = "INT4_DRILL_EVIDENCE_DIR";
+
+export function prepareVitestExecution(
+  suite,
+  environment = process.env,
+) {
+  const configuredEvidence = environment[EVIDENCE_ENV]?.trim();
+  const temporary = !configuredEvidence;
+  const evidenceDir = configuredEvidence
+    ? path.resolve(configuredEvidence)
+    : mkdtempSync(path.join(tmpdir(), "int4-vitest-"));
+  mkdirSync(evidenceDir, { recursive: true });
+  const reportPath = path.join(evidenceDir, "vitest-report.json");
+
+  return {
+    reportPath,
+    reporterArgs: [
+      "--reporter=verbose",
+      "--reporter=json",
+      `--outputFile.json=${reportPath}`,
+    ],
+    assert(childStatus) {
+      return assertVitestExecution({
+        suite,
+        childStatus,
+        reportPath,
+        evidenceDir,
+      });
+    },
+    cleanup() {
+      if (temporary) rmSync(evidenceDir, { recursive: true, force: true });
+    },
+  };
+}
+
+export function assertVitestExecution({
+  suite,
+  childStatus,
+  reportPath,
+  evidenceDir,
+}) {
+  const status = childStatus ?? 1;
+  if (!existsSync(reportPath)) {
+    if (status !== 0) return undefined;
+    throw new Error(`${suite}_VITEST_REPORT_MISSING path=${reportPath}`);
+  }
+
+  let counts;
+  try {
+    const report = JSON.parse(readFileSync(reportPath, "utf8"));
+    const passed = countField(report, "numPassedTests");
+    const failed = countField(report, "numFailedTests");
+    const skipped = countField(report, "numPendingTests");
+    const total = countField(report, "numTotalTests");
+    counts = { passed, failed, skipped, executed: passed + failed, total };
+  } catch (error) {
+    if (status !== 0) return undefined;
+    throw new Error(
+      `${suite}_VITEST_REPORT_INVALID error=${safeErrorMessage(error)}`,
+    );
+  }
+
+  const { passed, failed, skipped, executed, total } = counts;
+  writeFileSync(
+    path.join(evidenceDir, "executed-count.txt"),
+    `${executed}\n`,
+    "utf8",
+  );
+  writeFileSync(
+    path.join(evidenceDir, "execution-summary.json"),
+    `${JSON.stringify({ suite, passed, failed, skipped, executed, total }, null, 2)}\n`,
+    "utf8",
+  );
+
+  if (status !== 0) return { passed, failed, skipped, executed, total };
+  if (skipped > 0) {
+    throw new Error(
+      `${suite}_DRILLS_SKIPPED passed=${passed} skipped=${skipped} total=${total}`,
+    );
+  }
+  if (passed < 1) {
+    throw new Error(
+      `${suite}_DRILLS_NOT_EXECUTED passed=${passed} skipped=${skipped} total=${total}`,
+    );
+  }
+
+  console.info(
+    `${suite}_DRILLS_EXECUTED passed=${passed} skipped=${skipped} failed=${failed} total=${total}`,
+  );
+  return { passed, failed, skipped, executed, total };
+}
+
+function countField(report, field) {
+  const value = report?.[field];
+  if (!Number.isSafeInteger(value) || value < 0) {
+    throw new Error(`VITEST_REPORT_COUNT_INVALID field=${field}`);
+  }
+  return value;
+}
+
+function safeErrorMessage(error) {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/scripts/ceremony/run-int4b-drills.mjs
+++ b/scripts/ceremony/run-int4b-drills.mjs
@@ -6,6 +6,7 @@ import {
   assertKnownMutation,
   assertMutationApplied,
 } from "./lib/int4-mutation-contract.mjs";
+import { prepareVitestExecution } from "./lib/int4-vitest-execution.mjs";
 
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
 const suffix = `${process.pid}-${Date.now()}`;
@@ -19,6 +20,7 @@ const validMutations = [
   "drop-orphan-class",
 ];
 assertKnownMutation("INT4B", mutation, validMutations);
+const vitestExecution = prepareVitestExecution("INT4B");
 
 try {
   startDatabase(reference, "reference_int4b");
@@ -31,7 +33,12 @@ try {
   console.info(`INT4B_DATABASE_LIVE boundary=harness container=${harness}`);
   const result = spawnSync(
     "npx",
-    ["vitest", "run", "test/integration/int4b-quarantine.test.ts"],
+    [
+      "vitest",
+      "run",
+      "test/integration/int4b-quarantine.test.ts",
+      ...vitestExecution.reporterArgs,
+    ],
     {
       cwd: root,
       env: {
@@ -50,10 +57,12 @@ try {
   process.stdout.write(result.stdout ?? "");
   process.stderr.write(result.stderr ?? "");
   assertMutationApplied("INT4B", mutation, output);
+  vitestExecution.assert(result.status);
   process.exitCode = result.status ?? 1;
 } finally {
   removeDatabase(reference);
   removeDatabase(harness);
+  vitestExecution.cleanup();
 }
 
 function startDatabase(name, database) {

--- a/scripts/ceremony/run-int4c-d0.mjs
+++ b/scripts/ceremony/run-int4c-d0.mjs
@@ -2,9 +2,12 @@ import { spawnSync } from "node:child_process";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
+import { prepareVitestExecution } from "./lib/int4-vitest-execution.mjs";
+
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
 const container = `int4c-d0-${process.pid}-${Date.now()}`;
 const leaseOnly = process.argv.includes("--lease-only");
+const vitestExecution = prepareVitestExecution("INT4C_D0");
 
 try {
   const started = docker([
@@ -21,7 +24,8 @@ try {
   console.info(`INT4C_D0_PROBE_SHA=${git(["rev-parse", "HEAD"]).stdout.trim()}`);
   console.info(`INT4C_D0_DATABASE_LIVE container=${container}`);
   const args = [
-    "vitest", "run", "test/integration/int4c-d0-baseline.test.ts", "--reporter=verbose",
+    "vitest", "run", "test/integration/int4c-d0-baseline.test.ts",
+    ...vitestExecution.reporterArgs,
     ...(leaseOnly
       ? ["-t", "records dead-holder takeover and the live-holder negative with two processes"]
       : []),
@@ -37,9 +41,11 @@ try {
   });
   process.stdout.write(result.stdout ?? "");
   process.stderr.write(result.stderr ?? "");
+  vitestExecution.assert(result.status);
   process.exitCode = result.status ?? 1;
 } finally {
   docker(["rm", "--force", container], true);
+  vitestExecution.cleanup();
 }
 
 function waitForDatabase() {

--- a/scripts/ceremony/run-int4c-drills.mjs
+++ b/scripts/ceremony/run-int4c-drills.mjs
@@ -6,6 +6,7 @@ import {
   assertKnownMutation,
   assertMutationApplied,
 } from "./lib/int4-mutation-contract.mjs";
+import { prepareVitestExecution } from "./lib/int4-vitest-execution.mjs";
 
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
 const suffix = `${process.pid}-${Date.now()}`;
@@ -19,6 +20,7 @@ const validMutations = [
   "alert-dedup",
 ];
 assertKnownMutation("INT4C", mutation, validMutations);
+const vitestExecution = prepareVitestExecution("INT4C");
 
 try {
   startDatabase(reference, "reference_int4c");
@@ -35,7 +37,7 @@ try {
       "vitest",
       "run",
       "test/integration/int4c-lease-takeover.test.ts",
-      "--reporter=verbose",
+      ...vitestExecution.reporterArgs,
       ...(filter ? ["-t", filter] : []),
     ],
     {
@@ -56,10 +58,12 @@ try {
   process.stdout.write(result.stdout ?? "");
   process.stderr.write(result.stderr ?? "");
   assertMutationApplied("INT4C", mutation, output);
+  vitestExecution.assert(result.status);
   process.exitCode = result.status ?? 1;
 } finally {
   removeDatabase(reference);
   removeDatabase(harness);
+  vitestExecution.cleanup();
 }
 
 function startDatabase(name, database) {

--- a/scripts/ceremony/run-int4d-drills.mjs
+++ b/scripts/ceremony/run-int4d-drills.mjs
@@ -8,6 +8,7 @@ import {
   assertKnownMutation,
   assertMutationApplied,
 } from "./lib/int4-mutation-contract.mjs";
+import { prepareVitestExecution } from "./lib/int4-vitest-execution.mjs";
 
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
 const pin = "3355f4906864b0f0e0fe5fd5eb5220172e174206";
@@ -24,6 +25,7 @@ const validMutations = [
   "disable-size-gate",
 ];
 assertKnownMutation("INT4D", mutation, validMutations);
+const vitestExecution = prepareVitestExecution("INT4D");
 const scratch = mkdtempSync(path.join(tmpdir(), "int4d-runner-"));
 const suppliedCheckout = process.env.HARNESS_CHECKOUT?.trim();
 const harnessCheckout = suppliedCheckout || path.join(scratch, "agent-harness");
@@ -47,7 +49,7 @@ try {
       "vitest",
       "run",
       "test/integration/int4d-drill-matrix.test.ts",
-      "--reporter=verbose",
+      ...vitestExecution.reporterArgs,
       ...(filter ? ["-t", filter] : []),
     ],
     {
@@ -70,11 +72,13 @@ try {
   process.stdout.write(result.stdout ?? "");
   process.stderr.write(result.stderr ?? "");
   assertMutationApplied("INT4D", mutation, output);
+  vitestExecution.assert(result.status);
   process.exitCode = result.status ?? 1;
 } finally {
   removeDatabase(reference);
   removeDatabase(harness);
   rmSync(scratch, { recursive: true, force: true });
+  vitestExecution.cleanup();
 }
 
 function prepareHarnessCheckout() {

--- a/test/integration/int4c-d0-baseline.test.ts
+++ b/test/integration/int4c-d0-baseline.test.ts
@@ -127,8 +127,6 @@ RUN("INT-4c exact-main D0", () => {
       taskVersion: task.taskVersion,
       approvedTaskHash: task.approval.approvedTaskHash!,
       intendedRunId: runId,
-      holder: "d0-orphaned-holder",
-      leaseTtlMs: 30_000,
     }, deps());
 
     const heartbeats: DispatcherHeartbeat[] = [];
@@ -340,10 +338,6 @@ function dispatchDeps(
     dispatcherId: "d0-backpressure",
     leaseTtlSeconds: 30,
     isDispatchEnabled: () => true,
-    activePolicyIdentity: {
-      version: fixture.approval.policyVersion!,
-      hash: fixture.approval.policyHash!,
-    },
     isHalted: () => false,
     listDispatchable: () => listDispatchableAgentTasks(deps()),
     saveTask: (task) => putAgentTask(task, deps()),

--- a/test/integration/int4c-d0-baseline.test.ts
+++ b/test/integration/int4c-d0-baseline.test.ts
@@ -127,6 +127,8 @@ RUN("INT-4c exact-main D0", () => {
       taskVersion: task.taskVersion,
       approvedTaskHash: task.approval.approvedTaskHash!,
       intendedRunId: runId,
+      holder: "d0-orphaned-holder",
+      leaseTtlMs: 30_000,
     }, deps());
 
     const heartbeats: DispatcherHeartbeat[] = [];
@@ -338,6 +340,10 @@ function dispatchDeps(
     dispatcherId: "d0-backpressure",
     leaseTtlSeconds: 30,
     isDispatchEnabled: () => true,
+    activePolicyIdentity: {
+      version: fixture.approval.policyVersion!,
+      hash: fixture.approval.policyHash!,
+    },
     isHalted: () => false,
     listDispatchable: () => listDispatchableAgentTasks(deps()),
     saveTask: (task) => putAgentTask(task, deps()),

--- a/test/unit/int4-runner-execution-drill.test.ts
+++ b/test/unit/int4-runner-execution-drill.test.ts
@@ -1,0 +1,47 @@
+import { spawnSync } from "node:child_process";
+
+import { describe, expect, it } from "vitest";
+
+const SCRIPT = "scripts/ceremony/drill-int4-runner-execution.mjs";
+const SUITES = [
+  ["INT4B", 5],
+  ["INT4C", 6],
+  ["INT4C_D0", 3],
+  ["INT4D", 6],
+] as const;
+
+describe("INT-4 runner execution drill", () => {
+  it("makes broken environment coupling red and intact coupling green", () => {
+    const result = run([]);
+    expect(result.status, result.stderr).toBe(0);
+    for (const [suite, expected] of SUITES) {
+      expect(result.stdout).toContain(
+        `INT4_RUNNER_EXECUTION_COUPLING_RED suite=${suite} exit=1`,
+      );
+      expect(result.stdout).toContain(
+        `INT4_RUNNER_EXECUTION_GREEN suite=${suite} exit=0 executed=${expected}`,
+      );
+    }
+  }, 30_000);
+
+  it("fails for every runner when the execution guard is removed", () => {
+    const result = run(["--mutation", "remove-guard"]);
+    expect(result.status).not.toBe(0);
+    for (const [suite] of SUITES) {
+      expect(result.stdout).toContain(
+        `INT4_RUNNER_EXECUTION_MUTATION_APPLIED suite=${suite} name=remove-guard`,
+      );
+      expect(result.stderr).toContain(
+        `INT4_RUNNER_EXECUTION_DRILL_FAILED suite=${suite} `
+          + "expected=nonzero actual=0 reason=all_skipped_was_accepted",
+      );
+    }
+  }, 30_000);
+});
+
+function run(args: string[]) {
+  return spawnSync(process.execPath, [SCRIPT, ...args], {
+    cwd: process.cwd(),
+    encoding: "utf8",
+  });
+}

--- a/test/unit/int4-vitest-execution.test.ts
+++ b/test/unit/int4-vitest-execution.test.ts
@@ -1,0 +1,109 @@
+import {
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  assertVitestExecution,
+} from "../../scripts/ceremony/lib/int4-vitest-execution.mjs";
+
+describe("INT-4 Vitest execution accounting", () => {
+  const directories: string[] = [];
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    for (const directory of directories.splice(0)) {
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
+  it("records a successful, fully executed suite", () => {
+    const fixture = report({ passed: 6, failed: 0, skipped: 0, total: 6 });
+    const info = vi.spyOn(console, "info").mockImplementation(() => undefined);
+
+    expect(assertVitestExecution({
+      suite: "INT4C",
+      childStatus: 0,
+      ...fixture,
+    })).toEqual({ passed: 6, failed: 0, skipped: 0, executed: 6, total: 6 });
+    expect(readFileSync(path.join(fixture.evidenceDir, "executed-count.txt"), "utf8"))
+      .toBe("6\n");
+    expect(info).toHaveBeenCalledWith(
+      "INT4C_DRILLS_EXECUTED passed=6 skipped=0 failed=0 total=6",
+    );
+  });
+
+  it("refuses a successful Vitest process that skipped any test", () => {
+    const fixture = report({ passed: 0, failed: 0, skipped: 6, total: 6 });
+
+    expect(() => assertVitestExecution({
+      suite: "INT4C",
+      childStatus: 0,
+      ...fixture,
+    })).toThrow("INT4C_DRILLS_SKIPPED passed=0 skipped=6 total=6");
+  });
+
+  it("refuses a successful Vitest process that passed no test", () => {
+    const fixture = report({ passed: 0, failed: 0, skipped: 0, total: 0 });
+
+    expect(() => assertVitestExecution({
+      suite: "INT4D",
+      childStatus: 0,
+      ...fixture,
+    })).toThrow("INT4D_DRILLS_NOT_EXECUTED passed=0 skipped=0 total=0");
+  });
+
+  it("preserves a genuine Vitest failure and still records its accounting", () => {
+    const fixture = report({ passed: 4, failed: 1, skipped: 0, total: 5 });
+
+    expect(assertVitestExecution({
+      suite: "INT4B",
+      childStatus: 1,
+      ...fixture,
+    })).toEqual({ passed: 4, failed: 1, skipped: 0, executed: 5, total: 5 });
+    expect(readFileSync(path.join(fixture.evidenceDir, "executed-count.txt"), "utf8"))
+      .toBe("5\n");
+  });
+
+  it("does not replace a genuine child failure with a malformed-report error", () => {
+    const evidenceDir = directory();
+    const reportPath = path.join(evidenceDir, "vitest-report.json");
+    writeFileSync(reportPath, "not-json", "utf8");
+
+    expect(assertVitestExecution({
+      suite: "INT4B",
+      childStatus: 1,
+      reportPath,
+      evidenceDir,
+    })).toBeUndefined();
+  });
+
+  function report(counts: {
+    passed: number;
+    failed: number;
+    skipped: number;
+    total: number;
+  }) {
+    const evidenceDir = directory();
+    const reportPath = path.join(evidenceDir, "vitest-report.json");
+    writeFileSync(reportPath, JSON.stringify({
+      numPassedTests: counts.passed,
+      numFailedTests: counts.failed,
+      numPendingTests: counts.skipped,
+      numTotalTests: counts.total,
+    }), "utf8");
+    return { evidenceDir, reportPath };
+  }
+
+  function directory() {
+    const value = mkdtempSync(path.join(tmpdir(), "int4-vitest-test-"));
+    directories.push(value);
+    return value;
+  }
+});


### PR DESCRIPTION
## What changed

- add shared Vitest JSON accounting to the four INT-4 ceremony runners
  - refuse a successful child when any test skipped
  - refuse a successful child when zero tests passed
  - preserve genuine Vitest failures as their original non-zero result
  - write `executed-count.txt`, `execution-summary.json`, and the raw report to the configured evidence directory
- add a reproducible runner-level probe that breaks each producer-side environment coupling while driving the real Vitest reporter
- add parallel CI coverage for the three live mechanism suites: INT-4b, INT-4c, and INT-4d
- explicitly exclude INT-4c D0 from live CI because it is a completed pre-implementation baseline; preserve its local fail-loud runner guard and cite `docs/evidence/INT4C_D0_PARTIAL_2026-08-06.md` plus #790

The runners use the self-maintaining rule "zero skipped and at least one passed". CI additionally declares exact counts 5/6/6, following the existing INT-2 precedent: drill-count drift fails loudly instead of silently expiring.

Closes #787.

## Mechanism drill

Guard removed (deliberate mutation; meta-drill exit 1):

```text
INT4_RUNNER_EXECUTION_MUTATION_APPLIED suite=INT4B name=remove-guard
INT4_RUNNER_EXECUTION_DRILL_FAILED suite=INT4B expected=nonzero actual=0 reason=all_skipped_was_accepted
INT4_RUNNER_EXECUTION_MUTATION_APPLIED suite=INT4C name=remove-guard
INT4_RUNNER_EXECUTION_DRILL_FAILED suite=INT4C expected=nonzero actual=0 reason=all_skipped_was_accepted
INT4_RUNNER_EXECUTION_MUTATION_APPLIED suite=INT4C_D0 name=remove-guard
INT4_RUNNER_EXECUTION_DRILL_FAILED suite=INT4C_D0 expected=nonzero actual=0 reason=all_skipped_was_accepted
INT4_RUNNER_EXECUTION_MUTATION_APPLIED suite=INT4D name=remove-guard
INT4_RUNNER_EXECUTION_DRILL_FAILED suite=INT4D expected=nonzero actual=0 reason=all_skipped_was_accepted
```

Guard present, coupling broken red and intact green (exit 0):

```text
INT4_RUNNER_EXECUTION_COUPLING_RED suite=INT4B exit=1 reason=INT4B_DRILLS_SKIPPED passed=0 skipped=5 total=5
INT4_RUNNER_EXECUTION_GREEN suite=INT4B exit=0 executed=5
INT4_RUNNER_EXECUTION_COUPLING_RED suite=INT4C exit=1 reason=INT4C_DRILLS_SKIPPED passed=0 skipped=6 total=6
INT4_RUNNER_EXECUTION_GREEN suite=INT4C exit=0 executed=6
INT4_RUNNER_EXECUTION_COUPLING_RED suite=INT4C_D0 exit=1 reason=INT4C_D0_DRILLS_SKIPPED passed=0 skipped=3 total=3
INT4_RUNNER_EXECUTION_GREEN suite=INT4C_D0 exit=0 executed=3
INT4_RUNNER_EXECUTION_COUPLING_RED suite=INT4D exit=1 reason=INT4D_DRILLS_SKIPPED passed=0 skipped=6 total=6
INT4_RUNNER_EXECUTION_GREEN suite=INT4D exit=0 executed=6
```

Commands:

```text
node scripts/ceremony/drill-int4-runner-execution.mjs --mutation remove-guard
node scripts/ceremony/drill-int4-runner-execution.mjs
```

Both guards remain deliberately present: `skipped > 0` names partial execution, while `passed < 1` independently catches the all-skipped/empty case.

## Checks

Local:

- `npm run typecheck` — exit 0
- `npm test` — exit 0; 197 files passed, 6 skipped; 2,893 tests passed, 40 skipped
- `npm run build` — exit 0
- targeted guard tests — 11 passed

Passing CI matrix, [run 31252656833](https://github.com/depre-dev/averray-reference-agent/actions/runs/31252656833):

- INT-4b — 40s, 5/5 executed
- INT-4c — 52s, 6/6 executed
- INT-4d — 1m25s, 6/6 executed
- parallel wall-clock contribution — 1m25s
- aggregate runner time — 2m57s

The matrix finished before the existing Node gate (1m33s), so it did not become the measured PR critical path. Mutation runs remain out of the per-PR job; a periodic scheduled mechanism-proof workflow is their appropriate home because they multiply runtime.

## CI provisioning decisions

- `npm ci` has no lifecycle build. The matrix runs `npm run build`, producing both package and dispatcher `dist/` imports.
- only INT-4d receives the already-approved read-only `INT2_HARNESS_DEPLOY_KEY` and uv setup for the pinned private Harness checkout.
- no dispatcher workspace-root preparation is needed: these suites do not perform filesystem work under `/var/lib/harness-dispatcher/workspaces`.
- D0 remains unchanged from main and is not modernized into a misleading current-main version of a historical silence baseline.

## Issue evidence audit

- comment 2's claim that `ci.yml` had only two jobs and no INT-2 job was wrong; comment 3 correctly records the existing `int2-supervised-dispatch` job.
- comment 3's corrected uncovered count (26) and private-checkout/key requirement match current main.
- comment 3's build inventory was incomplete: INT-4c needs dispatcher output as well as `packages/averray-mcp/dist`; `npm run build` covers both.
- D0 was initially misclassified as a live CI candidate. The durable evidence and #790 establish it as a completed historical baseline, so its exclusion is explicit rather than silent.

## Affected surfaces

CI workflow and local ceremony runner validation only. No live drill assertions, dispatcher behavior, kernel pin, ledger wording, production configuration, or secrets changed.
