### PR TITLE
Show the traffic the funnel can claim for neither side

### DIFF
--- a/packages/monitor-ui/src/components/ops/ArrivalsPanel.test.tsx
+++ b/packages/monitor-ui/src/components/ops/ArrivalsPanel.test.tsx
@@ -167,3 +167,98 @@ describe("ArrivalsPanel", () => {
     expect(getByTestId("ops-arrivals-unreachable").textContent).toContain("feed not present");
   });
 });
+
+// UNCLAIMABLE — traffic under a client name we use ourselves. Our own Claude
+// session and a stranger's both declare `Anthropic/ClaudeAI`, so no rule over
+// that name can separate them. Observed live on 2026-08-10, when the operator
+// inspecting the front door through Claude was counted as outside interest.
+describe("ArrivalsPanel — traffic that can be claimed by neither side", () => {
+  const withAmbiguous: ArrivalsSnapshot = {
+    ...arrivals,
+    funnelAmbiguous: {
+      reached: 0, browsed: 3, evaluated: 0, identified: 0, authenticated: 0, claimed: 0, submitted: 0,
+    },
+    funnel: { ...arrivals.funnel, browsed: 19 },
+    distinct: { ...arrivals.distinct, ambiguous: 1, furthestAmbiguous: "browsed" },
+  };
+
+  test("is shown beside the external figure, never inside it", () => {
+    const { getByTestId } = render(<ArrivalsPanel arrivals={withAmbiguous} />);
+
+    // The headline is unmoved by traffic we cannot attribute.
+    expect(getByTestId("ops-arrival-stage-browsed").querySelector("strong")?.textContent).toBe("10");
+    expect(getByTestId("ops-arrival-ambiguous-browsed").textContent).toBe("?3");
+    expect(getByTestId("ops-arrivals-distinct-ambiguous").textContent).toContain("UNCLAIMABLE 1");
+  });
+
+  // The defect this change closes. `unattributed` is computed by subtraction,
+  // so before the third bucket was subtracted too, every unclaimable call was
+  // rendered under a line stating it predated the external/self split. The
+  // number was real and the explanation printed beside it was false.
+  test("is not mislabelled as history that predates the split", () => {
+    const { queryByTestId } = render(<ArrivalsPanel arrivals={withAmbiguous} />);
+
+    expect(queryByTestId("ops-arrivals-unattributed")).toBeNull();
+  });
+
+  // Both kinds at once: genuinely pre-split calls still have to be named, and
+  // the unclaimable ones must not be counted into that explanation.
+  test("real pre-split history is still named, and counts only itself", () => {
+    const { getByTestId } = render(
+      <ArrivalsPanel arrivals={{ ...withAmbiguous, funnel: { ...withAmbiguous.funnel, reached: 33 } }} />,
+    );
+
+    // 33 reached − 20 external − 8 ours − 0 unclaimable = 5, and nothing more.
+    expect(getByTestId("ops-arrivals-unattributed").textContent).toContain("5 calls");
+    expect(getByTestId("ops-arrivals-unattributed").textContent).toContain("predate the");
+  });
+
+  test("the furthest an outsider reached is not borrowed from an unclaimable client", () => {
+    const { getByTestId } = render(
+      <ArrivalsPanel
+        arrivals={{
+          ...withAmbiguous,
+          distinct: { ...withAmbiguous.distinct, furthestExternal: "reached", furthestAmbiguous: "claimed" },
+        }}
+      />,
+    );
+
+    expect(getByTestId("ops-arrivals-furthest").getAttribute("data-advanced")).toBe("no");
+    // Reported alongside, because it may well have been an outsider.
+    expect(getByTestId("ops-arrivals-furthest-ambiguous").textContent).toContain("claimed");
+  });
+
+  test("the panel explains why the external figure is narrower than it was", () => {
+    const { getByTestId } = render(<ArrivalsPanel arrivals={withAmbiguous} />);
+
+    expect(getByTestId("ops-arrivals-ambiguous-note").textContent).toContain("client name we use ourselves");
+  });
+
+  // A platform deployed before the bucket existed reports nothing here. That
+  // is not a measurement of zero, so the panel makes no claim at all — and
+  // renders exactly as it did before, rather than blanking on a deploy skew.
+  test("a platform that does not report the bucket renders as it always did", () => {
+    const { queryByTestId, getByTestId } = render(<ArrivalsPanel arrivals={arrivals} />);
+
+    expect(queryByTestId("ops-arrival-ambiguous-browsed")).toBeNull();
+    expect(queryByTestId("ops-arrivals-distinct-ambiguous")).toBeNull();
+    expect(queryByTestId("ops-arrivals-furthest-ambiguous")).toBeNull();
+    expect(queryByTestId("ops-arrivals-ambiguous-note")).toBeNull();
+    expect(getByTestId("ops-arrival-stage-browsed").querySelector("strong")?.textContent).toBe("10");
+  });
+
+  // Reported-and-zero is a real finding: nobody arrived under a shared name.
+  // It keeps the column, unlike absent, which keeps nothing.
+  test("a reported zero still counts as a reading", () => {
+    const zeroed = Object.fromEntries(ARRIVAL_STAGES.map((stage) => [stage, 0])) as typeof arrivals.funnel;
+    const { getByTestId } = render(
+      <ArrivalsPanel
+        arrivals={{ ...arrivals, funnelAmbiguous: zeroed, distinct: { ...arrivals.distinct, ambiguous: 0 } }}
+      />,
+    );
+
+    expect(getByTestId("ops-arrival-ambiguous-browsed").textContent).toBe("");
+    expect(getByTestId("ops-arrivals-distinct-ambiguous").textContent).toContain("UNCLAIMABLE 0");
+    expect(getByTestId("ops-arrivals-ambiguous-note")).toBeTruthy();
+  });
+});

--- a/packages/monitor-ui/src/components/ops/ArrivalsPanel.tsx
+++ b/packages/monitor-ui/src/components/ops/ArrivalsPanel.tsx
@@ -10,6 +10,17 @@
 // them to the same bars — it once read BROWSED 2 when one of the two was our
 // own roadmap probe. Ours are still shown, deliberately: knowing a probe ran
 // is useful. They are just never part of the number that reads as demand.
+//
+// A third column is neither. A declared client name identifies the client
+// SOFTWARE, not the operator: our own Claude session and a stranger's both
+// announce `Anthropic/ClaudeAI`, so no rule over that name can separate them.
+// Counted as outsiders they manufacture demand every time we inspect our own
+// front door; counted as ours they erase the real users who arrive the same
+// way. So they are shown apart, and the panel says why — an operator watching
+// the external figure drop is owed the reason it was wrong before.
+//
+// The column is absent, not zero, against a platform deployed before the
+// bucket existed. Zero is a measurement; absent is not.
 
 import {
   ARRIVAL_STAGES,
@@ -38,15 +49,27 @@ export function ArrivalsPanel({ arrivals }: ArrivalsPanelProps) {
   // Scaling on the total would let one busy canary flatten every real bar.
   const peak = Math.max(1, ...ARRIVAL_STAGES.map((stage) => arrivals.funnelExternal[stage]));
   const advanced = arrivals.distinct.furthestExternal !== "reached";
+  // Absent means a platform deployed before the bucket existed, which is a
+  // different thing from a platform reporting none — so the column appears
+  // only when there is actually a reading behind it.
+  const ambiguousCounts = arrivals.funnelAmbiguous;
   // Calls the platform counted before it split the funnel. Their actor was
-  // never recorded and cannot be recovered, so they sit in neither half. They
-  // have to be named: the furthest-stage figures come from the client table,
-  // which DOES remember that history, so an operator can otherwise face a
-  // funnel reading 0 outsiders beside "an outsider reached browsed" with
-  // nothing on screen to reconcile them.
+  // never recorded and cannot be recovered, so they sit in none of the
+  // columns. They have to be named: the furthest-stage figures come from the
+  // client table, which DOES remember that history, so an operator can
+  // otherwise face a funnel reading 0 outsiders beside "an outsider reached
+  // browsed" with nothing on screen to reconcile them.
+  //
+  // Ambiguous calls are subtracted here too. They are unattributed in the
+  // ordinary sense, but they do NOT predate the split — saying so on screen
+  // would be a false explanation of a real number.
   const unattributed = ARRIVAL_STAGES.reduce(
     (total, stage) =>
-      total + (arrivals.funnel[stage] - arrivals.funnelExternal[stage] - arrivals.funnelSelf[stage]),
+      total +
+      (arrivals.funnel[stage] -
+        arrivals.funnelExternal[stage] -
+        arrivals.funnelSelf[stage] -
+        (ambiguousCounts?.[stage] ?? 0)),
     0,
   );
 
@@ -54,18 +77,24 @@ export function ArrivalsPanel({ arrivals }: ArrivalsPanelProps) {
     <section className="ops-arrivals" aria-label="Arrivals — MCP front door" data-testid="ops-arrivals">
       <header className="ops-panel-head">
         <h2 className="ops-panel-title">ARRIVALS — MCP FRONT DOOR</h2>
-        <span className="ops-panel-note">reached → submitted · outsiders, with ours counted apart</span>
+        <span className="ops-panel-note">
+          reached → submitted · outsiders, with ours and the unclaimable counted apart
+        </span>
       </header>
 
       <ol className="ops-arrivals-funnel" aria-label="Arrival funnel, reached through submitted">
         {ARRIVAL_STAGES.map((stage) => {
           const value = arrivals.funnelExternal[stage];
           const ours = arrivals.funnelSelf[stage];
+          const unclear = ambiguousCounts?.[stage];
           return (
             <li
               key={stage}
               data-testid={`ops-arrival-stage-${stage}`}
-              aria-label={`${stage}: ${value} external, ${ours} ours`}
+              aria-label={
+                `${stage}: ${value} external, ${ours} ours` +
+                (unclear === undefined ? "" : `, ${unclear} unattributable`)
+              }
             >
               <span className="ops-arrivals-stage">{stage}</span>
               <span className="ops-arrivals-track" aria-hidden>
@@ -75,6 +104,17 @@ export function ArrivalsPanel({ arrivals }: ArrivalsPanelProps) {
               <span className="ops-arrivals-self" data-testid={`ops-arrival-self-${stage}`} aria-hidden>
                 {ours > 0 ? `+${ours}` : ""}
               </span>
+              {/* Beside the headline, never inside it. Rendered only when the
+                  platform actually reports the bucket. */}
+              {unclear !== undefined ? (
+                <span
+                  className="ops-arrivals-ambiguous"
+                  data-testid={`ops-arrival-ambiguous-${stage}`}
+                  aria-hidden
+                >
+                  {unclear > 0 ? `?${unclear}` : ""}
+                </span>
+              ) : null}
             </li>
           );
         })}
@@ -85,6 +125,11 @@ export function ArrivalsPanel({ arrivals }: ArrivalsPanelProps) {
           <span>DECLARED <strong>{arrivals.distinct.declared}</strong></span>
           <span>ANONYMOUS <strong>{arrivals.distinct.anonymous}</strong></span>
           <span>OURS <strong>{arrivals.distinct.self}</strong></span>
+          {arrivals.distinct.ambiguous === undefined ? null : (
+            <span data-testid="ops-arrivals-distinct-ambiguous">
+              UNCLAIMABLE <strong>{arrivals.distinct.ambiguous}</strong>
+            </span>
+          )}
         </div>
         <div
           className="ops-arrivals-furthest"
@@ -96,8 +141,25 @@ export function ArrivalsPanel({ arrivals }: ArrivalsPanelProps) {
               statement about ourselves. */}
           <span>FURTHEST STAGE AN OUTSIDER REACHED</span>
           <strong>{arrivals.distinct.furthestExternal}</strong>
+          {/* Shown beside it, because narrowing the claim must not throw the
+              signal away: this may well have been an outsider, and the honest
+              statement is that we cannot tell. */}
+          {arrivals.distinct.furthestAmbiguous === undefined ? null : (
+            <span className="ops-arrivals-furthest-ambiguous" data-testid="ops-arrivals-furthest-ambiguous">
+              possibly, unclaimable client <strong>{arrivals.distinct.furthestAmbiguous}</strong>
+            </span>
+          )}
         </div>
       </div>
+
+      {ambiguousCounts ? (
+        <p className="ops-arrivals-ambiguous-note" data-testid="ops-arrivals-ambiguous-note">
+          <strong>UNCLAIMABLE</strong> — calls under a client name we use ourselves. A declared name
+          identifies the client software, not the operator, so our own session and a stranger's are
+          indistinguishable. Counted as outsiders they would manufacture demand; counted as ours they
+          would erase real users. They are neither, and are shown apart.
+        </p>
+      ) : null}
 
       {unattributed > 0 ? (
         <p

--- a/packages/monitor-ui/src/lib/monitor/product-health.ts
+++ b/packages/monitor-ui/src/lib/monitor/product-health.ts
@@ -299,6 +299,8 @@ export interface ArrivalClient {
   era: string | null;
   /** Declared as one of ours. Unmarked callers are external on purpose. */
   self: boolean;
+  /** Declared under a name we also use, so neither side can be claimed. */
+  ambiguous?: boolean;
   firstSeenMs: number;
   lastSeenMs: number;
   furthestStage: ArrivalStage;
@@ -319,12 +321,21 @@ export interface ArrivalsSnapshot {
   funnelExternal: Record<ArrivalStage, number>;
   /** Our own probes, kept because confirming they ran is worth something. */
   funnelSelf: Record<ArrivalStage, number>;
+  /**
+   * Traffic under a client name WE also present — our Claude session and a
+   * stranger's declare the same thing, so neither side can be claimed.
+   * Absent from a platform deployed before the bucket existed: absent, never
+   * zero, because a zero here would be a measurement we did not make.
+   */
+  funnelAmbiguous?: Record<ArrivalStage, number>;
   distinct: {
     declared: number;
     anonymous: number;
     self: number;
+    ambiguous?: number;
     furthest: ArrivalStage;
     furthestExternal: ArrivalStage;
+    furthestAmbiguous?: ArrivalStage;
   };
   clients: ArrivalClient[];
 }

--- a/packages/monitor-ui/src/styles/hermes4-ops.css
+++ b/packages/monitor-ui/src/styles/hermes4-ops.css
@@ -946,9 +946,12 @@ body,
 }
 .ops-arrivals-funnel li {
   display: grid;
-  /* Fourth column is ours, counted apart. It holds its width even when empty
-     so the external figures stay on one line down the panel. */
-  grid-template-columns: calc(104 * var(--ops-u)) 1fr calc(48 * var(--ops-u)) calc(38 * var(--ops-u));
+  /* Fourth column is ours and the fifth is the unclaimable, both counted
+     apart. They hold their width even when empty so the external figures stay
+     on one line down the panel. */
+  grid-template-columns:
+    calc(104 * var(--ops-u)) 1fr calc(48 * var(--ops-u)) calc(38 * var(--ops-u))
+    calc(38 * var(--ops-u));
   gap: calc(10 * var(--ops-u));
   align-items: center;
   min-width: 0;
@@ -982,6 +985,14 @@ body,
   text-align: right;
   font-size: calc(9 * var(--ops-u));
   color: var(--h4-muted);
+}
+/* The unclaimable. Styled like ours rather than like the external figure: it
+   is emphatically not evidence of demand, but unlike ours it is not evidence
+   of nothing either, so it keeps the tone colour rather than plain muted. */
+.ops-arrivals-ambiguous {
+  text-align: right;
+  font-size: calc(9 * var(--ops-u));
+  color: var(--h4-tel);
 }
 .ops-arrivals-summary {
   display: grid;
@@ -1023,6 +1034,19 @@ body,
   color: var(--h4-tel);
 }
 .ops-arrivals-furthest[data-advanced="yes"] strong { color: var(--h4-ok); }
+/* Beside the headline stage, never replacing it. Small, because "possibly an
+   outsider" must not read with the weight of "an outsider". */
+.ops-arrivals-furthest-ambiguous {
+  display: block;
+  font-size: calc(9 * var(--ops-u));
+  color: var(--h4-muted);
+}
+.ops-arrivals-furthest-ambiguous strong {
+  font-family: var(--h4-font-mono);
+  font-size: calc(10 * var(--ops-u));
+  letter-spacing: 0.04em;
+  color: var(--h4-tel);
+}
 .ops-arrivals-unreachable {
   margin: 0;
   font-family: var(--h4-font-mono);
@@ -1046,6 +1070,22 @@ body,
 .ops-arrivals-unattributed strong {
   letter-spacing: 0.08em;
   color: var(--tone, var(--h4-tel));
+}
+/* Why a number an operator watched go DOWN is the more honest one. Full width
+   below both columns, and present only when the platform reports the bucket. */
+.ops-arrivals-ambiguous-note {
+  grid-column: 1 / -1;
+  margin: 0;
+  padding-top: calc(6 * var(--ops-u));
+  border-top: 1px solid var(--ops-hair);
+  font-family: var(--h4-font-mono);
+  font-size: calc(9 * var(--ops-u));
+  line-height: 1.5;
+  color: var(--h4-muted);
+}
+.ops-arrivals-ambiguous-note strong {
+  letter-spacing: 0.08em;
+  color: var(--h4-tel);
 }
 
 /* ---- BANK lane -------------------------------------------------

--- a/services/slack-operator/src/arrivals-feed.ts
+++ b/services/slack-operator/src/arrivals-feed.ts
@@ -12,6 +12,15 @@
 // manufactures demand evidence. Both are required: a platform that cannot
 // supply the split cannot answer the question this panel asks, so the block
 // becomes unavailable rather than falling back to the inflated total.
+//
+// `funnelAmbiguous` is traffic under a client name the platform ITSELF uses —
+// our Claude session and a stranger's both declare `Anthropic/ClaudeAI`, so
+// neither side can be claimed. It is OPTIONAL, and that is not the same laxity
+// as above: a platform without it is one deployed before the bucket existed,
+// and its `funnelExternal` is the number this panel has always rendered.
+// Blanking the board over a deploy-order skew would be worse than showing it.
+// Absent therefore stays ABSENT rather than becoming zero — a zero here is a
+// measurement, and in that case we have not made one.
 
 export const ARRIVALS_SCHEMA_VERSION = "averray.arrivals.v1";
 export const ARRIVAL_STAGES = [
@@ -33,6 +42,8 @@ export interface ArrivalClient {
   era: string | null;
   /** Declared as one of ours. Unmarked callers are external on purpose. */
   self: boolean;
+  /** Declared under a name we also use, so neither side can be claimed. */
+  ambiguous?: boolean;
   firstSeenMs: number;
   lastSeenMs: number;
   furthestStage: ArrivalStage;
@@ -50,12 +61,19 @@ export interface ArrivalsSnapshot {
   funnelExternal: Record<ArrivalStage, number>;
   /** Our own probes, kept because confirming they ran is worth something. */
   funnelSelf: Record<ArrivalStage, number>;
+  /**
+   * Traffic we cannot attribute either way. Absent from a platform deployed
+   * before the bucket existed — absent, never zero.
+   */
+  funnelAmbiguous?: Record<ArrivalStage, number>;
   distinct: {
     declared: number;
     anonymous: number;
     self: number;
+    ambiguous?: number;
     furthest: ArrivalStage;
     furthestExternal: ArrivalStage;
+    furthestAmbiguous?: ArrivalStage;
   };
   clients: ArrivalClient[];
 }
@@ -120,17 +138,31 @@ export function normalizeArrivalsFeed(body: unknown): ArrivalsBlock {
   if ("unavailable" in funnelExternal) return funnelExternal;
   const funnelSelf = stageCounts(value.funnelSelf, "funnelSelf");
   if ("unavailable" in funnelSelf) return funnelSelf;
+  // Optional, but malformed-when-present is still a producer we cannot read.
+  const funnelAmbiguous =
+    value.funnelAmbiguous === undefined
+      ? undefined
+      : stageCounts(value.funnelAmbiguous, "funnelAmbiguous");
+  if (funnelAmbiguous && "unavailable" in funnelAmbiguous) return funnelAmbiguous;
+  const ambiguousCounts = funnelAmbiguous && "counts" in funnelAmbiguous ? funnelAmbiguous.counts : undefined;
 
-  // External and self are subsets of the total, so neither can exceed it and
-  // together they cannot either. A producer that says otherwise is describing
-  // a funnel we do not understand, and the safe reading of a funnel we do not
-  // understand is none at all.
+  // External, self and ambiguous are disjoint subsets of the total, so no one
+  // of them can exceed it and together they cannot either. A producer that
+  // says otherwise is describing a funnel we do not understand, and the safe
+  // reading of a funnel we do not understand is none at all.
+  //
+  // The check is an INEQUALITY, not an equality: calls the platform counted
+  // before it split the funnel restore into the total alone, so the parts
+  // legitimately fall short of the whole. Requiring them to add up would
+  // reject every producer carrying real pre-split history.
   const incoherent = ARRIVAL_STAGES.find(
-    (stage) => funnelExternal.counts[stage] + funnelSelf.counts[stage] > funnel.counts[stage],
+    (stage) =>
+      funnelExternal.counts[stage] + funnelSelf.counts[stage] + (ambiguousCounts?.[stage] ?? 0) >
+      funnel.counts[stage],
   );
   if (incoherent) {
     return {
-      unavailable: `arrivals feed unreadable — ${incoherent} external plus self exceeds the total`,
+      unavailable: `arrivals feed unreadable — ${incoherent} external plus self plus ambiguous exceeds the total`,
     };
   }
 
@@ -148,6 +180,15 @@ export function normalizeArrivalsFeed(body: unknown): ArrivalsBlock {
     furthest === undefined || furthestExternal === undefined
   ) {
     return { unavailable: "arrivals feed unreadable — distinct counts or furthest stages are invalid" };
+  }
+  const ambiguous = distinctValue.ambiguous === undefined ? undefined : count(distinctValue.ambiguous);
+  const furthestAmbiguous =
+    distinctValue.furthestAmbiguous === undefined ? undefined : arrivalStage(distinctValue.furthestAmbiguous);
+  if (
+    (distinctValue.ambiguous !== undefined && ambiguous === undefined) ||
+    (distinctValue.furthestAmbiguous !== undefined && furthestAmbiguous === undefined)
+  ) {
+    return { unavailable: "arrivals feed unreadable — distinct ambiguous figures are invalid" };
   }
 
   if (!Array.isArray(value.clients)) {
@@ -167,7 +208,17 @@ export function normalizeArrivalsFeed(body: unknown): ArrivalsBlock {
     funnel: funnel.counts,
     funnelExternal: funnelExternal.counts,
     funnelSelf: funnelSelf.counts,
-    distinct: { declared, anonymous, self, furthest, furthestExternal },
+    // Omitted, not zero-filled, when the producer did not supply it.
+    ...(ambiguousCounts === undefined ? {} : { funnelAmbiguous: ambiguousCounts }),
+    distinct: {
+      declared,
+      anonymous,
+      self,
+      ...(ambiguous === undefined ? {} : { ambiguous }),
+      furthest,
+      furthestExternal,
+      ...(furthestAmbiguous === undefined ? {} : { furthestAmbiguous }),
+    },
     clients,
   };
 }
@@ -205,6 +256,9 @@ function normalizeClient(raw: unknown): { client: ArrivalClient } | { unavailabl
     // treating it as false would silently promote our own probe to an
     // outsider. Absent is not the same as external here.
     typeof value.self !== "boolean" ||
+    // The ambiguous mark IS allowed to be absent — an older producer has no
+    // opinion to report — but a present one must be a real boolean.
+    (value.ambiguous !== undefined && typeof value.ambiguous !== "boolean") ||
     firstSeenMs === undefined || lastSeenMs === undefined || calls === undefined ||
     furthestStage === undefined || tools === undefined
   ) {
@@ -217,6 +271,7 @@ function normalizeClient(raw: unknown): { client: ArrivalClient } | { unavailabl
       version: value.version,
       era: value.era,
       self: value.self,
+      ...(value.ambiguous === undefined ? {} : { ambiguous: value.ambiguous }),
       firstSeenMs,
       lastSeenMs,
       furthestStage,

--- a/services/slack-operator/test/unit/arrivals-feed.test.ts
+++ b/services/slack-operator/test/unit/arrivals-feed.test.ts
@@ -128,16 +128,18 @@ describe("normalizeArrivalsFeed", () => {
     expect("unavailable" in result && result.unavailable).toContain("client entry has invalid fields");
   });
 
-  // External and self are subsets of the total. A producer claiming more
-  // outsiders than calls is describing a funnel we cannot interpret, and the
-  // safe reading of a funnel we cannot interpret is none at all.
+  // External, self and ambiguous are disjoint subsets of the total. A producer
+  // claiming more outsiders than calls is describing a funnel we cannot
+  // interpret, and the safe reading of a funnel we cannot interpret is none.
   test("a split that exceeds its own total is refused", () => {
     const result = normalizeArrivalsFeed({
       ...good,
       funnelExternal: { ...good.funnelExternal, browsed: good.funnel.browsed + 1 },
     });
 
-    expect("unavailable" in result && result.unavailable).toContain("browsed external plus self exceeds");
+    expect("unavailable" in result && result.unavailable).toContain(
+      "browsed external plus self plus ambiguous exceeds",
+    );
   });
 
   test("the producer's own unavailable state stays unavailable, not seven zeroes", () => {
@@ -166,5 +168,117 @@ describe("normalizeArrivalsFeed", () => {
   test("a schema drift is visible by version", () => {
     const result = normalizeArrivalsFeed({ ...good, schemaVersion: "averray.arrivals.v2" });
     expect("unavailable" in result && result.unavailable).toContain("schemaVersion averray.arrivals.v1");
+  });
+});
+
+// AMBIGUOUS — traffic under a client name the platform itself uses. Our Claude
+// session and a stranger's both declare `Anthropic/ClaudeAI`, so the funnel
+// structurally cannot separate them and neither side may be claimed.
+describe("normalizeArrivalsFeed — the ambiguous bucket", () => {
+  const withAmbiguous = {
+    ...good,
+    funnelAmbiguous: {
+      reached: 0,
+      browsed: 3,
+      evaluated: 0,
+      identified: 0,
+      authenticated: 0,
+      claimed: 0,
+      submitted: 0,
+    },
+    // The base fixture spends its whole `browsed` total on external and self,
+    // so the third bucket needs room in the total to be coherent at all.
+    funnel: { ...good.funnel, browsed: 15 },
+    distinct: { ...good.distinct, ambiguous: 1, furthestAmbiguous: "browsed" },
+  };
+
+  test("the third bucket is carried through when the platform reports it", () => {
+    const result = normalizeArrivalsFeed(withAmbiguous);
+
+    expect("funnelAmbiguous" in result && result.funnelAmbiguous).toEqual(withAmbiguous.funnelAmbiguous);
+    expect("distinct" in result && result.distinct.ambiguous).toBe(1);
+    expect("distinct" in result && result.distinct.furthestAmbiguous).toBe("browsed");
+  });
+
+  // Unlike the external split, absence here is not a producer we cannot read —
+  // it is one deployed before the bucket existed, whose `funnelExternal` is the
+  // number this panel has always rendered. Blanking the board over a
+  // deploy-order skew would be strictly worse than showing it.
+  test("a platform without the bucket still reads, it does not blank the board", () => {
+    const result = normalizeArrivalsFeed(good);
+
+    expect("unavailable" in result).toBe(false);
+    expect("funnelExternal" in result && result.funnelExternal).toEqual(good.funnelExternal);
+  });
+
+  // Absent and zero are different claims. Zero-filling would have the board
+  // state that no unattributable traffic arrived, which nobody measured.
+  test("an absent bucket stays absent rather than becoming a zero reading", () => {
+    const result = normalizeArrivalsFeed(good);
+
+    expect("funnelAmbiguous" in result).toBe(false);
+    expect("distinct" in result && "ambiguous" in result.distinct).toBe(false);
+    expect("distinct" in result && "furthestAmbiguous" in result.distinct).toBe(false);
+  });
+
+  test("optional does not mean unchecked — a malformed bucket is still refused", () => {
+    const result = normalizeArrivalsFeed({
+      ...withAmbiguous,
+      funnelAmbiguous: { ...withAmbiguous.funnelAmbiguous, browsed: "3" },
+    });
+
+    expect("unavailable" in result && result.unavailable).toContain("funnelAmbiguous.browsed");
+  });
+
+  test("a malformed distinct ambiguous figure is refused", () => {
+    const result = normalizeArrivalsFeed({
+      ...withAmbiguous,
+      distinct: { ...withAmbiguous.distinct, furthestAmbiguous: "loitering" },
+    });
+
+    expect("unavailable" in result && result.unavailable).toContain("distinct ambiguous figures");
+  });
+
+  // The invariant this bucket had to be added to. All three are subsets of the
+  // total, so together they still cannot exceed it.
+  test("the three buckets together may not exceed the total", () => {
+    const result = normalizeArrivalsFeed({
+      ...withAmbiguous,
+      funnelAmbiguous: { ...withAmbiguous.funnelAmbiguous, browsed: good.funnel.browsed },
+    });
+
+    expect("unavailable" in result && result.unavailable).toContain(
+      "browsed external plus self plus ambiguous exceeds",
+    );
+  });
+
+  // An INEQUALITY on purpose: calls counted before the platform split its
+  // funnel restore into the total alone, so the parts legitimately fall short.
+  // Requiring them to add up would reject every producer with real history.
+  test("buckets falling short of the total is history, not incoherence", () => {
+    const result = normalizeArrivalsFeed({
+      ...withAmbiguous,
+      funnel: { ...good.funnel, browsed: good.funnel.browsed + 40 },
+    });
+
+    expect("unavailable" in result).toBe(false);
+  });
+
+  test("a client may carry the ambiguous mark, and need not", () => {
+    const [client] = good.clients;
+    const marked = normalizeArrivalsFeed({
+      ...withAmbiguous,
+      clients: [{ ...client, ambiguous: true }],
+    });
+    expect("clients" in marked && marked.clients[0].ambiguous).toBe(true);
+
+    const unmarked = normalizeArrivalsFeed(good);
+    expect("clients" in unmarked && "ambiguous" in unmarked.clients[0]).toBe(false);
+
+    const malformed = normalizeArrivalsFeed({
+      ...withAmbiguous,
+      clients: [{ ...client, ambiguous: "yes" }],
+    });
+    expect("unavailable" in malformed && malformed.unavailable).toContain("client entry has invalid fields");
   });
 });


### PR DESCRIPTION
Consumer half of [averray-agent/agent#1037](https://github.com/averray-agent/agent/pull/1037), which adds a third arrival bucket to the platform observatory. **Ships in either merge order.**

## Why the platform changed

A declared MCP client name identifies the client **software**, not the operator. Our own Claude session and a stranger's both announce `Anthropic/ClaudeAI`, so the funnel structurally cannot separate them. Observed live on 2026-08-10: `funnelExternal.browsed` read 5 while some of the advancing traffic was the operator inspecting the front door through Claude minutes earlier.

Counted as outsiders, our inspections manufacture demand evidence. Counted as ours, we erase the real users who arrive the same way. So they are neither — and this panel shows them apart.

## This isn't only a missing column — the board would lie

`unattributed` is computed by subtraction:

```
funnel − funnelExternal − funnelSelf
```

so once the platform starts routing traffic into `funnelAmbiguous`, every unclaimable call falls into that remainder and renders under a line stating it **predates the external/self split**. The number would be real and the explanation printed beside it would be false. Ambiguous is now subtracted too, so that line counts only genuine pre-split history.

That is the reason this PR exists rather than waiting for a UI pass.

## Contract changes

- **Coherence invariant extended**: `external + self + ambiguous > total` ⇒ unavailable. It stays an **inequality** — calls counted before the platform split its funnel restore into the total alone, so the parts legitimately fall short, and requiring them to add up would reject every producer carrying real history.
- **`funnelAmbiguous` is optional**, unlike the external split. Not the same laxity: a platform without it is one deployed *before the bucket existed*, and its `funnelExternal` is the number this panel has always rendered — blanking the board over a deploy-order skew would be strictly worse than showing it. Optional is not unchecked: malformed-when-present is still refused.
- **Absent stays absent, never zero**, through the type, the normalizer and the panel. A reported zero is a finding (nobody arrived under a shared name); an absent bucket is no measurement at all, and the panel makes no claim where it has none.
- `ArrivalClient.ambiguous` is optional for the same reason; `self` keeps its strict boolean requirement.

## What an operator sees

- Each stage row gains a `?N` figure beside the external count and the `+N` ours count — beside the headline, never inside it.
- `UNCLAIMABLE n` joins DECLARED / ANONYMOUS / OURS.
- `furthestAmbiguous` renders beneath the furthest-an-outsider-reached stage, so narrowing the claim does not discard the signal.
- A short note explains *why* — an operator watching the external figure drop is owed the reason it was wrong before.

All four appear only when the platform actually reports the bucket.

## Tests

18 in `arrivals-feed.test.ts` (7 new), 14 in `ArrivalsPanel.test.tsx` (7 new), including the mislabelling regression directly: an ambiguous-only difference must produce **no** pre-split disclaimer, while a genuine one still counts only itself.

Full suite: 201 files / 2964 tests pass, 5 skipped. `npm run typecheck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)