### PR TITLE
docs(ops): document the social queue vars where an operator looks

### DIFF
--- a/ops/.env.example
+++ b/ops/.env.example
@@ -277,6 +277,23 @@ GITHUB_HELPER_REPOS=
 GITHUB_API_BASE_URL=https://api.github.com
 GITHUB_HELPER_LIMIT=5
 
+# --- Social draft queue (carried in the morning digest) ---------------------
+# The social signal sweep opens one `social-draft` issue per fired signal in the
+# agent repo; the digest lists the open ones so a queued post is not invisible.
+#
+# OFF by default, armed deliberately. Once armed, a missing token reports as
+# UNREADABLE in the digest rather than silently printing nothing — but you still
+# have to give it a token that can read the queue.
+#
+# NOTE the owner: the queue lives under `averray-agent`, NOT this repo's owner,
+# so plain GITHUB_TOKEN will usually not reach it. Add an entry to
+# GITHUB_OWNER_TOKENS above, e.g. `averray-agent=ghp_...`.
+#
+# Requires BUZZ_MORNING_DIGEST to be armed too — the queue line rides in that
+# message and appears nowhere else.
+SOCIAL_QUEUE_ENABLED=
+SOCIAL_QUEUE_REPO=averray-agent/agent
+
 # ORCH-P4b Hermes router routine. Default-off authority surface: when enabled,
 # Hermes reads the roadmap backlog, proposes queue tasks, and narrates the
 # decision in the monitor rail. It never approves or dispatches; operator /


### PR DESCRIPTION
`compose.yml` gained `SOCIAL_QUEUE_ENABLED` and `SOCIAL_QUEUE_REPO` in [#798](https://github.com/depre-dev/averray-reference-agent/pull/798), but `ops/.env.example` did not — and that 400-line file is what an operator actually reads when arming something.

**A variable that exists only in a compose interpolation is a variable nobody sets.**

Records the two things most likely to go wrong, each of which costs a silent morning:

- **The owner.** The queue lives under `averray-agent`, *not* this repo's owner, so a plain `GITHUB_TOKEN` usually will not reach it — `GITHUB_OWNER_TOKENS` needs an entry. The example already documents that mechanism four lines above; this says which owner to name.
- **The carrier.** The line rides in the morning digest and appears nowhere else, so `BUZZ_MORNING_DIGEST` has to be armed too.

Documentation only — no behaviour change, no tests affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)