### PR TITLE
feat(digest): carry the draft queue into the morning message

### DIFF
--- a/services/slack-operator/src/github-pr-state.ts
+++ b/services/slack-operator/src/github-pr-state.ts
@@ -1036,7 +1036,14 @@ function normalize(value: string | undefined): string {
   return String(value ?? "").trim().toLowerCase().replace(/[-\s]+/g, "_");
 }
 
-function resolveGithubTokenForRepo(repo: string, env: NodeJS.ProcessEnv): string | undefined {
+/**
+ * Which token reads which repo, in one place.
+ *
+ * Exported so cross-repo readers — the social queue reads `averray-agent/agent`
+ * from here — share this resolution instead of growing a second one. "Which
+ * token for which owner" is exactly the rule that drifts once it exists twice.
+ */
+export function resolveGithubTokenForRepo(repo: string, env: NodeJS.ProcessEnv): string | undefined {
   const [owner, name] = repo.split("/");
   if (!owner || !name) return env.GITHUB_TOKEN?.trim() || undefined;
   const repoToken = parseTokenMap(env.GITHUB_REPO_TOKENS).get(`${owner}/${name}`);

--- a/services/slack-operator/src/index.ts
+++ b/services/slack-operator/src/index.ts
@@ -158,6 +158,7 @@ import { startBuzzInbound } from "./buzz-inbound-start.js";
 import { decideProbeTransitions } from "./probe-transitions.js";
 import { buildMorningDigest, digestDue, digestFactStrings, readDigestSchedule } from "./morning-digest.js";
 import { readSocialSignal } from "./social-signal.js";
+import { buildSocialQueueLine, readSocialQueue } from "./social-queue.js";
 import { composeConversationalDigest } from "./digest-voice.js";
 import { probeLabel } from "./ops-voice.js";
 import { describeBuzzDelivery, recordBuzzDelivery, type BuzzDeliveryState } from "./buzz-delivery.js";
@@ -3971,6 +3972,11 @@ function startOperatorRoutines() {
             ? { payout: productHealthSnapshotBlocks.flow.payout }
             : {}),
         });
+        const readQueuedDraftsLine = async () => {
+          const queue = await readSocialQueue();
+          const line = buildSocialQueueLine(queue);
+          return line ? { ...line, count: queue.drafts.length } : null;
+        };
         const digestInput = {
           localDate: digestCheck.localDate,
           localTime: digestCheck.localTime,
@@ -3988,6 +3994,10 @@ function startOperatorRoutines() {
           // unreachable endpoint returns a degraded line, so a transparency
           // outage costs one sentence rather than the whole digest.
           socialSignal: await readSocialSignal(),
+          // Drafts the sweep queued overnight. Never throws: an unreachable
+          // GitHub yields a "could not be read" line, so a queue outage costs
+          // one sentence rather than the digest.
+          socialQueue: await readQueuedDraftsLine(),
         };
         // The plain digest is both the fallback and Hermes's source text; the
         // gate in digest-voice guarantees his prose carries every figure, so a

--- a/services/slack-operator/src/morning-digest.ts
+++ b/services/slack-operator/src/morning-digest.ts
@@ -184,6 +184,20 @@ export interface MorningDigestInput {
    * which is how that count stops being believed.
    */
   socialSignal?: { text: string; tone: string } | null;
+  /**
+   * Drafts the sweep queued overnight, from social-queue.ts. A to-do list, not
+   * a health reading.
+   *
+   * Like the public-record line, its tone never enters the operational tally —
+   * a post worth writing is not an incident, and inflating "needs you now" with
+   * one is how that count stops being believed.
+   *
+   * Unlike that line, it DOES bear on the closing sentence. Listing three
+   * waiting drafts and then signing off "Nothing is waiting on you" is exactly
+   * the self-contradiction the one-verdict rule forbids — the same shape
+   * truth-boundary review caught in #755. See the closing block below.
+   */
+  socialQueue?: { text: string; tone: string; count: number } | null;
 }
 
 const DIGEST_LINE_PROBES: readonly { key: string; name: string }[] = [
@@ -213,6 +227,9 @@ export function digestFactStrings(input: MorningDigestInput): string[] {
   // degraded form ("could not read the public record") must survive a
   // rephrasing, or the digest reads as complete when it was not.
   if (input.socialSignal) facts.push(input.socialSignal.text);
+  // The unreadable form especially must survive a rephrasing: losing it would
+  // make the digest read as complete while a queued post sat invisible.
+  if (input.socialQueue) facts.push(input.socialQueue.text);
   return facts;
 }
 
@@ -275,6 +292,7 @@ export function buildMorningDigest(input: MorningDigestInput): string {
   }
   if (input.bankRequests) lines.push(`Bank: ${input.bankRequests.text}`);
   if (input.socialSignal) lines.push(`Public record: ${input.socialSignal.text}`);
+  if (input.socialQueue) lines.push(`Drafts: ${input.socialQueue.text}`);
 
   if (attention.length > 0) {
     const redFirst = [...attention].sort(
@@ -316,7 +334,21 @@ export function buildMorningDigest(input: MorningDigestInput): string {
         : "Worth a look when you're at the desk — and read the verdict line above.",
     );
   } else if (verdictCalm) {
-    lines.push("Nothing is waiting on you.");
+    // The only branch that claims nothing is outstanding, so the only one the
+    // draft queue can contradict. Operationally calm and "nothing waiting" are
+    // not the same sentence once a queue exists.
+    if (input.socialQueue?.tone === "degraded") {
+      lines.push("Nothing operational is waiting on you — but the draft queue could not be read.");
+    } else if ((input.socialQueue?.count ?? 0) > 0) {
+      const count = input.socialQueue?.count ?? 0;
+      lines.push(
+        count === 1
+          ? "Nothing operational is waiting on you — one draft to write when you have a minute."
+          : `Nothing operational is waiting on you — ${count} drafts to write when you have a minute.`,
+      );
+    } else {
+      lines.push("Nothing is waiting on you.");
+    }
   } else {
     lines.push("The probes are green, but the verdict line above is the one to read.");
   }

--- a/services/slack-operator/src/social-queue.ts
+++ b/services/slack-operator/src/social-queue.ts
@@ -1,0 +1,146 @@
+// The social draft queue, read for the morning digest.
+//
+// The sweep in the `agent` repo opens one issue per fired signal, labelled
+// `social-draft`. This reads the open ones so a signal that fired overnight
+// arrives in Buzz rather than sitting in a workflow artifact nobody opens.
+//
+// ## What this is and is not
+//
+// It is a **to-do list**, not a health probe. Nothing here says anything about
+// whether the product is working, and it must never be able to make the digest
+// look alarmed. See the closing-line rule in morning-digest.ts.
+//
+// It is also **not** the approval mechanism. Closing the issue is the decision,
+// taken by a human, in GitHub. Nothing in this file writes.
+//
+// ## Truth boundary
+//
+// The same rule as every other reader here: **"nothing queued" and "we could
+// not ask" must never render the same.** The first means there is nothing to
+// write today; the second means the queue is invisible and a signal may be
+// waiting unseen. An unreachable GitHub is reported as unreadable, never as an
+// empty queue.
+
+import { resolveGithubTokenForRepo } from "./github-pr-state.js";
+
+const GITHUB_API = "https://api.github.com";
+export const QUEUE_LABEL = "social-draft";
+export const DEFAULT_QUEUE_REPO = "averray-agent/agent";
+const MAX_SHOWN = 5;
+
+export interface QueuedDraft {
+  number: number;
+  title: string;
+  url: string;
+}
+
+export interface SocialQueue {
+  /** "live" — a real reading. "unreadable" — we could not ask. "off" — not configured. */
+  state: "live" | "unreadable" | "off";
+  drafts: QueuedDraft[];
+  /** Present when state is not "live"; why the queue could not be read. */
+  problem?: string;
+}
+
+/**
+ * Open `social-draft` issues, oldest first.
+ *
+ * Oldest first because the queue is a backlog: the thing that has been waiting
+ * longest is the thing most likely to go stale.
+ */
+export async function readSocialQueue({
+  env = process.env,
+  fetchImpl = globalThis.fetch,
+  timeoutMs = 5000,
+}: {
+  env?: NodeJS.ProcessEnv;
+  fetchImpl?: typeof globalThis.fetch;
+  timeoutMs?: number;
+} = {}): Promise<SocialQueue> {
+  const repo = (env.SOCIAL_QUEUE_REPO ?? DEFAULT_QUEUE_REPO).trim();
+  if (!repo || env.SOCIAL_QUEUE_ENABLED === "0") {
+    return { state: "off", drafts: [], problem: "social queue not enabled" };
+  }
+
+  const token = resolveGithubTokenForRepo(repo, env);
+  if (!token) {
+    // Not configured is not the same as empty, and it is not the same as
+    // broken. Say which.
+    return { state: "off", drafts: [], problem: `no GitHub token resolves for ${repo}` };
+  }
+
+  const url = `${GITHUB_API}/repos/${repo}/issues?labels=${QUEUE_LABEL}&state=open&sort=created&direction=asc&per_page=20`;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+
+  try {
+    const response = await fetchImpl(url, {
+      headers: {
+        accept: "application/vnd.github+json",
+        authorization: `Bearer ${token}`,
+        "x-github-api-version": "2022-11-28",
+      },
+      signal: controller.signal,
+    });
+
+    if (!response.ok) {
+      return { state: "unreadable", drafts: [], problem: `HTTP ${response.status}` };
+    }
+
+    const body = await response.json();
+    if (!Array.isArray(body)) {
+      return { state: "unreadable", drafts: [], problem: "response was not a list" };
+    }
+
+    const drafts = body
+      // Pull requests come back on this endpoint too and are never queue items.
+      .filter((issue: { pull_request?: unknown }) => !issue.pull_request)
+      .map((issue: { number: number; title?: string; html_url?: string }) => ({
+        number: issue.number,
+        title: String(issue.title ?? "").trim(),
+        url: String(issue.html_url ?? ""),
+      }));
+
+    return { state: "live", drafts };
+  } catch (error) {
+    const reason = error instanceof Error ? error.message : String(error);
+    return { state: "unreadable", drafts: [], problem: reason };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/**
+ * The digest line, or `null` when there is genuinely nothing to say.
+ *
+ * A live-but-empty queue produces NO line: on most mornings there is nothing
+ * waiting, and printing "0 drafts waiting" every day trains the reader to skip
+ * the section that will one day matter.
+ *
+ * An unreadable queue always produces a line, because silence would be
+ * indistinguishable from an empty one.
+ */
+export function buildSocialQueueLine(queue: SocialQueue): { text: string; tone: string } | null {
+  if (queue.state === "off") return null;
+
+  if (queue.state === "unreadable") {
+    return {
+      text: `draft queue unreadable (${queue.problem ?? "unknown"}) — a post may be waiting unseen`,
+      tone: "degraded",
+    };
+  }
+
+  if (queue.drafts.length === 0) return null;
+
+  const shown = queue.drafts.slice(0, MAX_SHOWN);
+  const listed = shown.map((draft) => `#${draft.number} ${draft.title}`).join("; ");
+  const more = queue.drafts.length - shown.length;
+
+  return {
+    text:
+      queue.drafts.length === 1
+        ? `1 draft waiting — ${listed}`
+        : `${queue.drafts.length} drafts waiting — ${listed}${more > 0 ? `; +${more} more` : ""}`,
+    tone: "ok",
+  };
+}

--- a/services/slack-operator/test/unit/morning-digest.test.ts
+++ b/services/slack-operator/test/unit/morning-digest.test.ts
@@ -164,6 +164,78 @@ describe("the message quotes; it does not opine", () => {
     expect(text.endsWith("Nothing is waiting on you.")).toBe(true);
   });
 
+  test("queued drafts are listed", () => {
+    const text = buildMorningDigest({
+      ...base,
+      socialQueue: { text: "2 drafts waiting — #4 a; #5 b", tone: "ok", count: 2 },
+    });
+    expect(text).toContain("Drafts: 2 drafts waiting — #4 a; #5 b");
+  });
+
+  test("an empty queue contributes NO line and the sign-off stays flat", () => {
+    const text = buildMorningDigest({ ...base, socialQueue: null });
+    expect(text).not.toContain("Drafts:");
+    expect(text.endsWith("Nothing is waiting on you.")).toBe(true);
+  });
+
+  test("the sign-off never says nothing is waiting while drafts are listed", () => {
+    // Listing three waiting drafts and then signing off "Nothing is waiting on
+    // you" is the same self-contradiction #755 caught between the closing line
+    // and the verdict.
+    const text = buildMorningDigest({
+      ...base,
+      socialQueue: { text: "3 drafts waiting — #4 a; #5 b; #6 c", tone: "ok", count: 3 },
+    });
+    expect(text).not.toContain("Nothing is waiting on you.");
+    expect(text.endsWith("Nothing operational is waiting on you — 3 drafts to write when you have a minute.")).toBe(true);
+  });
+
+  test("one draft reads as one in the sign-off", () => {
+    const text = buildMorningDigest({
+      ...base,
+      socialQueue: { text: "1 draft waiting — #4 a", tone: "ok", count: 1 },
+    });
+    expect(text.endsWith("Nothing operational is waiting on you — one draft to write when you have a minute.")).toBe(true);
+  });
+
+  test("an unreadable queue is admitted in the sign-off, not smoothed over", () => {
+    const text = buildMorningDigest({
+      ...base,
+      socialQueue: { text: "draft queue unreadable (HTTP 502) — a post may be waiting unseen", tone: "degraded", count: 0 },
+    });
+    expect(text).not.toContain("Nothing is waiting on you.");
+    expect(text.endsWith("Nothing operational is waiting on you — but the draft queue could not be read.")).toBe(true);
+  });
+
+  test("drafts never inflate the operational tally", () => {
+    // A post worth writing is not an incident. If it counted, a quiet morning
+    // with three queued drafts would read as three items needing attention.
+    const text = buildMorningDigest({
+      ...base,
+      socialQueue: { text: "3 drafts waiting", tone: "ok", count: 3 },
+    });
+    expect(text).not.toContain("items need you now");
+    expect(text).not.toContain("Worth a look");
+  });
+
+  test("a real incident still outranks the draft queue in the sign-off", () => {
+    const text = buildMorningDigest({
+      ...base,
+      probes: [...probes, { name: "money_path", status: "red", detail: "settlement stalled" }],
+      socialQueue: { text: "3 drafts waiting", tone: "ok", count: 3 },
+    });
+    expect(text).toMatch(/needs? you now/);
+    expect(text).not.toContain("drafts to write");
+  });
+
+  test("the queue line is a must-survive fact for the rephraser", () => {
+    const facts = digestFactStrings({
+      ...base,
+      socialQueue: { text: "draft queue unreadable (HTTP 502) — a post may be waiting unseen", tone: "degraded", count: 0 },
+    });
+    expect(facts).toContain("draft queue unreadable (HTTP 502) — a post may be waiting unseen");
+  });
+
   test("the public-record line is a must-survive fact for the rephraser", () => {
     const facts = digestFactStrings({
       ...base,

--- a/services/slack-operator/test/unit/social-queue.test.ts
+++ b/services/slack-operator/test/unit/social-queue.test.ts
@@ -1,0 +1,130 @@
+// The draft queue's contract: a backlog you can act on, never a health reading,
+// and "we could not ask" never rendered as "there is nothing waiting".
+import { describe, expect, test } from "vitest";
+
+import {
+  DEFAULT_QUEUE_REPO,
+  QUEUE_LABEL,
+  buildSocialQueueLine,
+  readSocialQueue,
+} from "../../src/social-queue.js";
+
+const ENV = { GITHUB_TOKEN: "t" } as NodeJS.ProcessEnv;
+
+function issue(number: number, title: string, extra: Record<string, unknown> = {}) {
+  return {
+    number,
+    title,
+    html_url: `https://github.com/averray-agent/agent/issues/${number}`,
+    ...extra,
+  };
+}
+
+function respond(body: unknown, ok = true, status = 200) {
+  return (async () => ({ ok, status, json: async () => body })) as unknown as typeof fetch;
+}
+
+describe("reading the queue", () => {
+  test("open drafts come back oldest first, from the sweep's repo", async () => {
+    let seen = "";
+    const fetchImpl = (async (url: string) => {
+      seen = url;
+      return { ok: true, status: 200, json: async () => [issue(4, "passed 500 settled jobs")] };
+    }) as unknown as typeof fetch;
+
+    const queue = await readSocialQueue({ env: ENV, fetchImpl });
+
+    expect(queue.state).toBe("live");
+    expect(queue.drafts).toEqual([
+      { number: 4, title: "passed 500 settled jobs", url: "https://github.com/averray-agent/agent/issues/4" },
+    ]);
+    expect(seen).toContain(DEFAULT_QUEUE_REPO);
+    expect(seen).toContain(`labels=${QUEUE_LABEL}`);
+    expect(seen).toContain("state=open");
+    expect(seen).toContain("direction=asc");
+  });
+
+  test("pull requests on the issues endpoint are never queue items", async () => {
+    const fetchImpl = respond([issue(9, "a PR", { pull_request: { url: "p" } })]);
+
+    expect((await readSocialQueue({ env: ENV, fetchImpl })).drafts).toEqual([]);
+  });
+
+  test("no token means off — not empty, and not broken", async () => {
+    const queue = await readSocialQueue({ env: {} as NodeJS.ProcessEnv, fetchImpl: respond([]) });
+
+    expect(queue.state).toBe("off");
+    expect(queue.problem).toContain("no GitHub token");
+  });
+
+  test("a non-200 is unreadable, never an empty queue", async () => {
+    const queue = await readSocialQueue({ env: ENV, fetchImpl: respond([], false, 502) });
+
+    expect(queue.state).toBe("unreadable");
+    expect(queue.problem).toContain("502");
+  });
+
+  test("a thrown fetch is unreadable rather than taking the digest down", async () => {
+    const fetchImpl = (async () => {
+      throw new Error("ETIMEDOUT");
+    }) as unknown as typeof fetch;
+
+    const queue = await readSocialQueue({ env: ENV, fetchImpl });
+
+    expect(queue.state).toBe("unreadable");
+    expect(queue.problem).toContain("ETIMEDOUT");
+  });
+
+  test("a non-list body is unreadable rather than read as nothing queued", async () => {
+    const queue = await readSocialQueue({ env: ENV, fetchImpl: respond({}) });
+
+    expect(queue.state).toBe("unreadable");
+  });
+});
+
+describe("the line", () => {
+  test("a live but empty queue produces NO line — most mornings there is nothing", () => {
+    // Printing "0 drafts waiting" daily trains the reader to skip the section
+    // that will one day matter.
+    expect(buildSocialQueueLine({ state: "live", drafts: [] })).toBeNull();
+  });
+
+  test("an off queue produces no line at all", () => {
+    expect(buildSocialQueueLine({ state: "off", drafts: [] })).toBeNull();
+  });
+
+  test("an UNREADABLE queue always produces a line — silence would look empty", () => {
+    const line = buildSocialQueueLine({ state: "unreadable", drafts: [], problem: "HTTP 502" });
+
+    expect(line?.tone).toBe("degraded");
+    expect(line?.text).toContain("may be waiting unseen");
+  });
+
+  test("one draft reads as one, not as a count", () => {
+    const line = buildSocialQueueLine({
+      state: "live",
+      drafts: [{ number: 4, title: "passed 500 settled jobs", url: "u" }],
+    });
+
+    expect(line?.text).toContain("1 draft waiting");
+    expect(line?.text).toContain("#4 passed 500 settled jobs");
+    expect(line?.tone).toBe("ok");
+  });
+
+  test("a long queue lists the first few and counts the rest", () => {
+    const drafts = Array.from({ length: 8 }, (_, i) => ({ number: i + 1, title: `t${i + 1}`, url: "u" }));
+
+    const line = buildSocialQueueLine({ state: "live", drafts });
+
+    expect(line?.text).toContain("8 drafts waiting");
+    expect(line?.text).toContain("+3 more");
+  });
+
+  test("an empty queue and an unreadable one never render the same", () => {
+    const empty = buildSocialQueueLine({ state: "live", drafts: [] });
+    const broken = buildSocialQueueLine({ state: "unreadable", drafts: [], problem: "x" });
+
+    expect(empty).toBeNull();
+    expect(broken).not.toBeNull();
+  });
+});


### PR DESCRIPTION
The sweep in `averray-agent/agent` now opens one `social-draft` issue per fired signal ([agent#1033](https://github.com/averray-agent/agent/pull/1033)). Until something reads them, a signal that fired overnight sits in a workflow artifact nobody opens.

This closes the loop: open drafts appear in the morning Buzz digest.

```
Drafts: 2 drafts waiting — #4 Averray mainnet has passed 500 settled jobs; #5 Merged: …
…
Nothing operational is waiting on you — 2 drafts to write when you have a minute.
```

## A to-do list, not a health reading

Nothing here says anything about whether the product is working, and **its tone never enters the operational tally**. A post worth writing is not an incident, and inflating "needs you now" with one is how that count stops being believed.

Two tests pin this: a queued draft produces neither `needs you now` nor `Worth a look`, and a genuinely red probe still outranks the queue in the sign-off.

## …but it does bear on the sign-off

Listing three waiting drafts and then signing off *"Nothing is waiting on you"* is the same self-contradiction truth-boundary review caught in **#755** between the closing line and the verdict.

So the **calm branch only** — the one branch that claims nothing is outstanding — now distinguishes operational calm from an empty desk:

| Situation | Sign-off |
|---|---|
| Nothing anywhere | `Nothing is waiting on you.` |
| 3 drafts queued | `Nothing operational is waiting on you — 3 drafts to write when you have a minute.` |
| Queue unreadable | `Nothing operational is waiting on you — but the draft queue could not be read.` |
| A red probe | unchanged — the incident wins |

## Truth boundary

Same rules as the rest of this surface:

- An unreachable GitHub is **unreadable**, never an empty queue — and the sign-off admits it rather than smoothing over it.
- `off` (not configured) stays distinct from `unreadable` (configured, could not ask).
- A live-but-empty queue prints **no line at all**. "0 drafts waiting" every morning trains the reader to skip the section that will one day matter.
- The queue line is a must-survive fact for `digest-voice`, so the unreadable form cannot be lost to a rephrasing.

## One shared helper

`resolveGithubTokenForRepo` is **exported** from `github-pr-state.ts` rather than reimplemented. "Which token for which owner" is exactly the rule that drifts once it exists twice.

## Verified

- Against the real queue in `averray-agent/agent`: `state: live`, 0 drafts, no line — correct
- `services/slack-operator/test/unit`: **232 passed**
- `npm run typecheck`: clean

## Worktree note

Same footgun as last time: the worktree has no `node_modules`, and `.gitignore` uses `node_modules/` — a trailing-slash pattern matches directories, **not symlinks** — so a convenience symlink is committable as an absolute path. Removed before committing; prefer a real `npm install`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)