### PR TITLE
Read the arrivals tile as outside interest, not all traffic

### DIFF
--- a/packages/monitor-ui/src/components/ops/ArrivalsPanel.test.tsx
+++ b/packages/monitor-ui/src/components/ops/ArrivalsPanel.test.tsx
@@ -2,53 +2,154 @@
 import { afterEach, describe, expect, test } from "vitest";
 import { cleanup, render } from "@testing-library/react";
 
-import { ARRIVAL_STAGES, type ArrivalsBlock } from "../../lib/monitor/product-health.js";
+import { ARRIVAL_STAGES, type ArrivalsSnapshot } from "../../lib/monitor/product-health.js";
 import { ArrivalsPanel } from "./ArrivalsPanel.js";
 
 afterEach(cleanup);
 
-const arrivals: ArrivalsBlock = {
+// Deliberately a funnel where the total and the external count disagree at
+// every stage, including one our own probes walked to the end and no outsider
+// ever entered. Any assertion below that passes on the total is a bug.
+const arrivals: ArrivalsSnapshot = {
   schemaVersion: "averray.arrivals.v1",
   generatedAtMs: 1_786_100_000_000,
   observingSinceMs: 1_786_000_000_000,
   funnel: {
+    reached: 28,
+    browsed: 16,
+    evaluated: 9,
+    identified: 4,
+    authenticated: 3,
+    claimed: 1,
+    submitted: 1,
+  },
+  funnelExternal: {
     reached: 20,
-    browsed: 12,
-    evaluated: 7,
-    identified: 3,
+    browsed: 10,
+    evaluated: 5,
+    identified: 2,
+    authenticated: 1,
+    claimed: 0,
+    submitted: 0,
+  },
+  funnelSelf: {
+    reached: 8,
+    browsed: 6,
+    evaluated: 4,
+    identified: 2,
     authenticated: 2,
     claimed: 1,
     submitted: 1,
   },
-  distinct: { declared: 4, anonymous: 9, furthest: "submitted" },
+  distinct: {
+    declared: 4,
+    anonymous: 9,
+    self: 2,
+    furthest: "submitted",
+    furthestExternal: "authenticated",
+  },
   clients: [],
 };
 
 describe("ArrivalsPanel", () => {
-  test("renders the complete reached-to-submitted funnel as descending bars", () => {
-    const { getByTestId } = render(<ArrivalsPanel arrivals={arrivals} />);
+  // The headline is what an outsider did. Our own probes reach the same door
+  // and were once added to these bars, which is how this panel came to say
+  // BROWSED 2 on a day exactly one outsider had browsed.
+  test("every funnel figure is the external count, never the total", () => {
+    const { getByTestId, queryByTestId } = render(<ArrivalsPanel arrivals={arrivals} />);
     const rows = ARRIVAL_STAGES.map((stage) => getByTestId(`ops-arrival-stage-${stage}`));
 
+    // Every call here is attributed, so there is nothing to disclaim.
+    expect(queryByTestId("ops-arrivals-unattributed")).toBeNull();
+
     expect(rows.map((row) => row.querySelector(".ops-arrivals-stage")?.textContent)).toEqual(ARRIVAL_STAGES);
+    expect(rows.map((row) => row.querySelector("strong")?.textContent)).toEqual(
+      ["20", "10", "5", "2", "1", "0", "0"],
+    );
+    // Bars scale on the external peak of 20, not the total peak of 28, so one
+    // busy canary cannot flatten a real outsider's bar.
     expect(rows.map((row) => (row.querySelector("i") as HTMLElement).style.width)).toEqual([
       "100%",
-      "60%",
-      "35%",
-      "15%",
+      "50%",
+      "25%",
       "10%",
       "5%",
-      "5%",
+      "0%",
+      "0%",
     ]);
-    expect(rows.map((row) => row.querySelector("strong")?.textContent)).toEqual(["20", "12", "7", "3", "2", "1", "1"]);
   });
 
-  test("shows declared versus anonymous and makes the furthest stage explicit", () => {
+  // Kept visible, not dropped: a probe that silently stopped running is its
+  // own kind of blindness. It is simply never part of the headline.
+  test("our own traffic is shown apart from the external figure", () => {
+    const { getByTestId } = render(<ArrivalsPanel arrivals={arrivals} />);
+
+    expect(ARRIVAL_STAGES.map((stage) => getByTestId(`ops-arrival-self-${stage}`).textContent)).toEqual(
+      ["+8", "+6", "+4", "+2", "+2", "+1", "+1"],
+    );
+    // A stage no outsider entered reads 0, with our own run still legible.
+    expect(getByTestId("ops-arrival-stage-submitted").textContent).toContain("0");
+    expect(getByTestId("ops-arrival-self-submitted").textContent).toBe("+1");
+  });
+
+  test("shows declared, anonymous and ours, and the furthest an OUTSIDER reached", () => {
     const { getByTestId, getByLabelText } = render(<ArrivalsPanel arrivals={arrivals} />);
 
     expect(getByLabelText("Distinct arrival clients").textContent).toContain("DECLARED 4");
     expect(getByLabelText("Distinct arrival clients").textContent).toContain("ANONYMOUS 9");
-    expect(getByTestId("ops-arrivals-furthest").textContent).toContain("submitted");
+    expect(getByLabelText("Distinct arrival clients").textContent).toContain("OURS 2");
+    // Our own probes submitted. The headline must not borrow their progress.
+    expect(getByTestId("ops-arrivals-furthest").textContent).toContain("authenticated");
+    expect(getByTestId("ops-arrivals-furthest").textContent).not.toContain("submitted");
     expect(getByTestId("ops-arrivals-furthest").getAttribute("data-advanced")).toBe("yes");
+  });
+
+  // The board went green on our own traffic before the split existed. With no
+  // outsider past the door, nothing here may look like progress.
+  test("a funnel only our own probes walked reads as no outside interest", () => {
+    const { getByTestId } = render(
+      <ArrivalsPanel
+        arrivals={{
+          ...arrivals,
+          funnel: {
+            reached: 9, browsed: 6, evaluated: 4, identified: 2, authenticated: 2, claimed: 1, submitted: 1,
+          },
+          funnelExternal: {
+            reached: 1, browsed: 0, evaluated: 0, identified: 0, authenticated: 0, claimed: 0, submitted: 0,
+          },
+          distinct: { declared: 2, anonymous: 0, self: 1, furthest: "submitted", furthestExternal: "reached" },
+        }}
+      />,
+    );
+
+    expect(getByTestId("ops-arrival-stage-browsed").querySelector("strong")?.textContent).toBe("0");
+    expect(getByTestId("ops-arrivals-furthest").textContent).toContain("reached");
+    expect(getByTestId("ops-arrivals-furthest").getAttribute("data-advanced")).toBe("no");
+  });
+
+  // What the platform serves for a while after the split ships: the totals
+  // survived the upgrade, their actor attribution did not, and the client
+  // table still remembers that an outsider browsed. Unexplained, the panel
+  // would show BROWSED 0 directly beside "furthest an outsider reached:
+  // browsed" and leave an operator to guess which one is lying.
+  test("pre-split history is named, not folded into either column", () => {
+    const zeroed = Object.fromEntries(ARRIVAL_STAGES.map((stage) => [stage, 0])) as typeof arrivals.funnel;
+    const { getByTestId } = render(
+      <ArrivalsPanel
+        arrivals={{
+          ...arrivals,
+          funnel: { ...zeroed, reached: 22, browsed: 2 },
+          funnelExternal: zeroed,
+          funnelSelf: zeroed,
+          distinct: { declared: 2, anonymous: 1, self: 1, furthest: "browsed", furthestExternal: "browsed" },
+        }}
+      />,
+    );
+
+    expect(getByTestId("ops-arrivals-unattributed").textContent).toContain("24 calls");
+    expect(getByTestId("ops-arrivals-unattributed").textContent).toContain("predate the");
+    expect(getByTestId("ops-arrival-stage-browsed").querySelector("strong")?.textContent).toBe("0");
+    expect(getByTestId("ops-arrivals-furthest").textContent).toContain("browsed");
   });
 
   test("an unreadable feed says unreachable and renders no zero funnel", () => {

--- a/packages/monitor-ui/src/components/ops/ArrivalsPanel.tsx
+++ b/packages/monitor-ui/src/components/ops/ArrivalsPanel.tsx
@@ -4,6 +4,12 @@
 // snapshot; it never infers a later stage from calls or client names. Most
 // importantly, an absent/unreachable feed is a named instrument failure, not a
 // seven-zero funnel that would read as "nobody arrived".
+//
+// Every headline here is the EXTERNAL count. Our own canaries, smokes and
+// adversarial probes reach the same door, and for a while this panel added
+// them to the same bars — it once read BROWSED 2 when one of the two was our
+// own roadmap probe. Ours are still shown, deliberately: knowing a probe ran
+// is useful. They are just never part of the number that reads as demand.
 
 import {
   ARRIVAL_STAGES,
@@ -28,26 +34,47 @@ export function ArrivalsPanel({ arrivals }: ArrivalsPanelProps) {
     );
   }
 
-  const peak = Math.max(1, ...ARRIVAL_STAGES.map((stage) => arrivals.funnel[stage]));
-  const advanced = arrivals.distinct.furthest !== "reached";
+  // Scaled on the external peak so the bars are a picture of outside interest.
+  // Scaling on the total would let one busy canary flatten every real bar.
+  const peak = Math.max(1, ...ARRIVAL_STAGES.map((stage) => arrivals.funnelExternal[stage]));
+  const advanced = arrivals.distinct.furthestExternal !== "reached";
+  // Calls the platform counted before it split the funnel. Their actor was
+  // never recorded and cannot be recovered, so they sit in neither half. They
+  // have to be named: the furthest-stage figures come from the client table,
+  // which DOES remember that history, so an operator can otherwise face a
+  // funnel reading 0 outsiders beside "an outsider reached browsed" with
+  // nothing on screen to reconcile them.
+  const unattributed = ARRIVAL_STAGES.reduce(
+    (total, stage) =>
+      total + (arrivals.funnel[stage] - arrivals.funnelExternal[stage] - arrivals.funnelSelf[stage]),
+    0,
+  );
 
   return (
     <section className="ops-arrivals" aria-label="Arrivals — MCP front door" data-testid="ops-arrivals">
       <header className="ops-panel-head">
         <h2 className="ops-panel-title">ARRIVALS — MCP FRONT DOOR</h2>
-        <span className="ops-panel-note">reached → submitted · cumulative calls</span>
+        <span className="ops-panel-note">reached → submitted · outsiders, with ours counted apart</span>
       </header>
 
       <ol className="ops-arrivals-funnel" aria-label="Arrival funnel, reached through submitted">
         {ARRIVAL_STAGES.map((stage) => {
-          const value = arrivals.funnel[stage];
+          const value = arrivals.funnelExternal[stage];
+          const ours = arrivals.funnelSelf[stage];
           return (
-            <li key={stage} data-testid={`ops-arrival-stage-${stage}`} aria-label={`${stage}: ${value}`}>
+            <li
+              key={stage}
+              data-testid={`ops-arrival-stage-${stage}`}
+              aria-label={`${stage}: ${value} external, ${ours} ours`}
+            >
               <span className="ops-arrivals-stage">{stage}</span>
               <span className="ops-arrivals-track" aria-hidden>
                 <i style={{ width: `${(value / peak) * 100}%` }} />
               </span>
               <strong>{value}</strong>
+              <span className="ops-arrivals-self" data-testid={`ops-arrival-self-${stage}`} aria-hidden>
+                {ours > 0 ? `+${ours}` : ""}
+              </span>
             </li>
           );
         })}
@@ -57,16 +84,32 @@ export function ArrivalsPanel({ arrivals }: ArrivalsPanelProps) {
         <div className="ops-arrivals-distinct" aria-label="Distinct arrival clients">
           <span>DECLARED <strong>{arrivals.distinct.declared}</strong></span>
           <span>ANONYMOUS <strong>{arrivals.distinct.anonymous}</strong></span>
+          <span>OURS <strong>{arrivals.distinct.self}</strong></span>
         </div>
         <div
           className="ops-arrivals-furthest"
           data-advanced={advanced ? "yes" : "no"}
           data-testid="ops-arrivals-furthest"
         >
-          <span>FURTHEST STAGE ANY ARRIVAL REACHED</span>
-          <strong>{arrivals.distinct.furthest}</strong>
+          {/* An OUTSIDER, not "any arrival" — our own probes walk the whole
+              funnel routinely, so the old wording turned a green board into a
+              statement about ourselves. */}
+          <span>FURTHEST STAGE AN OUTSIDER REACHED</span>
+          <strong>{arrivals.distinct.furthestExternal}</strong>
         </div>
       </div>
+
+      {unattributed > 0 ? (
+        <p
+          className="ops-arrivals-unattributed"
+          data-tone="awaiting"
+          data-testid="ops-arrivals-unattributed"
+        >
+          <strong>UNATTRIBUTED</strong> — {unattributed} call{unattributed === 1 ? "" : "s"} predate the
+          external/self split and belong to neither column. The stage counts above begin at the split;
+          the furthest stage does not, and may run ahead of them.
+        </p>
+      ) : null}
     </section>
   );
 }

--- a/packages/monitor-ui/src/lib/monitor/product-health.ts
+++ b/packages/monitor-ui/src/lib/monitor/product-health.ts
@@ -297,6 +297,8 @@ export interface ArrivalClient {
   name: string | null;
   version: string | null;
   era: string | null;
+  /** Declared as one of ours. Unmarked callers are external on purpose. */
+  self: boolean;
   firstSeenMs: number;
   lastSeenMs: number;
   furthestStage: ArrivalStage;
@@ -308,11 +310,21 @@ export interface ArrivalsSnapshot {
   schemaVersion: "averray.arrivals.v1";
   generatedAtMs?: number;
   observingSinceMs?: number;
+  /**
+   * Every call, our own canaries and probes included. Never a headline on its
+   * own: a self-marked probe read as an arrival manufactures demand evidence.
+   */
   funnel: Record<ArrivalStage, number>;
+  /** The subset outsiders drove — the only count that reads as demand. */
+  funnelExternal: Record<ArrivalStage, number>;
+  /** Our own probes, kept because confirming they ran is worth something. */
+  funnelSelf: Record<ArrivalStage, number>;
   distinct: {
     declared: number;
     anonymous: number;
+    self: number;
     furthest: ArrivalStage;
+    furthestExternal: ArrivalStage;
   };
   clients: ArrivalClient[];
 }

--- a/packages/monitor-ui/src/styles/hermes4-ops.css
+++ b/packages/monitor-ui/src/styles/hermes4-ops.css
@@ -946,7 +946,9 @@ body,
 }
 .ops-arrivals-funnel li {
   display: grid;
-  grid-template-columns: calc(104 * var(--ops-u)) 1fr calc(48 * var(--ops-u));
+  /* Fourth column is ours, counted apart. It holds its width even when empty
+     so the external figures stay on one line down the panel. */
+  grid-template-columns: calc(104 * var(--ops-u)) 1fr calc(48 * var(--ops-u)) calc(38 * var(--ops-u));
   gap: calc(10 * var(--ops-u));
   align-items: center;
   min-width: 0;
@@ -973,6 +975,13 @@ body,
   text-align: right;
   font-size: calc(11 * var(--ops-u));
   color: var(--h4-ink);
+}
+/* Ours. Muted and smaller than the external figure beside it, because the
+   entire point of the split is that this number is not evidence of demand. */
+.ops-arrivals-self {
+  text-align: right;
+  font-size: calc(9 * var(--ops-u));
+  color: var(--h4-muted);
 }
 .ops-arrivals-summary {
   display: grid;
@@ -1021,6 +1030,23 @@ body,
   color: var(--tone, var(--h4-tel));
 }
 .ops-arrivals-unreachable strong { letter-spacing: 0.08em; }
+/* Pre-split history: real calls whose actor was never recorded. Named rather
+   than folded into either column, because the furthest-stage figures come
+   from the client table and DO remember it — without this line the two read
+   as a contradiction. Full width, below both, and absent when the count is 0. */
+.ops-arrivals-unattributed {
+  grid-column: 1 / -1;
+  margin: 0;
+  padding-top: calc(6 * var(--ops-u));
+  border-top: 1px solid var(--ops-hair);
+  font-family: var(--h4-font-mono);
+  font-size: calc(9 * var(--ops-u));
+  color: var(--h4-muted);
+}
+.ops-arrivals-unattributed strong {
+  letter-spacing: 0.08em;
+  color: var(--tone, var(--h4-tel));
+}
 
 /* ---- BANK lane -------------------------------------------------
    A second money path beside the funnel's. Compact by design: four
@@ -1186,6 +1212,7 @@ body,
   }
   .ops-arrivals { grid-template-columns: 1fr; }
   .ops-arrivals > .ops-panel-head,
+  .ops-arrivals-unattributed,
   .ops-arrivals-unreachable { grid-column: auto; }
   .ops-arrivals-summary {
     padding: calc(8 * var(--ops-u)) 0 0;

--- a/services/slack-operator/src/arrivals-feed.ts
+++ b/services/slack-operator/src/arrivals-feed.ts
@@ -5,6 +5,13 @@
 // the result. Nothing crossing that network boundary is trusted implicitly:
 // malformed or unreachable data becomes an explicit `unavailable` block,
 // never an empty funnel that could be mistaken for "nobody arrived".
+//
+// `funnel` is every call the platform saw, our own canaries and probes
+// included. `funnelExternal` is the subset outsiders drove, and it is the only
+// one a headline may render — a self-marked probe counted as an arrival
+// manufactures demand evidence. Both are required: a platform that cannot
+// supply the split cannot answer the question this panel asks, so the block
+// becomes unavailable rather than falling back to the inflated total.
 
 export const ARRIVALS_SCHEMA_VERSION = "averray.arrivals.v1";
 export const ARRIVAL_STAGES = [
@@ -24,6 +31,8 @@ export interface ArrivalClient {
   name: string | null;
   version: string | null;
   era: string | null;
+  /** Declared as one of ours. Unmarked callers are external on purpose. */
+  self: boolean;
   firstSeenMs: number;
   lastSeenMs: number;
   furthestStage: ArrivalStage;
@@ -35,11 +44,18 @@ export interface ArrivalsSnapshot {
   schemaVersion: typeof ARRIVALS_SCHEMA_VERSION;
   generatedAtMs?: number;
   observingSinceMs?: number;
+  /** Every call, ours included. Never a headline on its own. */
   funnel: Record<ArrivalStage, number>;
+  /** The subset outsiders drove — the only count that reads as demand. */
+  funnelExternal: Record<ArrivalStage, number>;
+  /** Our own probes, kept because confirming they ran is worth something. */
+  funnelSelf: Record<ArrivalStage, number>;
   distinct: {
     declared: number;
     anonymous: number;
+    self: number;
     furthest: ArrivalStage;
+    furthestExternal: ArrivalStage;
   };
   clients: ArrivalClient[];
 }
@@ -100,6 +116,23 @@ export function normalizeArrivalsFeed(body: unknown): ArrivalsBlock {
 
   const funnel = stageCounts(value.funnel, "funnel");
   if ("unavailable" in funnel) return funnel;
+  const funnelExternal = stageCounts(value.funnelExternal, "funnelExternal");
+  if ("unavailable" in funnelExternal) return funnelExternal;
+  const funnelSelf = stageCounts(value.funnelSelf, "funnelSelf");
+  if ("unavailable" in funnelSelf) return funnelSelf;
+
+  // External and self are subsets of the total, so neither can exceed it and
+  // together they cannot either. A producer that says otherwise is describing
+  // a funnel we do not understand, and the safe reading of a funnel we do not
+  // understand is none at all.
+  const incoherent = ARRIVAL_STAGES.find(
+    (stage) => funnelExternal.counts[stage] + funnelSelf.counts[stage] > funnel.counts[stage],
+  );
+  if (incoherent) {
+    return {
+      unavailable: `arrivals feed unreadable — ${incoherent} external plus self exceeds the total`,
+    };
+  }
 
   if (!value.distinct || typeof value.distinct !== "object") {
     return { unavailable: "arrivals feed unreadable — distinct is missing" };
@@ -107,9 +140,14 @@ export function normalizeArrivalsFeed(body: unknown): ArrivalsBlock {
   const distinctValue = value.distinct as Record<string, unknown>;
   const declared = count(distinctValue.declared);
   const anonymous = count(distinctValue.anonymous);
+  const self = count(distinctValue.self);
   const furthest = arrivalStage(distinctValue.furthest);
-  if (declared === undefined || anonymous === undefined || furthest === undefined) {
-    return { unavailable: "arrivals feed unreadable — distinct counts or furthest stage are invalid" };
+  const furthestExternal = arrivalStage(distinctValue.furthestExternal);
+  if (
+    declared === undefined || anonymous === undefined || self === undefined ||
+    furthest === undefined || furthestExternal === undefined
+  ) {
+    return { unavailable: "arrivals feed unreadable — distinct counts or furthest stages are invalid" };
   }
 
   if (!Array.isArray(value.clients)) {
@@ -127,7 +165,9 @@ export function normalizeArrivalsFeed(body: unknown): ArrivalsBlock {
     ...(generatedAtMs === undefined ? {} : { generatedAtMs }),
     ...(observingSinceMs === undefined ? {} : { observingSinceMs }),
     funnel: funnel.counts,
-    distinct: { declared, anonymous, furthest },
+    funnelExternal: funnelExternal.counts,
+    funnelSelf: funnelSelf.counts,
+    distinct: { declared, anonymous, self, furthest, furthestExternal },
     clients,
   };
 }
@@ -161,6 +201,10 @@ function normalizeClient(raw: unknown): { client: ArrivalClient } | { unavailabl
   if (
     typeof value.key !== "string" || !value.key.trim() ||
     !nullableString(value.name) || !nullableString(value.version) || !nullableString(value.era) ||
+    // Not coerced: a missing mark is a producer we cannot read, whereas
+    // treating it as false would silently promote our own probe to an
+    // outsider. Absent is not the same as external here.
+    typeof value.self !== "boolean" ||
     firstSeenMs === undefined || lastSeenMs === undefined || calls === undefined ||
     furthestStage === undefined || tools === undefined
   ) {
@@ -172,6 +216,7 @@ function normalizeClient(raw: unknown): { client: ArrivalClient } | { unavailabl
       name: value.name,
       version: value.version,
       era: value.era,
+      self: value.self,
       firstSeenMs,
       lastSeenMs,
       furthestStage,

--- a/services/slack-operator/test/unit/arrivals-feed.test.ts
+++ b/services/slack-operator/test/unit/arrivals-feed.test.ts
@@ -18,12 +18,37 @@ const good = {
     claimed: 1,
     submitted: 1,
   },
-  distinct: { declared: 4, anonymous: 9, furthest: "submitted" },
+  funnelExternal: {
+    reached: 12,
+    browsed: 6,
+    evaluated: 3,
+    identified: 1,
+    authenticated: 0,
+    claimed: 0,
+    submitted: 0,
+  },
+  funnelSelf: {
+    reached: 8,
+    browsed: 6,
+    evaluated: 4,
+    identified: 2,
+    authenticated: 2,
+    claimed: 1,
+    submitted: 1,
+  },
+  distinct: {
+    declared: 4,
+    anonymous: 9,
+    self: 1,
+    furthest: "submitted",
+    furthestExternal: "identified",
+  },
   clients: [{
     key: "client:outside-agent@1.2.3",
     name: "outside-agent",
     version: "1.2.3",
     era: "2026-07-28",
+    self: false,
     firstSeenMs: 1_786_000_000_000,
     lastSeenMs: 1_786_100_000_000,
     furthestStage: "submitted",
@@ -44,7 +69,13 @@ describe("readArrivalsFeed", () => {
     });
 
     expect(requested).toBe("https://api.averray.com/monitor/arrivals");
-    expect("distinct" in result && result.distinct).toEqual({ declared: 4, anonymous: 9, furthest: "submitted" });
+    expect("distinct" in result && result.distinct).toEqual({
+      declared: 4,
+      anonymous: 9,
+      self: 1,
+      furthest: "submitted",
+      furthestExternal: "identified",
+    });
   });
 
   test("a configured feed failure is explicit, never an empty snapshot", async () => {
@@ -72,7 +103,41 @@ describe("normalizeArrivalsFeed", () => {
   test("preserves every funnel stage and client field", () => {
     const result = normalizeArrivalsFeed(good);
     expect("funnel" in result && result.funnel).toEqual(good.funnel);
+    expect("funnelExternal" in result && result.funnelExternal).toEqual(good.funnelExternal);
+    expect("funnelSelf" in result && result.funnelSelf).toEqual(good.funnelSelf);
     expect("clients" in result && result.clients).toEqual(good.clients);
+  });
+
+  // A producer too old to split the funnel cannot answer "did an OUTSIDER
+  // browse?". Reading `funnel` in its place would answer a different question
+  // with the same confident number, which is the defect this contract exists
+  // to close — so the whole block becomes a named non-reading instead.
+  test("a producer without the external split is a non-reading, never the total", () => {
+    const { funnelExternal, ...withoutSplit } = good;
+    const result = normalizeArrivalsFeed(withoutSplit);
+
+    expect("unavailable" in result && result.unavailable).toContain("funnelExternal is missing");
+    expect("funnel" in result).toBe(false);
+  });
+
+  test("a client whose self mark is missing is refused, not assumed external", () => {
+    const [client] = good.clients;
+    const { self, ...unmarked } = client;
+    const result = normalizeArrivalsFeed({ ...good, clients: [unmarked] });
+
+    expect("unavailable" in result && result.unavailable).toContain("client entry has invalid fields");
+  });
+
+  // External and self are subsets of the total. A producer claiming more
+  // outsiders than calls is describing a funnel we cannot interpret, and the
+  // safe reading of a funnel we cannot interpret is none at all.
+  test("a split that exceeds its own total is refused", () => {
+    const result = normalizeArrivalsFeed({
+      ...good,
+      funnelExternal: { ...good.funnelExternal, browsed: good.funnel.browsed + 1 },
+    });
+
+    expect("unavailable" in result && result.unavailable).toContain("browsed external plus self exceeds");
   });
 
   test("the producer's own unavailable state stays unavailable, not seven zeroes", () => {
@@ -80,7 +145,9 @@ describe("normalizeArrivalsFeed", () => {
       ...good,
       unavailable: "arrival state could not be read",
       funnel: Object.fromEntries(Object.keys(good.funnel).map((stage) => [stage, null])),
-      distinct: { declared: null, anonymous: null, furthest: null },
+      funnelExternal: Object.fromEntries(Object.keys(good.funnel).map((stage) => [stage, null])),
+      funnelSelf: Object.fromEntries(Object.keys(good.funnel).map((stage) => [stage, null])),
+      distinct: { declared: null, anonymous: null, self: null, furthest: null, furthestExternal: null },
       clients: [],
     });
 


### PR DESCRIPTION
Pairs with **averray-agent/agent#1019**, which adds `funnelExternal` / `funnelSelf` to the platform feed. **Deploy the platform first.**

The tile counted our own probes as arrivals. On 2026-08-10 it read **BROWSED 2** when one of the two was our own `averray-roadmap-probe`; only `sasame-audit@0.2` was an outsider.

## The board had never adopted the split at all

`arrivals-feed.ts` was dropping `distinct.self`, `distinct.furthestExternal`, and the per-client `self` flag on the floor — all of which the platform **already emitted**. So "FURTHEST STAGE ANY ARRIVAL REACHED" carried the same defect as the bars: our probes walk the whole funnel routinely, which turned a green board into a statement about ourselves.

Now:

- headline stage counts are `funnelExternal`
- bars scale on the **external** peak, so one busy canary cannot flatten every real bar
- ours shows as a muted `+N` beside each stage, and in an `OURS` figure — knowing a probe ran is useful, it just isn't demand
- the furthest-stage line reads **AN OUTSIDER** and uses `furthestExternal`

## The boundary fails toward silence, not toward flattery

`funnelExternal` is **required** at the normalizer. A producer that can't split falls to a named `unavailable` — never back to the total. A degraded tile is recoverable; a tile quietly reporting our own traffic as demand is not.

The normalizer also rejects a feed where external + self **exceeds** the total, since that describes a funnel we don't understand, while still allowing `<` for the pre-split remainder.

## A contradiction this surfaced in its own design

`distinct.furthestExternal` comes from the client table, which *does* remember pre-split history, while the new counters start at zero for it. After deploy the tile would have read `BROWSED 0` directly beside `AN OUTSIDER REACHED: browsed`, with nothing on screen to reconcile them.

The panel now renders an explicit `UNATTRIBUTED — N calls predate the external/self split` line when that remainder is non-zero, and nothing when it's zero. `sasame-audit@0.2` stays visible via the furthest-stage figure and the client list.

## Verification

`npm install && npx vitest run packages/monitor-ui/src/components/ops services/slack-operator/test/unit`

```
Test Files  18 passed (18)
     Tests  289 passed (289)
```

`npx tsc -b packages/monitor-ui services/slack-operator` clean.

## Surface

Hermes ops board only — `ArrivalsPanel` is imported and mounted solely in `OpsBoard.tsx`; no arrivals consumer exists in `app/`, `frontend/`, `site/`, or `marketing/`.

Worth naming though: `/monitor/arrivals` is world-readable by design (which is why the observatory salts IPs), so the inflated `funnel` was already public as JSON. "Not on any public page" holds for the rendering, not the data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)