### PR TITLE
feat(digest): carry the public record in the morning message

### DIFF
--- a/services/slack-operator/src/index.ts
+++ b/services/slack-operator/src/index.ts
@@ -157,6 +157,7 @@ import { publishNarration, readBuzzConfig } from "./buzz-client.js";
 import { startBuzzInbound } from "./buzz-inbound-start.js";
 import { decideProbeTransitions } from "./probe-transitions.js";
 import { buildMorningDigest, digestDue, digestFactStrings, readDigestSchedule } from "./morning-digest.js";
+import { readSocialSignal } from "./social-signal.js";
 import { composeConversationalDigest } from "./digest-voice.js";
 import { probeLabel } from "./ops-voice.js";
 import { describeBuzzDelivery, recordBuzzDelivery, type BuzzDeliveryState } from "./buzz-delivery.js";
@@ -3968,6 +3969,10 @@ function startOperatorRoutines() {
           verdictTone: digestVerdict.tone,
           probes: result.evaluation.probes,
           bankRequests: productHealthSnapshotBlocks?.bank?.lane?.requests ?? null,
+          // Read at compose time from the public record. Never throws: an
+          // unreachable endpoint returns a degraded line, so a transparency
+          // outage costs one sentence rather than the whole digest.
+          socialSignal: await readSocialSignal(),
         };
         // The plain digest is both the fallback and Hermes's source text; the
         // gate in digest-voice guarantees his prose carries every figure, so a

--- a/services/slack-operator/src/morning-digest.ts
+++ b/services/slack-operator/src/morning-digest.ts
@@ -173,6 +173,17 @@ export interface MorningDigestInput {
   probes: readonly DigestProbe[];
   /** The bank lane's server-decided requests line, when a lane exists at all. */
   bankRequests?: { text: string; tone: string } | null;
+  /**
+   * The public-record line from social-signal.ts, when configured. Decided
+   * there, composed here — like the bank line.
+   *
+   * Its tone is deliberately NOT counted toward "needs you now" or "worth a
+   * look": a post worth writing is not an operational finding, and a social
+   * reading that could not be taken says nothing about the product. Both would
+   * inflate the urgency count with something the operator cannot act on at 7am,
+   * which is how that count stops being believed.
+   */
+  socialSignal?: { text: string; tone: string } | null;
 }
 
 const DIGEST_LINE_PROBES: readonly { key: string; name: string }[] = [
@@ -198,6 +209,10 @@ export function digestFactStrings(input: MorningDigestInput): string[] {
     if (probe.status !== "ok") facts.push(probe.detail);
   }
   if (input.bankRequests) facts.push(input.bankRequests.text);
+  // Included for the same reason as the bank line, and one of its own: the
+  // degraded form ("could not read the public record") must survive a
+  // rephrasing, or the digest reads as complete when it was not.
+  if (input.socialSignal) facts.push(input.socialSignal.text);
   return facts;
 }
 
@@ -259,6 +274,7 @@ export function buildMorningDigest(input: MorningDigestInput): string {
     if (probe) lines.push(`${key}: ${probe.detail}`);
   }
   if (input.bankRequests) lines.push(`Bank: ${input.bankRequests.text}`);
+  if (input.socialSignal) lines.push(`Public record: ${input.socialSignal.text}`);
 
   if (attention.length > 0) {
     const redFirst = [...attention].sort(

--- a/services/slack-operator/src/social-signal.ts
+++ b/services/slack-operator/src/social-signal.ts
@@ -1,0 +1,167 @@
+// The morning digest's social line — one sentence of public record, daily.
+//
+// This reads the SAME public `/transparency` payload that averray.com/transparency
+// renders and that the signal sweep in the `agent` repo evaluates. It deliberately
+// does NOT re-implement that sweep.
+//
+// The division is: **this observes, CI decides.**
+//
+// The sweep owns the announcement decision — edge-triggered thresholds, the
+// truth-boundary veto, committed state saying what has already been said. That
+// lives in the `agent` repo beside the schema constant it depends on and the
+// tests that pin it. Porting the veto here would put two implementations of a
+// truth boundary in two repositories, and two implementations of a rule that
+// exists to stop false claims is exactly the rule you cannot afford to have
+// drift.
+//
+// This line makes no claim and publishes nothing. It reports a reading and how
+// fresh it is, so the operator sees the two numbers that matter every morning —
+// above all `composition24h.external`, because the day it stops being 0 is the
+// day the interesting thing happened.
+//
+// Truth boundary, in order of how badly each would mislead:
+//
+//  1. A failed or unreadable read NEVER shows figures. "0 external agents" and
+//     "we could not ask" must never render the same, because the first is a
+//     fact about the product and the second is a fact about our instruments.
+//  2. A stale field is labelled stale. The transparency service already decided
+//     it could not vouch for the reading; this line does not get to overrule it.
+//  3. The line never counts toward "needs you now". A post worth writing is not
+//     an operational incident, and inflating the urgency count with one is how
+//     the urgency count stops meaning anything.
+
+const TRANSPARENCY_PATH = "/transparency";
+const EXPECTED_SCHEMA_VERSION = "averray.transparency.v1";
+
+export interface SocialSignalLine {
+  text: string;
+  /** "ok" — a real reading. "degraded" — we could not look. Never counted as urgent. */
+  tone: "ok" | "degraded";
+}
+
+interface TransparencyField {
+  value: number | null;
+  status: string;
+}
+
+/** Read a dotted path, tolerating a missing branch rather than throwing. */
+function field(snapshot: unknown, path: string): TransparencyField {
+  const node = path
+    .split(".")
+    .reduce<unknown>(
+      (acc, key) =>
+        acc && typeof acc === "object" ? (acc as Record<string, unknown>)[key] : undefined,
+      snapshot,
+    );
+  if (!node || typeof node !== "object") return { value: null, status: "unknown" };
+  const record = node as Record<string, unknown>;
+  const raw = Number(record.value);
+  return {
+    value: Number.isFinite(raw) ? raw : null,
+    status: typeof record.status === "string" ? record.status : "unknown",
+  };
+}
+
+function plural(count: number, one: string, many: string): string {
+  return count === 1 ? one : many;
+}
+
+/**
+ * Compose the line from an already-fetched payload. Pure, so every rendering
+ * decision — especially the degraded ones — is testable without a network.
+ */
+export function buildSocialSignalLine(snapshot: unknown): SocialSignalLine {
+  if (!snapshot || typeof snapshot !== "object") {
+    return { text: "could not read the public record — no figures either way", tone: "degraded" };
+  }
+
+  const version = (snapshot as Record<string, unknown>).schemaVersion;
+  if (version !== EXPECTED_SCHEMA_VERSION) {
+    // Reading fields out of a payload whose shape we do not recognise is how a
+    // wrong number gets published with confidence.
+    return {
+      text: `public record is a shape we do not know (${String(version ?? "no version")}) — no figures either way`,
+      tone: "degraded",
+    };
+  }
+
+  const settled = field(snapshot, "flow.jobsSettled.allTime");
+  const external = field(snapshot, "flow.composition24h.external");
+
+  if (settled.status === "unknown" && external.status === "unknown") {
+    return { text: "public record answered but carried no figures", tone: "degraded" };
+  }
+
+  const parts: string[] = [];
+  parts.push(
+    settled.status === "unknown"
+      ? "settled jobs unreadable"
+      : `${settled.value} settled${settled.status === "fresh" ? "" : ` (${settled.status})`}`,
+  );
+
+  if (external.status === "unknown") {
+    parts.push("external agents unreadable");
+  } else {
+    const count = external.value ?? 0;
+    const suffix = external.status === "fresh" ? "" : ` (${external.status})`;
+    parts.push(
+      count === 0
+        ? `no external agents in 24h${suffix}`
+        : `${count} external ${plural(count, "agent", "agents")} in 24h${suffix}`,
+    );
+  }
+
+  const anyStale = [settled.status, external.status].some((s) => s !== "fresh");
+  const line = parts.join(", ");
+
+  // The one transition worth interrupting a morning for. Flagged, never
+  // announced — whether it is postable is the sweep's call, not this line's.
+  const worthSaying = (external.value ?? 0) >= 1 && external.status === "fresh";
+
+  return {
+    text: worthSaying ? `${line} — first outside activity, worth a post` : line,
+    tone: anyStale ? "degraded" : "ok",
+  };
+}
+
+/**
+ * Fetch and compose. Returns `null` when the feature is simply not configured —
+ * an absent line, the way the bank line is absent when there is no bank lane.
+ * That is distinct from `degraded`, which means we were meant to look and could
+ * not.
+ */
+export async function readSocialSignal({
+  env = process.env,
+  fetchImpl = globalThis.fetch,
+  timeoutMs = 5000,
+}: {
+  env?: NodeJS.ProcessEnv;
+  fetchImpl?: typeof globalThis.fetch;
+  timeoutMs?: number;
+} = {}): Promise<SocialSignalLine | null> {
+  const base = env.AVERRAY_API_BASE_URL;
+  if (!base) return null;
+
+  const url = `${base.replace(/\/+$/, "")}${TRANSPARENCY_PATH}`;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+
+  try {
+    const response = await fetchImpl(url, {
+      headers: { accept: "application/json" },
+      signal: controller.signal,
+    });
+    if (!response.ok) {
+      return {
+        text: `public record unreachable (HTTP ${response.status}) — no figures either way`,
+        tone: "degraded",
+      };
+    }
+    return buildSocialSignalLine(await response.json());
+  } catch (error) {
+    const reason = error instanceof Error ? error.message : String(error);
+    return { text: `public record unreachable (${reason}) — no figures either way`, tone: "degraded" };
+  } finally {
+    clearTimeout(timer);
+  }
+}

--- a/services/slack-operator/test/unit/morning-digest.test.ts
+++ b/services/slack-operator/test/unit/morning-digest.test.ts
@@ -129,6 +129,49 @@ describe("the message quotes; it does not opine", () => {
     expect(text).not.toContain("Bank:");
   });
 
+  test("the public-record line is quoted verbatim when supplied", () => {
+    const text = buildMorningDigest({
+      ...base,
+      socialSignal: { text: "142 settled, no external agents in 24h", tone: "ok" },
+    });
+    expect(text).toContain("Public record: 142 settled, no external agents in 24h");
+  });
+
+  test("no public-record reading, no line — same rule as the bank lane", () => {
+    const text = buildMorningDigest({ ...base, socialSignal: null });
+    expect(text).not.toContain("Public record:");
+  });
+
+  test("a degraded public-record line does NOT summon the operator", () => {
+    // A social reading we could not take says nothing about the product. If it
+    // counted toward the urgency tally, a transparency blip would read as an
+    // operational finding at 7am — and the tally stops being believed.
+    const text = buildMorningDigest({
+      ...base,
+      socialSignal: { text: "public record unreachable — no figures either way", tone: "degraded" },
+    });
+    expect(text).toContain("Public record: public record unreachable");
+    expect(text.endsWith("Nothing is waiting on you.")).toBe(true);
+    expect(text).not.toContain("needs you now");
+    expect(text).not.toContain("Worth a look");
+  });
+
+  test("even a red-toned public-record line never inflates the count", () => {
+    const text = buildMorningDigest({
+      ...base,
+      socialSignal: { text: "something loud", tone: "red" },
+    });
+    expect(text.endsWith("Nothing is waiting on you.")).toBe(true);
+  });
+
+  test("the public-record line is a must-survive fact for the rephraser", () => {
+    const facts = digestFactStrings({
+      ...base,
+      socialSignal: { text: "public record unreachable — no figures either way", tone: "degraded" },
+    });
+    expect(facts).toContain("public record unreachable — no figures either way");
+  });
+
   test("everything not-ok is quoted under 'Needs attention', red first — the hold may never have announced it", () => {
     const text = buildMorningDigest({
       ...base,

--- a/services/slack-operator/test/unit/social-signal.test.ts
+++ b/services/slack-operator/test/unit/social-signal.test.ts
@@ -1,0 +1,134 @@
+// The social line's contract: report a reading, never a claim, and never let
+// "we could not look" render as "there is nothing there".
+import { describe, expect, test } from "vitest";
+
+import { buildSocialSignalLine, readSocialSignal } from "../../src/social-signal.js";
+
+function snapshot({
+  settled = 142,
+  external = 0,
+  settledStatus = "fresh",
+  externalStatus = "fresh",
+  schemaVersion = "averray.transparency.v1",
+}: {
+  settled?: number;
+  external?: number;
+  settledStatus?: string;
+  externalStatus?: string;
+  schemaVersion?: string;
+} = {}) {
+  return {
+    schemaVersion,
+    flow: {
+      jobsSettled: { allTime: { value: settled, status: settledStatus } },
+      composition24h: { external: { value: external, status: externalStatus } },
+    },
+  };
+}
+
+describe("a real reading", () => {
+  test("reports both figures plainly", () => {
+    const line = buildSocialSignalLine(snapshot());
+
+    expect(line.tone).toBe("ok");
+    expect(line.text).toBe("142 settled, no external agents in 24h");
+  });
+
+  test("flags the first outside activity — the transition worth a morning", () => {
+    const line = buildSocialSignalLine(snapshot({ external: 1 }));
+
+    expect(line.text).toContain("1 external agent in 24h");
+    expect(line.text).toContain("worth a post");
+    expect(line.tone).toBe("ok");
+  });
+
+  test("pluralises more than one external agent", () => {
+    expect(buildSocialSignalLine(snapshot({ external: 3 })).text).toContain("3 external agents");
+  });
+});
+
+describe("a reading we cannot fully vouch for", () => {
+  test("a stale field is labelled, never shown as current", () => {
+    const line = buildSocialSignalLine(snapshot({ settledStatus: "stale" }));
+
+    expect(line.text).toContain("142 settled (stale)");
+    expect(line.tone).toBe("degraded");
+  });
+
+  test("a stale external count never earns the 'worth a post' flag", () => {
+    const line = buildSocialSignalLine(snapshot({ external: 2, externalStatus: "stale" }));
+
+    expect(line.text).not.toContain("worth a post");
+    expect(line.tone).toBe("degraded");
+  });
+});
+
+describe("the instruments failing must not look like a fact about the product", () => {
+  test("a payload of the wrong shape shows NO figures", () => {
+    const line = buildSocialSignalLine({ schemaVersion: "averray.transparency.v2" });
+
+    expect(line.tone).toBe("degraded");
+    expect(line.text).toContain("shape we do not know");
+    expect(line.text).not.toMatch(/\d+ settled/);
+  });
+
+  test("a useless body shows NO figures — never 'no external agents'", () => {
+    const line = buildSocialSignalLine({});
+
+    expect(line.tone).toBe("degraded");
+    expect(line.text).not.toContain("no external agents");
+  });
+
+  test("a right-shaped payload carrying no figures says exactly that", () => {
+    const line = buildSocialSignalLine({ schemaVersion: "averray.transparency.v1", flow: {} });
+
+    expect(line.tone).toBe("degraded");
+    expect(line.text).toBe("public record answered but carried no figures");
+  });
+
+  test("an empty reading and a zero reading never render the same", () => {
+    const broken = buildSocialSignalLine({});
+    const real = buildSocialSignalLine(snapshot({ external: 0 }));
+
+    expect(broken.text).not.toBe(real.text);
+    expect(broken.tone).not.toBe(real.tone);
+  });
+});
+
+describe("fetching", () => {
+  const env = { AVERRAY_API_BASE_URL: "https://api.example.test" } as NodeJS.ProcessEnv;
+
+  test("unconfigured means absent, not degraded — the feature is simply off", async () => {
+    expect(await readSocialSignal({ env: {} as NodeJS.ProcessEnv })).toBeNull();
+  });
+
+  test("a non-200 degrades with the status and no figures", async () => {
+    const fetchImpl = (async () => ({ ok: false, status: 503 })) as unknown as typeof fetch;
+    const line = await readSocialSignal({ env, fetchImpl });
+
+    expect(line?.tone).toBe("degraded");
+    expect(line?.text).toContain("503");
+  });
+
+  test("a thrown fetch degrades instead of taking the digest down with it", async () => {
+    const fetchImpl = (async () => {
+      throw new Error("ECONNREFUSED");
+    }) as unknown as typeof fetch;
+    const line = await readSocialSignal({ env, fetchImpl });
+
+    expect(line?.tone).toBe("degraded");
+    expect(line?.text).toContain("ECONNREFUSED");
+  });
+
+  test("a trailing slash on the base URL does not produce a double slash", async () => {
+    let seen = "";
+    const fetchImpl = (async (url: string) => {
+      seen = url;
+      return { ok: true, status: 200, json: async () => snapshot() };
+    }) as unknown as typeof fetch;
+
+    await readSocialSignal({ env: { AVERRAY_API_BASE_URL: "https://api.example.test/" }, fetchImpl });
+
+    expect(seen).toBe("https://api.example.test/transparency");
+  });
+});


### PR DESCRIPTION
One line in the morning digest, daily:

```
Public record: 143 settled, no external agents in 24h
```

The number that matters right now is `composition24h.external`. The morning it stops being `0` is the morning something happened, and this puts it in front of you with no approval machinery built yet.

## The digest observes; CI decides

This does **not** re-implement the signal sweep landing in `averray-agent/agent#1023`. That sweep owns the announcement decision — edge-triggered thresholds, the truth-boundary veto, committed state recording what has already been said — and it lives beside the transparency schema constant it depends on.

Porting the veto here would put **two implementations of a truth boundary in two repositories**, and a rule whose entire job is stopping false claims is precisely the one that must not drift. This line publishes nothing and claims nothing, so it needs no veto: it reports a reading and how fresh it is.

## Shape

Follows the `bankRequests` precedent exactly — decided elsewhere, merely composed by the digest, absent when unconfigured. `morning-digest.ts` keeps its rule that it composes and never computes.

`readSocialSignal()` returns `null` when `AVERRAY_API_BASE_URL` is unset (the feature is simply off) and a `degraded` line when it was meant to look and could not. Those are different states and they render differently.

## Three rules, each pinned by a test

1. **A failed read never shows figures.** "no external agents" and "we could not ask" must never render the same — the first is a fact about the product, the second about our instruments. There is an explicit test asserting the two strings differ.
2. **A stale field is labelled**, and a stale external count never earns the "worth a post" flag.
3. **The line never counts toward "needs you now."** A post worth writing is not an operational incident, and a transparency blip is not either. Inflating the urgency tally with either is how that tally stops being believed — so its tone is deliberately not wired into `needsNow`/`worthALook`, and a test pins that even a `red` tone leaves the closing line at *"Nothing is waiting on you."*

It **is** included in `digestFactStrings`, so the degraded form survives a `digest-voice` rephrasing — otherwise the digest could read as complete when it was not.

## Verified

- Against production `api.averray.com`: `143 settled, no external agents in 24h`
- 13 new tests in `social-signal.test.ts`, 5 added to `morning-digest.test.ts`
- `services/slack-operator/test/unit`: **202 passed**
- `npm run typecheck`: clean

## Note for anyone picking up the worktree

It has no `node_modules`. Symlinking the main checkout's works for tests, but `.gitignore` has `node_modules/` — a trailing-slash pattern matches directories, **not symlinks** — so the link is committable as an absolute path. Prefer a real `npm install`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)