### PR TITLE
test(ci): gate INT-2e Postgres suite execution

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,11 +134,16 @@ jobs:
         env:
           INT2_HARNESS_DEPLOY_KEY: ${{ secrets.INT2_HARNESS_DEPLOY_KEY }}
           INT2_SUITE_EVIDENCE_DIR: ${{ runner.temp }}/int2-suite-evidence
+          INT2E_SUITE_EVIDENCE_DIR: ${{ runner.temp }}/int2e-dispatch-store-evidence
         run: scripts/ceremony/run-int2-automated-suite.sh
 
       - name: Prove the suite did not skip
         if: always()
         run: test "$(tr -d '[:space:]' < '${{ runner.temp }}/int2-suite-evidence/executed-count.txt')" = "14"
+
+      - name: Prove the INT-2e store suite did not skip
+        if: always()
+        run: test "$(tr -d '[:space:]' < '${{ runner.temp }}/int2e-dispatch-store-evidence/executed-count.txt')" = "6"
 
       - name: Upload INT-2 evidence
         if: always()
@@ -146,6 +151,14 @@ jobs:
         with:
           name: int2-supervised-dispatch-evidence
           path: ${{ runner.temp }}/int2-suite-evidence
+          if-no-files-found: error
+
+      - name: Upload INT-2e store evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: int2e-dispatch-store-evidence
+          path: ${{ runner.temp }}/int2e-dispatch-store-evidence
           if-no-files-found: error
 
   int4-mechanism-drills:

--- a/scripts/ceremony/lib/int4-vitest-execution.mjs
+++ b/scripts/ceremony/lib/int4-vitest-execution.mjs
@@ -9,13 +9,15 @@ import {
 import { tmpdir } from "node:os";
 import path from "node:path";
 
-const EVIDENCE_ENV = "INT4_DRILL_EVIDENCE_DIR";
+const DEFAULT_EVIDENCE_ENV = "INT4_DRILL_EVIDENCE_DIR";
 
 export function prepareVitestExecution(
   suite,
   environment = process.env,
+  evidenceEnvironment = DEFAULT_EVIDENCE_ENV,
+  executionName = "DRILLS",
 ) {
-  const configuredEvidence = environment[EVIDENCE_ENV]?.trim();
+  const configuredEvidence = environment[evidenceEnvironment]?.trim();
   const temporary = !configuredEvidence;
   const evidenceDir = configuredEvidence
     ? path.resolve(configuredEvidence)
@@ -36,6 +38,7 @@ export function prepareVitestExecution(
         childStatus,
         reportPath,
         evidenceDir,
+        executionName,
       });
     },
     cleanup() {
@@ -49,6 +52,7 @@ export function assertVitestExecution({
   childStatus,
   reportPath,
   evidenceDir,
+  executionName = "DRILLS",
 }) {
   const status = childStatus ?? 1;
   if (!existsSync(reportPath)) {
@@ -86,17 +90,17 @@ export function assertVitestExecution({
   if (status !== 0) return { passed, failed, skipped, executed, total };
   if (skipped > 0) {
     throw new Error(
-      `${suite}_DRILLS_SKIPPED passed=${passed} skipped=${skipped} total=${total}`,
+      `${suite}_${executionName}_SKIPPED passed=${passed} skipped=${skipped} total=${total}`,
     );
   }
   if (passed < 1) {
     throw new Error(
-      `${suite}_DRILLS_NOT_EXECUTED passed=${passed} skipped=${skipped} total=${total}`,
+      `${suite}_${executionName}_NOT_EXECUTED passed=${passed} skipped=${skipped} total=${total}`,
     );
   }
 
   console.info(
-    `${suite}_DRILLS_EXECUTED passed=${passed} skipped=${skipped} failed=${failed} total=${total}`,
+    `${suite}_${executionName}_EXECUTED passed=${passed} skipped=${skipped} failed=${failed} total=${total}`,
   );
   return { passed, failed, skipped, executed, total };
 }

--- a/scripts/ceremony/run-int2-automated-suite.sh
+++ b/scripts/ceremony/run-int2-automated-suite.sh
@@ -10,6 +10,7 @@ _int2_harness_db="int2-suite-harness-${_int2_suffix}"
 _int2_reference_db="int2-suite-reference-${_int2_suffix}"
 _int2_evidence="${INT2_SUITE_EVIDENCE_DIR:-$_int2_root/evidence}"
 _int2_marker="$_int2_evidence/executed-count.txt"
+_int2e_evidence="${INT2E_SUITE_EVIDENCE_DIR:-$_int2_evidence/int2e-dispatch-store}"
 _int2_bootstrap_log="$_int2_evidence/bootstrap.log"
 _int2_started="$(date +%s)"
 _int2_docker_shared_root="${HOME:?}/.agent-runtime"
@@ -81,6 +82,7 @@ for _int2_command in docker git node npm uv; do
     || { echo "INT-2 suite requires $_int2_command" >&2; exit 2; }
 done
 mkdir -p "$_int2_evidence"
+mkdir -p "$_int2e_evidence"
 printf '%s\n' \
   "INT2_SUITE_BOOTSTRAP_STARTED pin=3355f4906864b0f0e0fe5fd5eb5220172e174206" \
   > "$_int2_bootstrap_log"
@@ -362,8 +364,23 @@ test "$_int2_executed" = "14" \
     echo "INT-2 suite executed $_int2_executed cases; expected 14" >&2
     exit 1
   }
+
+printf '%s\n' "INT2E_TESTS_STARTED expected=6" >> "$_int2_bootstrap_log"
+(
+  cd "$_int2_repo"
+  export INT2E_SUITE_EVIDENCE_DIR="$_int2e_evidence"
+  node scripts/ceremony/run-int2e-dispatch-store.mjs
+)
+_int2e_executed="$(tr -d '[:space:]' < "$_int2e_evidence/executed-count.txt")"
+test "$_int2e_executed" = "6" \
+  || {
+    echo "INT-2e store suite executed $_int2e_executed tests; expected 6" >&2
+    exit 1
+  }
+printf '%s\n' "INT2E_TESTS_COMPLETED executed=$_int2e_executed" \
+  >> "$_int2_bootstrap_log"
 _int2_elapsed="$(( $(date +%s) - _int2_started ))"
 printf '%s\n' "$_int2_elapsed" > "$_int2_evidence/wall-time-seconds.txt"
 printf '%s\n' "INT2_CASES_COMPLETED executed=$_int2_executed elapsed=$_int2_elapsed" \
   >> "$_int2_bootstrap_log"
-echo "INT-2 automated suite: $_int2_executed cases executed in ${_int2_elapsed}s"
+echo "INT-2 automated suite: $_int2_executed cases and $_int2e_executed INT-2e tests executed in ${_int2_elapsed}s"

--- a/scripts/ceremony/run-int2e-dispatch-store.mjs
+++ b/scripts/ceremony/run-int2e-dispatch-store.mjs
@@ -1,0 +1,60 @@
+#!/usr/bin/env node
+
+import { spawnSync } from "node:child_process";
+import { writeFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { prepareVitestExecution } from "./lib/int4-vitest-execution.mjs";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+const databaseUrl = process.env.DISPATCH_TEST_DATABASE_URL?.trim();
+if (!databaseUrl) {
+  throw new Error("INT2E_DATABASE_URL_MISSING");
+}
+
+// Reuse the already-drilled Vitest JSON accounting while giving INT-2e its own
+// evidence directory and vocabulary. Existing INT-4 callers retain their
+// default env name and DRILLS label.
+const execution = prepareVitestExecution(
+  "INT2E",
+  process.env,
+  "INT2E_SUITE_EVIDENCE_DIR",
+  "TESTS",
+);
+const childEnvironment = { ...process.env };
+delete childEnvironment.DISPATCH_TEST_DATABASE_URL;
+childEnvironment.DISPATCH_TEST_DATABASE_URL = databaseUrl;
+const startedAt = Date.now();
+
+try {
+  const result = spawnSync(
+    "npx",
+    [
+      "vitest",
+      "run",
+      "test/integration/dispatch-store-postgres.test.ts",
+      ...execution.reporterArgs,
+    ],
+    {
+      cwd: root,
+      env: childEnvironment,
+      encoding: "utf8",
+    },
+  );
+  process.stdout.write(result.stdout ?? "");
+  process.stderr.write(result.stderr ?? "");
+  const counts = execution.assert(result.status);
+  const elapsedMs = Date.now() - startedAt;
+  writeFileSync(
+    path.join(path.dirname(execution.reportPath), "wall-time-milliseconds.txt"),
+    `${elapsedMs}\n`,
+    "utf8",
+  );
+  console.info(
+    `INT2E_TESTS_COMPLETED executed=${counts?.executed ?? 0} skipped=${counts?.skipped ?? 0} elapsed_ms=${elapsedMs}`,
+  );
+  process.exitCode = result.status ?? 1;
+} finally {
+  execution.cleanup();
+}

--- a/test/unit/int2-ceremony-scripts.test.ts
+++ b/test/unit/int2-ceremony-scripts.test.ts
@@ -40,6 +40,10 @@ const AUTOMATED_SUITE_TEST = path.join(
   ROOT,
   "test/integration/int2-automated-suite.test.ts",
 );
+const INT2E_STORE_RUNNER = path.join(
+  SCRIPT_ROOT,
+  "run-int2e-dispatch-store.mjs",
+);
 const REAP_HELPER = path.join(SCRIPT_ROOT, "lib/int2-reap.sh");
 const PILOT_DOCKERFILE = path.join(ROOT, "ops/Dockerfile.pilot");
 const OPERATOR_SCRIPTS = [
@@ -228,8 +232,8 @@ describe("committed INT-2 ceremony mechanics", () => {
     expect(suite).not.toMatch(/pg_isready -U postgres -d \S+ >\/dev\/null$/m);
   });
 
-  it("keeps the idle model text-only and all three suite counts at ten", async () => {
-    const [idleScript, integrationSuite, shellSuite, workflow] =
+  it("keeps the idle model text-only and both required suite counts distinct", async () => {
+    const [idleScript, integrationSuite, shellSuite, storeRunner, workflow] =
       await Promise.all([
         readFile(
           path.join(
@@ -243,6 +247,7 @@ describe("committed INT-2 ceremony mechanics", () => {
           "utf8",
         ),
         readFile(AUTOMATED_SUITE, "utf8"),
+        readFile(INT2E_STORE_RUNNER, "utf8"),
         readFile(path.join(ROOT, ".github/workflows/ci.yml"), "utf8"),
       ]);
     const turns = idleScript.trimEnd().split("\n").map((line) =>
@@ -267,6 +272,22 @@ describe("committed INT-2 ceremony mechanics", () => {
     expect(shellSuite).toContain("INT2_CASES_STARTED expected=14");
     expect(shellSuite).toContain('test "$_int2_executed" = "14"');
     expect(workflow).toContain("executed-count.txt')\" = \"14\"");
+    expect(shellSuite).toContain("INT2E_TESTS_STARTED expected=6");
+    expect(shellSuite).toContain('test "$_int2e_executed" = "6"');
+    expect(shellSuite).toContain("run-int2e-dispatch-store.mjs");
+    expect(storeRunner).toContain(
+      "test/integration/dispatch-store-postgres.test.ts",
+    );
+    expect(storeRunner).toContain(
+      "delete childEnvironment.DISPATCH_TEST_DATABASE_URL",
+    );
+    expect(storeRunner).toContain(
+      "childEnvironment.DISPATCH_TEST_DATABASE_URL = databaseUrl",
+    );
+    expect(workflow).toContain(
+      "int2e-dispatch-store-evidence/executed-count.txt')\" = \"6\"",
+    );
+    expect(workflow).toContain("name: int2e-dispatch-store-evidence");
     expect(shellSuite).toContain(
       '-t "$_int2_image_tag" "$_int2_dep_source"',
     );


### PR DESCRIPTION
## What changed

- runs `test/integration/dispatch-store-postgres.test.ts` as a separate Vitest invocation inside the existing INT-2 ceremony, against its already-provisioned Postgres and `DISPATCH_TEST_DATABASE_URL`
- writes a distinct INT-2e JSON report, execution summary, executed-count marker, and wall-time artifact
- makes both the local ceremony and CI fail if the six INT-2e tests skip or do not execute
- keeps the existing INT-2 count and evidence independently asserted at 14
- reuses the existing fail-loud Vitest accounting helper with backward-compatible defaults for every INT-4 caller

Closes the remaining uncovered instance identified in #787.

## Why

Vitest exits zero when all tests are skipped. The INT-2e Postgres suite was gated on `DISPATCH_TEST_DATABASE_URL`, but no runner named the file, so its six tests skipped in every ordinary test run and no check could fail. Separate 14 and 6 markers keep the two mechanisms diagnostically distinct.

## Checks

- `npm run typecheck` — exit 0
- `npm test` — exit 0; 201 files passed, 5 skipped; 2,967 tests passed, 37 skipped
- `npm run build` — exit 0
- real container-backed INT-2 ceremony — exit 0; existing suite 14/14, INT-2e 6/6 with 0 skipped

Green evidence (verbatim):

```text
Test Files  1 passed (1)
     Tests  14 passed (14)

Test Files  1 passed (1)
     Tests  6 passed (6)

INT2E_TESTS_EXECUTED passed=6 skipped=0 failed=0 total=6
INT2E_TESTS_COMPLETED executed=6 skipped=0 elapsed_ms=2827
INT-2 automated suite: 14 cases and 6 INT-2e tests executed in 440s
```

Deliberate producer-side coupling break (renamed the child `DISPATCH_TEST_DATABASE_URL` assignment), exit 1 (verbatim):

```text
Test Files  1 passed (1)
     Tests  14 passed (14)

Test Files  1 skipped (1)
     Tests  6 skipped (6)

Error: INT2E_TESTS_SKIPPED passed=0 skipped=6 total=6
```

The red evidence markers were `14` for the existing suite and `0` for INT-2e, proving the original suite remained intact while the new guard caught the broken environment coupling. The mutation was restored before the green run and commit.

The GitHub CI evidence artifact measured the added runner at 2.804 seconds (the local CI-shaped proof measured 2.827 seconds). CI adds only the count assertion and small artifact upload around that invocation.

## Affected surfaces

CI workflow, ceremony runner/accounting, and unit invariants only. No production backend, frontend, indexer, Caddy, contracts, public site, database migration, runtime authority, environment value, or VPS secret changes.
