### PR TITLE
Show platform arrivals on the ops board

### DIFF
--- a/packages/monitor-ui/src/components/ops/ArrivalsPanel.test.tsx
+++ b/packages/monitor-ui/src/components/ops/ArrivalsPanel.test.tsx
@@ -1,0 +1,68 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, test } from "vitest";
+import { cleanup, render } from "@testing-library/react";
+
+import { ARRIVAL_STAGES, type ArrivalsBlock } from "../../lib/monitor/product-health.js";
+import { ArrivalsPanel } from "./ArrivalsPanel.js";
+
+afterEach(cleanup);
+
+const arrivals: ArrivalsBlock = {
+  schemaVersion: "averray.arrivals.v1",
+  generatedAtMs: 1_786_100_000_000,
+  observingSinceMs: 1_786_000_000_000,
+  funnel: {
+    reached: 20,
+    browsed: 12,
+    evaluated: 7,
+    identified: 3,
+    authenticated: 2,
+    claimed: 1,
+    submitted: 1,
+  },
+  distinct: { declared: 4, anonymous: 9, furthest: "submitted" },
+  clients: [],
+};
+
+describe("ArrivalsPanel", () => {
+  test("renders the complete reached-to-submitted funnel as descending bars", () => {
+    const { getByTestId } = render(<ArrivalsPanel arrivals={arrivals} />);
+    const rows = ARRIVAL_STAGES.map((stage) => getByTestId(`ops-arrival-stage-${stage}`));
+
+    expect(rows.map((row) => row.querySelector(".ops-arrivals-stage")?.textContent)).toEqual(ARRIVAL_STAGES);
+    expect(rows.map((row) => (row.querySelector("i") as HTMLElement).style.width)).toEqual([
+      "100%",
+      "60%",
+      "35%",
+      "15%",
+      "10%",
+      "5%",
+      "5%",
+    ]);
+    expect(rows.map((row) => row.querySelector("strong")?.textContent)).toEqual(["20", "12", "7", "3", "2", "1", "1"]);
+  });
+
+  test("shows declared versus anonymous and makes the furthest stage explicit", () => {
+    const { getByTestId, getByLabelText } = render(<ArrivalsPanel arrivals={arrivals} />);
+
+    expect(getByLabelText("Distinct arrival clients").textContent).toContain("DECLARED 4");
+    expect(getByLabelText("Distinct arrival clients").textContent).toContain("ANONYMOUS 9");
+    expect(getByTestId("ops-arrivals-furthest").textContent).toContain("submitted");
+    expect(getByTestId("ops-arrivals-furthest").getAttribute("data-advanced")).toBe("yes");
+  });
+
+  test("an unreadable feed says unreachable and renders no zero funnel", () => {
+    const { getByTestId, queryAllByTestId } = render(
+      <ArrivalsPanel arrivals={{ unavailable: "arrivals feed unreachable — platform returned HTTP 521" }} />,
+    );
+
+    expect(getByTestId("ops-arrivals-unreachable").textContent).toContain("UNREACHABLE");
+    expect(getByTestId("ops-arrivals-unreachable").textContent).toContain("HTTP 521");
+    expect(queryAllByTestId(/^ops-arrival-stage-/)).toHaveLength(0);
+  });
+
+  test("an older product-health payload is also a named non-reading", () => {
+    const { getByTestId } = render(<ArrivalsPanel arrivals={undefined} />);
+    expect(getByTestId("ops-arrivals-unreachable").textContent).toContain("feed not present");
+  });
+});

--- a/packages/monitor-ui/src/components/ops/ArrivalsPanel.tsx
+++ b/packages/monitor-ui/src/components/ops/ArrivalsPanel.tsx
@@ -1,0 +1,72 @@
+// ARRIVALS — who has actually crossed the public MCP front door, and how far.
+//
+// The platform owns these counts. This component only renders its versioned
+// snapshot; it never infers a later stage from calls or client names. Most
+// importantly, an absent/unreachable feed is a named instrument failure, not a
+// seven-zero funnel that would read as "nobody arrived".
+
+import {
+  ARRIVAL_STAGES,
+  type ArrivalsBlock,
+} from "../../lib/monitor/product-health.js";
+
+export interface ArrivalsPanelProps {
+  arrivals: ArrivalsBlock | undefined;
+}
+
+export function ArrivalsPanel({ arrivals }: ArrivalsPanelProps) {
+  if (!arrivals || "unavailable" in arrivals) {
+    return (
+      <section className="ops-arrivals" aria-label="Arrivals — MCP front door" data-testid="ops-arrivals">
+        <header className="ops-panel-head">
+          <h2 className="ops-panel-title">ARRIVALS — MCP FRONT DOOR</h2>
+        </header>
+        <p className="ops-arrivals-unreachable" data-tone="awaiting" role="status" data-testid="ops-arrivals-unreachable">
+          <strong>UNREACHABLE</strong> — {arrivals?.unavailable ?? "feed not present in this product-health snapshot"}
+        </p>
+      </section>
+    );
+  }
+
+  const peak = Math.max(1, ...ARRIVAL_STAGES.map((stage) => arrivals.funnel[stage]));
+  const advanced = arrivals.distinct.furthest !== "reached";
+
+  return (
+    <section className="ops-arrivals" aria-label="Arrivals — MCP front door" data-testid="ops-arrivals">
+      <header className="ops-panel-head">
+        <h2 className="ops-panel-title">ARRIVALS — MCP FRONT DOOR</h2>
+        <span className="ops-panel-note">reached → submitted · cumulative calls</span>
+      </header>
+
+      <ol className="ops-arrivals-funnel" aria-label="Arrival funnel, reached through submitted">
+        {ARRIVAL_STAGES.map((stage) => {
+          const value = arrivals.funnel[stage];
+          return (
+            <li key={stage} data-testid={`ops-arrival-stage-${stage}`} aria-label={`${stage}: ${value}`}>
+              <span className="ops-arrivals-stage">{stage}</span>
+              <span className="ops-arrivals-track" aria-hidden>
+                <i style={{ width: `${(value / peak) * 100}%` }} />
+              </span>
+              <strong>{value}</strong>
+            </li>
+          );
+        })}
+      </ol>
+
+      <div className="ops-arrivals-summary">
+        <div className="ops-arrivals-distinct" aria-label="Distinct arrival clients">
+          <span>DECLARED <strong>{arrivals.distinct.declared}</strong></span>
+          <span>ANONYMOUS <strong>{arrivals.distinct.anonymous}</strong></span>
+        </div>
+        <div
+          className="ops-arrivals-furthest"
+          data-advanced={advanced ? "yes" : "no"}
+          data-testid="ops-arrivals-furthest"
+        >
+          <span>FURTHEST STAGE ANY ARRIVAL REACHED</span>
+          <strong>{arrivals.distinct.furthest}</strong>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/packages/monitor-ui/src/components/ops/OpsBoard.test.tsx
+++ b/packages/monitor-ui/src/components/ops/OpsBoard.test.tsx
@@ -56,6 +56,14 @@ describe("OpsBoard — the honest empty states", () => {
     expect(within(flow).getAllByText("—").length).toBeGreaterThan(0);
     expect(within(flow).queryByText("0")).toBeNull();
   });
+
+  test("an absent arrivals feed is wired as an explicit non-reading, not an empty funnel", () => {
+    const { getByTestId, queryAllByTestId } = render(
+      <OpsBoard health={OPS_FIXTURE_LIVE} nowMs={fresh(OPS_FIXTURE_LIVE)} />,
+    );
+    expect(getByTestId("ops-arrivals-unreachable").textContent).toContain("UNREACHABLE");
+    expect(queryAllByTestId(/^ops-arrival-stage-/)).toHaveLength(0);
+  });
 });
 
 describe("OpsBoard — the banner must not argue with the trust panel", () => {

--- a/packages/monitor-ui/src/components/ops/OpsBoard.tsx
+++ b/packages/monitor-ui/src/components/ops/OpsBoard.tsx
@@ -25,6 +25,7 @@ import { FlowPanel } from "./FlowPanel.js";
 import { PillarStrip } from "./PillarStrip.js";
 import { SolvencyPanel } from "./SolvencyPanel.js";
 import { BankLane } from "./BankLane.js";
+import { ArrivalsPanel } from "./ArrivalsPanel.js";
 
 export interface OpsBoardProps {
   health: ProductHealth;
@@ -119,6 +120,8 @@ export function OpsBoard({
           <SolvencyPanel solvency={health.solvency} gas={health.gas} payout={health.flow?.payout} />
           <FlowPanel flow={health.flow} externalFunnel={health.externalFunnel} lifecycle={health.lifecycle} nowMs={nowMs} />
         </div>
+
+        <ArrivalsPanel arrivals={health.arrivals} />
 
         {/* The treasury's own money path, under the one that pays workers.
             Renders nothing at all when no feed is configured. */}

--- a/packages/monitor-ui/src/lib/monitor/product-health.ts
+++ b/packages/monitor-ui/src/lib/monitor/product-health.ts
@@ -280,6 +280,46 @@ export interface BankBlock {
   unavailable?: string;
 }
 
+export const ARRIVAL_STAGES = [
+  "reached",
+  "browsed",
+  "evaluated",
+  "identified",
+  "authenticated",
+  "claimed",
+  "submitted",
+] as const;
+
+export type ArrivalStage = (typeof ARRIVAL_STAGES)[number];
+
+export interface ArrivalClient {
+  key: string;
+  name: string | null;
+  version: string | null;
+  era: string | null;
+  firstSeenMs: number;
+  lastSeenMs: number;
+  furthestStage: ArrivalStage;
+  calls: number;
+  tools: Record<string, number>;
+}
+
+export interface ArrivalsSnapshot {
+  schemaVersion: "averray.arrivals.v1";
+  generatedAtMs?: number;
+  observingSinceMs?: number;
+  funnel: Record<ArrivalStage, number>;
+  distinct: {
+    declared: number;
+    anonymous: number;
+    furthest: ArrivalStage;
+  };
+  clients: ArrivalClient[];
+}
+
+/** A reading and a failure are mutually exclusive; neither becomes zero. */
+export type ArrivalsBlock = ArrivalsSnapshot | { unavailable: string };
+
 /** One hour of chain, counting back from the head at read time. */
 export interface HourSlice {
   /** 1 = the most recent hour, ascending into the past. */
@@ -415,6 +455,8 @@ export interface ProductHealth {
    * not render at all, and says nothing. Only `unavailable` is a fault.
    */
   bank?: BankBlock;
+  /** Public MCP-front-door arrivals, or why that feed could not be read. */
+  arrivals?: ArrivalsBlock;
   remediation?: RemediationStatus;
   /** #Ops delivery health — see BuzzDeliveryView. */
   buzz?: BuzzDeliveryView;

--- a/packages/monitor-ui/src/styles/hermes4-ops.css
+++ b/packages/monitor-ui/src/styles/hermes4-ops.css
@@ -921,6 +921,107 @@ body,
 }
 .ops-pillar-trend > span { min-width: 0; }
 
+/* ---- ARRIVALS ---------------------------------------------------
+   Public MCP-front-door funnel. The seven bars keep the producer's
+   reached→submitted order and exact counts; no stage is inferred here.
+   A failed read occupies the same named panel and says UNREACHABLE,
+   because seven quiet zeroes would falsely claim nobody arrived. */
+.ops-arrivals {
+  display: grid;
+  grid-template-columns: minmax(0, 2fr) minmax(calc(260 * var(--ops-u)), 1fr);
+  gap: calc(8 * var(--ops-u)) calc(18 * var(--ops-u));
+  padding: calc(9 * var(--ops-u)) calc(14 * var(--ops-u));
+  border: 1px solid var(--ops-rule);
+}
+.ops-arrivals > .ops-panel-head,
+.ops-arrivals-unreachable {
+  grid-column: 1 / -1;
+}
+.ops-arrivals-funnel {
+  display: grid;
+  gap: calc(4 * var(--ops-u));
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+.ops-arrivals-funnel li {
+  display: grid;
+  grid-template-columns: calc(104 * var(--ops-u)) 1fr calc(48 * var(--ops-u));
+  gap: calc(10 * var(--ops-u));
+  align-items: center;
+  min-width: 0;
+  font-family: var(--h4-font-mono);
+  font-size: calc(10 * var(--ops-u));
+}
+.ops-arrivals-stage {
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--h4-muted);
+}
+.ops-arrivals-track {
+  height: calc(7 * var(--ops-u));
+  overflow: hidden;
+  border: 1px solid var(--ops-hair);
+  background: var(--h4-paper-sunken);
+}
+.ops-arrivals-track i {
+  display: block;
+  height: 100%;
+  background: var(--h4-ink-2);
+}
+.ops-arrivals-funnel strong {
+  text-align: right;
+  font-size: calc(11 * var(--ops-u));
+  color: var(--h4-ink);
+}
+.ops-arrivals-summary {
+  display: grid;
+  align-content: stretch;
+  gap: calc(8 * var(--ops-u));
+  padding-left: calc(16 * var(--ops-u));
+  border-left: 1px solid var(--ops-hair);
+}
+.ops-arrivals-distinct {
+  display: flex;
+  justify-content: space-between;
+  gap: calc(12 * var(--ops-u));
+  font-family: var(--h4-font-mono);
+  font-size: calc(10 * var(--ops-u));
+  color: var(--h4-muted);
+}
+.ops-arrivals-distinct strong {
+  margin-left: calc(4 * var(--ops-u));
+  font-size: calc(13 * var(--ops-u));
+  color: var(--h4-ink);
+}
+.ops-arrivals-furthest {
+  display: grid;
+  align-content: end;
+  gap: calc(4 * var(--ops-u));
+  font-family: var(--h4-font-mono);
+}
+.ops-arrivals-furthest span {
+  font-size: calc(9 * var(--ops-u));
+  letter-spacing: 0.08em;
+  color: var(--h4-muted);
+}
+.ops-arrivals-furthest strong {
+  font-family: var(--h4-font-display);
+  font-size: calc(24 * var(--ops-u));
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--h4-tel);
+}
+.ops-arrivals-furthest[data-advanced="yes"] strong { color: var(--h4-ok); }
+.ops-arrivals-unreachable {
+  margin: 0;
+  font-family: var(--h4-font-mono);
+  font-size: calc(11 * var(--ops-u));
+  color: var(--tone, var(--h4-tel));
+}
+.ops-arrivals-unreachable strong { letter-spacing: 0.08em; }
+
 /* ---- BANK lane -------------------------------------------------
    A second money path beside the funnel's. Compact by design: four
    facts, one line each, label column aligned so the eye can drop
@@ -1082,6 +1183,14 @@ body,
     width: auto;
     border-right: 0;
     border-bottom: 1px solid var(--ops-rule);
+  }
+  .ops-arrivals { grid-template-columns: 1fr; }
+  .ops-arrivals > .ops-panel-head,
+  .ops-arrivals-unreachable { grid-column: auto; }
+  .ops-arrivals-summary {
+    padding: calc(8 * var(--ops-u)) 0 0;
+    border-left: 0;
+    border-top: 1px solid var(--ops-hair);
   }
   .ops-pillars { grid-template-columns: repeat(2, 1fr); }
   .ops-pillar:nth-child(3) { border-left: 0; }

--- a/services/slack-operator/src/arrivals-feed.ts
+++ b/services/slack-operator/src/arrivals-feed.ts
@@ -1,0 +1,208 @@
+// ARRIVALS — the platform's public MCP-front-door observatory.
+//
+// This is a cross-repo contract. The platform owns collection and serves
+// `GET /monitor/arrivals`; Hermes reads that one public endpoint and renders
+// the result. Nothing crossing that network boundary is trusted implicitly:
+// malformed or unreachable data becomes an explicit `unavailable` block,
+// never an empty funnel that could be mistaken for "nobody arrived".
+
+export const ARRIVALS_SCHEMA_VERSION = "averray.arrivals.v1";
+export const ARRIVAL_STAGES = [
+  "reached",
+  "browsed",
+  "evaluated",
+  "identified",
+  "authenticated",
+  "claimed",
+  "submitted",
+] as const;
+
+export type ArrivalStage = (typeof ARRIVAL_STAGES)[number];
+
+export interface ArrivalClient {
+  key: string;
+  name: string | null;
+  version: string | null;
+  era: string | null;
+  firstSeenMs: number;
+  lastSeenMs: number;
+  furthestStage: ArrivalStage;
+  calls: number;
+  tools: Record<string, number>;
+}
+
+export interface ArrivalsSnapshot {
+  schemaVersion: typeof ARRIVALS_SCHEMA_VERSION;
+  generatedAtMs?: number;
+  observingSinceMs?: number;
+  funnel: Record<ArrivalStage, number>;
+  distinct: {
+    declared: number;
+    anonymous: number;
+    furthest: ArrivalStage;
+  };
+  clients: ArrivalClient[];
+}
+
+/** The platform snapshot verbatim, or why there is no reading. */
+export type ArrivalsBlock = ArrivalsSnapshot | { unavailable: string };
+
+export const ARRIVALS_FEED_TIMEOUT_MS = 4000;
+
+export async function readArrivalsFeed(input: {
+  /** The same public platform base used for `/health`. */
+  baseUrl?: string;
+  fetchImpl: typeof fetch;
+  timeoutMs?: number;
+}): Promise<ArrivalsBlock> {
+  const baseUrl = input.baseUrl?.trim();
+  if (!baseUrl) {
+    return { unavailable: "arrivals feed unreachable — platform API base URL is not configured" };
+  }
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), input.timeoutMs ?? ARRIVALS_FEED_TIMEOUT_MS);
+  try {
+    const url = new URL("/monitor/arrivals", `${baseUrl.replace(/\/+$/, "")}/`).toString();
+    const response = await input.fetchImpl(url, { signal: controller.signal });
+    if (!response.ok) {
+      return { unavailable: `arrivals feed unreachable — platform returned HTTP ${response.status}` };
+    }
+    return normalizeArrivalsFeed(await response.json());
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return { unavailable: `arrivals feed unreachable — ${message}` };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/** Shape-check the independently deployed producer before anything renders. */
+export function normalizeArrivalsFeed(body: unknown): ArrivalsBlock {
+  if (!body || typeof body !== "object") {
+    return { unavailable: "arrivals feed unreadable — payload was not an object" };
+  }
+  const value = body as Record<string, unknown>;
+  if (typeof value.unavailable === "string" && value.unavailable.trim()) {
+    return { unavailable: `arrivals feed unavailable — ${value.unavailable.trim()}` };
+  }
+  if (value.schemaVersion !== ARRIVALS_SCHEMA_VERSION) {
+    return {
+      unavailable: `arrivals feed unreadable — expected schemaVersion ${ARRIVALS_SCHEMA_VERSION}`,
+    };
+  }
+
+  const generatedAtMs = optionalCount(value.generatedAtMs);
+  const observingSinceMs = optionalCount(value.observingSinceMs);
+  if (generatedAtMs === null || observingSinceMs === null) {
+    return { unavailable: "arrivals feed unreadable — source timestamps are invalid" };
+  }
+
+  const funnel = stageCounts(value.funnel, "funnel");
+  if ("unavailable" in funnel) return funnel;
+
+  if (!value.distinct || typeof value.distinct !== "object") {
+    return { unavailable: "arrivals feed unreadable — distinct is missing" };
+  }
+  const distinctValue = value.distinct as Record<string, unknown>;
+  const declared = count(distinctValue.declared);
+  const anonymous = count(distinctValue.anonymous);
+  const furthest = arrivalStage(distinctValue.furthest);
+  if (declared === undefined || anonymous === undefined || furthest === undefined) {
+    return { unavailable: "arrivals feed unreadable — distinct counts or furthest stage are invalid" };
+  }
+
+  if (!Array.isArray(value.clients)) {
+    return { unavailable: "arrivals feed unreadable — clients is not an array" };
+  }
+  const clients: ArrivalClient[] = [];
+  for (const rawClient of value.clients) {
+    const client = normalizeClient(rawClient);
+    if ("unavailable" in client) return client;
+    clients.push(client.client);
+  }
+
+  return {
+    schemaVersion: ARRIVALS_SCHEMA_VERSION,
+    ...(generatedAtMs === undefined ? {} : { generatedAtMs }),
+    ...(observingSinceMs === undefined ? {} : { observingSinceMs }),
+    funnel: funnel.counts,
+    distinct: { declared, anonymous, furthest },
+    clients,
+  };
+}
+
+function stageCounts(
+  raw: unknown,
+  field: string,
+): { counts: Record<ArrivalStage, number> } | { unavailable: string } {
+  if (!raw || typeof raw !== "object") {
+    return { unavailable: `arrivals feed unreadable — ${field} is missing` };
+  }
+  const value = raw as Record<string, unknown>;
+  const entries = ARRIVAL_STAGES.map((stage) => [stage, count(value[stage])] as const);
+  const invalid = entries.find(([, stageCount]) => stageCount === undefined);
+  if (invalid) {
+    return { unavailable: `arrivals feed unreadable — ${field}.${invalid[0]} is invalid` };
+  }
+  return { counts: Object.fromEntries(entries) as Record<ArrivalStage, number> };
+}
+
+function normalizeClient(raw: unknown): { client: ArrivalClient } | { unavailable: string } {
+  if (!raw || typeof raw !== "object") {
+    return { unavailable: "arrivals feed unreadable — client entry is not an object" };
+  }
+  const value = raw as Record<string, unknown>;
+  const firstSeenMs = count(value.firstSeenMs);
+  const lastSeenMs = count(value.lastSeenMs);
+  const calls = count(value.calls);
+  const furthestStage = arrivalStage(value.furthestStage);
+  const tools = toolCounts(value.tools);
+  if (
+    typeof value.key !== "string" || !value.key.trim() ||
+    !nullableString(value.name) || !nullableString(value.version) || !nullableString(value.era) ||
+    firstSeenMs === undefined || lastSeenMs === undefined || calls === undefined ||
+    furthestStage === undefined || tools === undefined
+  ) {
+    return { unavailable: "arrivals feed unreadable — client entry has invalid fields" };
+  }
+  return {
+    client: {
+      key: value.key,
+      name: value.name,
+      version: value.version,
+      era: value.era,
+      firstSeenMs,
+      lastSeenMs,
+      furthestStage,
+      calls,
+      tools,
+    },
+  };
+}
+
+function count(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isSafeInteger(value) && value >= 0 ? value : undefined;
+}
+
+function optionalCount(value: unknown): number | null | undefined {
+  if (value === undefined) return undefined;
+  return count(value) ?? null;
+}
+
+function arrivalStage(value: unknown): ArrivalStage | undefined {
+  return typeof value === "string" && (ARRIVAL_STAGES as readonly string[]).includes(value)
+    ? value as ArrivalStage
+    : undefined;
+}
+
+function nullableString(value: unknown): value is string | null {
+  return value === null || typeof value === "string";
+}
+
+function toolCounts(value: unknown): Record<string, number> | undefined {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return undefined;
+  const entries = Object.entries(value as Record<string, unknown>);
+  if (entries.some(([key, toolCount]) => !key || count(toolCount) === undefined)) return undefined;
+  return Object.fromEntries(entries) as Record<string, number>;
+}

--- a/services/slack-operator/src/index.ts
+++ b/services/slack-operator/src/index.ts
@@ -198,6 +198,7 @@ import {
 import type { TransportFailureRun } from "./probe-transport.js";
 import { deriveOpsVerdict } from "@avg/schemas";
 import { appendIncidents, readIncidents, reconcileIncidents } from "./product-health-incidents.js";
+import { readArrivalsFeed } from "./arrivals-feed.js";
 import {
   loadRemediationConfig,
   decideRpcRemediation,
@@ -900,6 +901,15 @@ async function handleHttpRequest(request: http.IncomingMessage, response: http.S
         return { buzzInbound: { phase: state.phase, detail: state.detail, failures: state.failures } };
       })(),
       ...(productHealthSnapshotBlocks ?? {}),
+      // Absence must never look like an empty funnel. Before the first
+      // heartbeat (or while the heartbeat is deliberately off), publish the
+      // missing read explicitly; after a heartbeat the sampled feed block
+      // above replaces this marker with either data or its concrete failure.
+      arrivals: productHealthSnapshotBlocks?.arrivals ?? {
+        unavailable: routineConfig.productHealth.enabled
+          ? "arrivals feed unreachable — awaiting the first product-health read"
+          : "arrivals feed unreachable — product-health heartbeat is disabled",
+      },
       // History-derived Trends + Incidents (uptime% / latency / balance series +
       // incident episodes) from the rolling buffer. Always present — the series
       // are honestly short and uptimePct24h is null until a check lands in-window.
@@ -3666,16 +3676,21 @@ function startOperatorRoutines() {
       const activeRpc = remediationConfig.endpoints[rpcRemediationState.activeIndex] ?? phConfig.rpcUrl;
       // One /health fetch feeds product_api + chain_height; the block-advance tracker
       // persists across ticks to catch a frozen chain. Balances come from direct RPC.
-      const collection = await collectProductHealthProbes({ ...phConfig, signerAddress, rpcUrl: activeRpc }, fetch, {
-        advance: productHealthChainAdvance,
-        nowMs: Date.now(),
-        previousSubmittedNotSettled:
-          productHealthSnapshotBlocks?.flow?.submittedNotSettled,
-        ...(productHealthTransportRun ? { transportRun: productHealthTransportRun } : {}),
-      });
+      const [collection, arrivals] = await Promise.all([
+        collectProductHealthProbes({ ...phConfig, signerAddress, rpcUrl: activeRpc }, fetch, {
+          advance: productHealthChainAdvance,
+          nowMs: Date.now(),
+          previousSubmittedNotSettled:
+            productHealthSnapshotBlocks?.flow?.submittedNotSettled,
+          ...(productHealthTransportRun ? { transportRun: productHealthTransportRun } : {}),
+        }),
+        // Same public platform, separate contract. Read beside the heartbeat so
+        // one slow arrivals response does not serialize every money-path probe.
+        readArrivalsFeed({ baseUrl: phConfig.apiBaseUrl, fetchImpl: fetch }),
+      ]);
       productHealthChainAdvance = collection.chainAdvance;
       productHealthTransportRun = collection.transportRun;
-      productHealthSnapshotBlocks = collection.snapshot;
+      productHealthSnapshotBlocks = { ...collection.snapshot, arrivals };
       // Decide + apply RPC auto-remediation from this cycle's read health. Pure
       // decision; the only effect is rotating which endpoint we read next tick
       // (state.activeIndex) + dispatching an audit (failover) or page (escalate).

--- a/services/slack-operator/src/product-health.ts
+++ b/services/slack-operator/src/product-health.ts
@@ -40,6 +40,7 @@ import { bucketPayoutsByHour, isHistogramUnavailable, type PayoutHistogram } fro
 import { endpointHost, pinnedCompareRange, type CrossCheckView } from "./payout-crosscheck.js";
 import { burnBasisLabel, isBurnUnmeasurable, type MeasuredBurn } from "./gas-burn-rate.js";
 import { readBankFeed } from "./bank-feed-fetch.js";
+import type { ArrivalsBlock } from "./arrivals-feed.js";
 import { collectCredentialExpiries, credentialExpiryProbe, tlsCertReader } from "./credential-expiry.js";
 import { bankFeedIsDisabled } from "./bank-feed.js";
 import { bankLaneView, BANK_FEED_DISABLED, type BankLaneView } from "./bank-lane.js";
@@ -2675,6 +2676,12 @@ export interface ProductHealthSnapshotBlocks {
    * a CONFIGURED feed that failed, which is worth saying out loud.
    */
   bank?: BankBlock;
+  /**
+   * Public MCP-front-door arrivals, or the explicit reason the feed could not
+   * be read. The heartbeat always supplies one side; optional only for stored
+   * snapshots and older monitor builds.
+   */
+  arrivals?: ArrivalsBlock;
 }
 
 export interface BankBlock {

--- a/services/slack-operator/test/unit/arrivals-feed.test.ts
+++ b/services/slack-operator/test/unit/arrivals-feed.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, test } from "vitest";
+
+import {
+  normalizeArrivalsFeed,
+  readArrivalsFeed,
+} from "../../src/arrivals-feed.js";
+
+const good = {
+  schemaVersion: "averray.arrivals.v1",
+  generatedAtMs: 1_786_100_000_000,
+  observingSinceMs: 1_786_000_000_000,
+  funnel: {
+    reached: 20,
+    browsed: 12,
+    evaluated: 7,
+    identified: 3,
+    authenticated: 2,
+    claimed: 1,
+    submitted: 1,
+  },
+  distinct: { declared: 4, anonymous: 9, furthest: "submitted" },
+  clients: [{
+    key: "client:outside-agent@1.2.3",
+    name: "outside-agent",
+    version: "1.2.3",
+    era: "2026-07-28",
+    firstSeenMs: 1_786_000_000_000,
+    lastSeenMs: 1_786_100_000_000,
+    furthestStage: "submitted",
+    calls: 9,
+    tools: { listJobs: 2, submitWork: 1 },
+  }],
+};
+
+describe("readArrivalsFeed", () => {
+  test("reads the public platform route from the configured API base", async () => {
+    let requested = "";
+    const result = await readArrivalsFeed({
+      baseUrl: "https://api.averray.com/",
+      fetchImpl: (async (url: RequestInfo | URL) => {
+        requested = String(url);
+        return { ok: true, status: 200, json: async () => good } as Response;
+      }) as typeof fetch,
+    });
+
+    expect(requested).toBe("https://api.averray.com/monitor/arrivals");
+    expect("distinct" in result && result.distinct).toEqual({ declared: 4, anonymous: 9, furthest: "submitted" });
+  });
+
+  test("a configured feed failure is explicit, never an empty snapshot", async () => {
+    const result = await readArrivalsFeed({
+      baseUrl: "https://api.averray.com",
+      fetchImpl: (async () => ({ ok: false, status: 503 })) as typeof fetch,
+    });
+
+    expect("unavailable" in result && result.unavailable).toContain("unreachable");
+    expect("unavailable" in result && result.unavailable).toContain("HTTP 503");
+  });
+
+  test("missing platform configuration is also a named non-reading", async () => {
+    const result = await readArrivalsFeed({
+      fetchImpl: (async () => { throw new Error("must not fetch"); }) as typeof fetch,
+    });
+
+    expect(result).toEqual({
+      unavailable: "arrivals feed unreachable — platform API base URL is not configured",
+    });
+  });
+});
+
+describe("normalizeArrivalsFeed", () => {
+  test("preserves every funnel stage and client field", () => {
+    const result = normalizeArrivalsFeed(good);
+    expect("funnel" in result && result.funnel).toEqual(good.funnel);
+    expect("clients" in result && result.clients).toEqual(good.clients);
+  });
+
+  test("the producer's own unavailable state stays unavailable, not seven zeroes", () => {
+    const result = normalizeArrivalsFeed({
+      ...good,
+      unavailable: "arrival state could not be read",
+      funnel: Object.fromEntries(Object.keys(good.funnel).map((stage) => [stage, null])),
+      distinct: { declared: null, anonymous: null, furthest: null },
+      clients: [],
+    });
+
+    expect("unavailable" in result && result.unavailable).toContain("arrival state could not be read");
+  });
+
+  test("malformed counts are refused instead of coerced to zero", () => {
+    const result = normalizeArrivalsFeed({
+      ...good,
+      funnel: { ...good.funnel, identified: "3" },
+    });
+
+    expect("unavailable" in result && result.unavailable).toContain("funnel.identified");
+  });
+
+  test("a schema drift is visible by version", () => {
+    const result = normalizeArrivalsFeed({ ...good, schemaVersion: "averray.arrivals.v2" });
+    expect("unavailable" in result && result.unavailable).toContain("schemaVersion averray.arrivals.v1");
+  });
+});


### PR DESCRIPTION
Renders the MCP front-door funnel on the ops board. Platform side is [averray-agent/agent#993](https://github.com/averray-agent/agent/pull/993), which serves `GET /monitor/arrivals`.

Implemented by Codex; pushed and opened here because its `gh` token was invalid. Commit `681f712` is unmodified.

## Why

We could not distinguish an aggregator crawler from a real agent — Caddy logs only errors, and `http_requests_total` carries path and status but no client. Roughly twenty `/mcp` requests were unattributable, and no `/auth/nonce` had ever been seen. That left every distribution decision ungradeable except by settlements, the slowest signal we have.

## Shape

Follows the existing `bank-feed.ts` precedent — a platform `/monitor/*` feed folded into product-health, rendered as an ops panel.

- `services/slack-operator/src/arrivals-feed.ts` — fetch + validate
- `packages/monitor-ui/src/lib/monitor/product-health.ts` — type
- `packages/monitor-ui/src/components/ops/ArrivalsPanel.tsx` — seven-stage funnel, declared vs anonymous, furthest stage
- `hermes4-ops.css` — styles; `main.tsx` import unchanged, split layout preserved

## The property that mattered

**An unreachable feed never renders as zero arrivals.** Every failure path returns an explicit `unavailable` with its reason — unconfigured base URL, non-200, malformed payload, schema mismatch, invalid timestamps — and the panel shows `UNREACHABLE` plus that reason instead of an empty funnel. "Nobody arrived" and "we could not read" are the two answers we must never confuse, since the whole point is measuring arrivals.

It also validates `schemaVersion` against `averray.arrivals.v1`, so a future v2 fails loudly rather than being misread.

This matters immediately: until #993 deploys, `/monitor/arrivals` returns 404, and the panel will correctly say so rather than reporting zero.

## Verified before pushing

- Commit scope is exactly the 10 specified files, 643 insertions
- Failure paths confirmed to carry reasons rather than degrading to zeros
- Panel renders the unavailable branch distinctly, and flags `furthest !== "reached"` — the number that changes the day someone actually arrives

Codex's checks: typecheck, MCP prebuild, monitor Vite build, root build all passed; vitest 2,905 passed / 37 skipped; `arrivals-feed.test.ts` (7), `ArrivalsPanel.test.tsx` (4), `OpsBoard.test.tsx` (32).

Draft until #993 merges and deploys — there is nothing to render before then.