### PR TITLE
fix(digest): arm the draft queue, so a missing token cannot hide a draft

### DIFF
--- a/ops/compose.yml
+++ b/ops/compose.yml
@@ -479,6 +479,13 @@ services:
       BUZZ_MORNING_DIGEST: ${BUZZ_MORNING_DIGEST:-}
       BUZZ_DIGEST_TIME: ${BUZZ_DIGEST_TIME:-08:00}
       BUZZ_DIGEST_TZ: ${BUZZ_DIGEST_TZ:-Europe/Zurich}
+      # The social draft queue carried in that digest. Off by default, armed
+      # deliberately. Once armed, a missing token reports as UNREADABLE rather
+      # than off: the queue lives under a different GitHub owner
+      # (averray-agent) than this repo, so GITHUB_OWNER_TOKENS must carry an
+      # entry for it or a waiting draft would be invisible.
+      SOCIAL_QUEUE_ENABLED: ${SOCIAL_QUEUE_ENABLED:-}
+      SOCIAL_QUEUE_REPO: ${SOCIAL_QUEUE_REPO:-averray-agent/agent}
       # Buzz INBOUND — answering questions in #Ops. Default OFF, and separate
       # from the four above on purpose: publishing narration is safe, while
       # listening hands an LLM turn to whatever is typed in the channel.

--- a/services/slack-operator/src/social-queue.ts
+++ b/services/slack-operator/src/social-queue.ts
@@ -57,16 +57,34 @@ export async function readSocialQueue({
   fetchImpl?: typeof globalThis.fetch;
   timeoutMs?: number;
 } = {}): Promise<SocialQueue> {
+  // Armed deliberately, like the digest itself — and for the same reason. Off
+  // by default means an unconfigured deployment stays quiet instead of
+  // complaining about a feature nobody switched on.
+  const flag = (env.SOCIAL_QUEUE_ENABLED ?? "").trim().toLowerCase();
+  if (!["1", "true", "yes", "on"].includes(flag)) {
+    return { state: "off", drafts: [], problem: "SOCIAL_QUEUE_ENABLED is not set" };
+  }
+
   const repo = (env.SOCIAL_QUEUE_REPO ?? DEFAULT_QUEUE_REPO).trim();
-  if (!repo || env.SOCIAL_QUEUE_ENABLED === "0") {
-    return { state: "off", drafts: [], problem: "social queue not enabled" };
+  if (!repo) {
+    return { state: "unreadable", drafts: [], problem: "SOCIAL_QUEUE_REPO is empty" };
   }
 
   const token = resolveGithubTokenForRepo(repo, env);
   if (!token) {
-    // Not configured is not the same as empty, and it is not the same as
-    // broken. Say which.
-    return { state: "off", drafts: [], problem: `no GitHub token resolves for ${repo}` };
+    // Once armed, a missing token is a BROKEN queue, not an absent one.
+    //
+    // This matters more than it looks: the queue lives in a different GitHub
+    // owner (`averray-agent`) from this repo (`depre-dev`), so the plain
+    // GITHUB_TOKEN may not reach it and GITHUB_OWNER_TOKENS must carry an entry.
+    // Reporting that as "off" would print no line at all, and a missing token
+    // would be indistinguishable from an empty queue — a draft could sit unseen
+    // for weeks while every morning said nothing was waiting.
+    return {
+      state: "unreadable",
+      drafts: [],
+      problem: `no GitHub token resolves for ${repo} — check GITHUB_OWNER_TOKENS`,
+    };
   }
 
   const url = `${GITHUB_API}/repos/${repo}/issues?labels=${QUEUE_LABEL}&state=open&sort=created&direction=asc&per_page=20`;

--- a/services/slack-operator/test/unit/social-queue.test.ts
+++ b/services/slack-operator/test/unit/social-queue.test.ts
@@ -9,7 +9,7 @@ import {
   readSocialQueue,
 } from "../../src/social-queue.js";
 
-const ENV = { GITHUB_TOKEN: "t" } as NodeJS.ProcessEnv;
+const ENV = { SOCIAL_QUEUE_ENABLED: "1", GITHUB_TOKEN: "t" } as NodeJS.ProcessEnv;
 
 function issue(number: number, title: string, extra: Record<string, unknown> = {}) {
   return {
@@ -50,11 +50,47 @@ describe("reading the queue", () => {
     expect((await readSocialQueue({ env: ENV, fetchImpl })).drafts).toEqual([]);
   });
 
-  test("no token means off — not empty, and not broken", async () => {
+  test("unarmed is off — an unconfigured deployment stays quiet", async () => {
     const queue = await readSocialQueue({ env: {} as NodeJS.ProcessEnv, fetchImpl: respond([]) });
 
     expect(queue.state).toBe("off");
-    expect(queue.problem).toContain("no GitHub token");
+    expect(queue.problem).toContain("SOCIAL_QUEUE_ENABLED");
+  });
+
+  test("ARMED but untokened is UNREADABLE, never off", async () => {
+    // The queue lives under a different GitHub owner than this repo, so the
+    // plain GITHUB_TOKEN may not reach it. Reporting that as "off" prints no
+    // line, and a missing token becomes indistinguishable from an empty queue —
+    // a draft could sit unseen for weeks while every morning said nothing was
+    // waiting.
+    const queue = await readSocialQueue({
+      env: { SOCIAL_QUEUE_ENABLED: "1" } as NodeJS.ProcessEnv,
+      fetchImpl: respond([]),
+    });
+
+    expect(queue.state).toBe("unreadable");
+    expect(queue.problem).toContain("GITHUB_OWNER_TOKENS");
+  });
+
+  test("an armed queue with no token still produces a visible line", () => {
+    const line = buildSocialQueueLine({
+      state: "unreadable",
+      drafts: [],
+      problem: "no GitHub token resolves for averray-agent/agent — check GITHUB_OWNER_TOKENS",
+    });
+
+    expect(line).not.toBeNull();
+    expect(line?.tone).toBe("degraded");
+  });
+
+  test("the arming flag accepts the same words as the digest flag", async () => {
+    for (const flag of ["1", "true", "yes", "on", "ON", "True"]) {
+      const queue = await readSocialQueue({
+        env: { SOCIAL_QUEUE_ENABLED: flag, GITHUB_TOKEN: "t" } as NodeJS.ProcessEnv,
+        fetchImpl: respond([]),
+      });
+      expect(queue.state, `flag "${flag}" should arm the queue`).toBe("live");
+    }
   });
 
   test("a non-200 is unreadable, never an empty queue", async () => {


### PR DESCRIPTION
Found while checking what the merge of [#797](https://github.com/depre-dev/averray-reference-agent/pull/797) actually needs to go live.

## The problem

The queue lives under a **different GitHub owner** — `averray-agent/agent` — than this repo (`depre-dev`). So the plain `GITHUB_TOKEN` may not reach it, and `GITHUB_OWNER_TOKENS` must carry an entry.

Before this, an unresolvable token returned `off`. And `off` prints **no line at all** — so a missing token was indistinguishable from an empty queue. **A draft could sit unseen for weeks while every morning said nothing was waiting.**

That is the *fourth* appearance of one shape in this pipeline: something looks wired and silently does nothing.

| # | Where |
|---|---|
| 1 | the merge-time watermark — labelling an old PR did nothing ([agent#1027](https://github.com/averray-agent/agent/pull/1027)) |
| 2 | the unpersisted seed marker — labelled PRs seeded forever ([agent#1031](https://github.com/averray-agent/agent/pull/1031)) |
| 3 | an unconfigured queue dropping fired signals ([agent#1033](https://github.com/averray-agent/agent/pull/1033)) |
| 4 | this |

## The fix

The queue is armed **deliberately**, exactly like the digest it rides in. `SOCIAL_QUEUE_ENABLED` is off by default and accepts the same words as `BUZZ_MORNING_DIGEST`.

- **Unarmed → silent.** An unconfigured deployment should not complain about a feature nobody switched on.
- **Armed but untokened → `unreadable`, not `off`** — a visible line naming the env var to check.

Also wires `SOCIAL_QUEUE_ENABLED` and `SOCIAL_QUEUE_REPO` through `compose.yml`. The reader had defaults, but nothing passed them to the container, so they were not settable at all.

## Verified against the real queue

```
armed + token    → live        | 1 draft waiting — #1036 Merged: Measure both sides of the x402 rail…
armed, NO token  → unreadable  | draft queue unreadable (no GitHub token resolves for
                                 averray-agent/agent — check GITHUB_OWNER_TOKENS) — a post
                                 may be waiting unseen
unarmed          → off         | (no line)
```

235 unit tests pass; `npm run typecheck` clean.

## To switch it on

Set in `.env.prod` on the VPS (not `.env` — that one is read by nothing):

- `SOCIAL_QUEUE_ENABLED=1`
- `GITHUB_OWNER_TOKENS` must resolve a token for the `averray-agent` owner
- `BUZZ_MORNING_DIGEST=1` if the digest itself is not already armed

If the token is missing, the digest will now say so out loud instead of going quiet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)