### PR TITLE
Page when the reward bank breaches its floor

### DIFF
--- a/services/slack-operator/src/money-alert.ts
+++ b/services/slack-operator/src/money-alert.ts
@@ -1,8 +1,9 @@
 // What is worth waking you for, and what the page is allowed to claim.
 //
 // Product-health alerting is probe-driven: `evaluateProductHealth` collects the
-// RED probes and those page. That already covers a pool under its floor, a
-// halted chain and a degraded money path — they are probes, so they alert.
+// RED probes and those page. A reward-bank floor breach is also pinned here as
+// an explicit money condition: the authoritative structured balance + floor
+// must page even if the surrounding probe taxonomy changes.
 //
 // One money signal is NOT a probe and therefore could never page: payout
 // evidence lives in the snapshot's `flow.payout` block. So the system could
@@ -33,26 +34,53 @@ export interface MoneyAlert {
 }
 
 /**
- * The money-blocking facts that no probe covers. PURE.
+ * The money-blocking facts allowed to page from structured snapshot evidence,
+ * independently of probe classification. PURE.
  *
- * Today that is exactly one: a payout shortfall. Pools, chain halt and money
- * path are already red probes and already page — repeating them here would
- * double-send, and two pages for one fact is its own kind of noise.
+ * Today these are a payout shortfall and an observed reward-bank floor breach.
+ * The latter deliberately repeats a probe-backed fact at the money boundary:
+ * payouts hard-stop when that pool empties, so future probe refactors must not
+ * silently remove its page. This remains alert-only; it never moves funds.
  */
 export function decideMoneyAlert(snapshot?: ProductHealthSnapshotBlocks): MoneyAlert {
-  const payout = snapshot?.flow?.payout;
-  if (!payout || payout.status !== "shortfall") {
-    // "unverified" deliberately lands here: it is not evidence of lost money.
-    return { lines: [], key: "" };
+  const lines: string[] = [];
+  const keys: string[] = [];
+
+  const rewardBank = snapshot?.solvency?.pools.find((pool) => pool.key === "reward_bank");
+  const liquid = rewardBank?.amount;
+  const floor = rewardBank?.floor;
+  if (
+    typeof liquid === "number"
+    && Number.isFinite(liquid)
+    && typeof floor === "number"
+    && Number.isFinite(floor)
+    && floor > 0
+    && liquid < floor
+  ) {
+    lines.push(
+      `• 🏦 reward bank floor breached: ${liquid.toFixed(2)} USDC liquid < ${floor.toFixed(2)} USDC floor — operator top-up required; no automatic refill`,
+    );
+    // The crossing is the event. Do not re-page on every payout while the bank
+    // remains below the same floor; the existing cooldown owns reminders.
+    keys.push(`reward-bank:below:${floor}`);
   }
-  const settled = payout.settledCount ?? null;
-  const confirmed = payout.confirmedCount ?? null;
-  const gap = settled !== null && confirmed !== null ? settled - confirmed : null;
-  return {
-    lines: [`• 💸 payout shortfall: ${payout.detail}`],
+
+  const payout = snapshot?.flow?.payout;
+  if (payout?.status === "shortfall") {
+    const settled = payout.settledCount ?? null;
+    const confirmed = payout.confirmedCount ?? null;
+    const gap = settled !== null && confirmed !== null ? settled - confirmed : null;
+    lines.push(`• 💸 payout shortfall: ${payout.detail}`);
     // Key on the SIZE of the gap, not the raw detail string: the detail carries
     // USDC totals that drift every cycle and would re-page on noise alone.
-    key: `payout:${gap ?? "unknown"}`,
+    keys.push(`payout:${gap ?? "unknown"}`);
+  }
+
+  // "unverified" deliberately contributes nothing: it is not evidence of lost
+  // money. The same absent-not-zero rule applies to an unreadable bank or floor.
+  return {
+    lines,
+    key: keys.join("|"),
   };
 }
 

--- a/test/unit/money-alert.test.ts
+++ b/test/unit/money-alert.test.ts
@@ -3,10 +3,27 @@ import { describe, expect, it } from "vitest";
 import { alertProvenance, decideMoneyAlert } from "../../services/slack-operator/src/money-alert.js";
 import type { ProductHealthSnapshotBlocks } from "../../services/slack-operator/src/product-health.js";
 
-function snap(payout?: Record<string, unknown>, self?: Record<string, unknown>): ProductHealthSnapshotBlocks {
+function snap(
+  payout?: Record<string, unknown>,
+  self?: Record<string, unknown>,
+  rewardBank?: { amount: number | null; floor?: number | null },
+): ProductHealthSnapshotBlocks {
   return {
     chainId: 420420419,
     ...(self ? { self: self as never } : {}),
+    ...(rewardBank
+      ? {
+          solvency: {
+            pools: [{
+              key: "reward_bank",
+              label: "Reward bank",
+              unit: "USDC",
+              status: "red",
+              ...rewardBank,
+            }],
+          },
+        }
+      : {}),
     ...(payout
       ? { flow: { settled24h: 14, payout: payout as never } }
       : {}),
@@ -67,6 +84,41 @@ describe("decideMoneyAlert", () => {
     const r = decideMoneyAlert(snap({ status: "shortfall", detail: "d", settledCount: null, confirmedCount: null }));
     expect(r.lines).toHaveLength(1);
     expect(r.key).toBe("payout:unknown");
+  });
+
+  it("pages when the authoritative reward-bank liquid balance breaches its floor", () => {
+    const r = decideMoneyAlert(snap(undefined, undefined, { amount: 0.32, floor: 2 }));
+    expect(r.lines).toEqual([
+      "• 🏦 reward bank floor breached: 0.32 USDC liquid < 2.00 USDC floor — operator top-up required; no automatic refill",
+    ]);
+    expect(r.key).toBe("reward-bank:below:2");
+  });
+
+  it("does not page at the floor, without a floor, or when liquid is unreadable", () => {
+    expect(decideMoneyAlert(snap(undefined, undefined, { amount: 2, floor: 2 })))
+      .toEqual({ lines: [], key: "" });
+    expect(decideMoneyAlert(snap(undefined, undefined, { amount: 0.32, floor: null })))
+      .toEqual({ lines: [], key: "" });
+    expect(decideMoneyAlert(snap(undefined, undefined, { amount: null, floor: 2 })))
+      .toEqual({ lines: [], key: "" });
+  });
+
+  it("keeps the floor-breach key stable as liquid drains, while a floor change re-pages", () => {
+    const first = decideMoneyAlert(snap(undefined, undefined, { amount: 0.32, floor: 2 }));
+    const lower = decideMoneyAlert(snap(undefined, undefined, { amount: 0.12, floor: 2 }));
+    const newFloor = decideMoneyAlert(snap(undefined, undefined, { amount: 0.12, floor: 3 }));
+    expect(lower.key).toBe(first.key);
+    expect(newFloor.key).not.toBe(first.key);
+  });
+
+  it("combines simultaneous reward-bank and payout failures into one money page", () => {
+    const r = decideMoneyAlert(snap(
+      { status: "shortfall", detail: "2 payouts missing", settledCount: 14, confirmedCount: 12 },
+      undefined,
+      { amount: 0.32, floor: 2 },
+    ));
+    expect(r.lines).toHaveLength(2);
+    expect(r.key).toBe("reward-bank:below:2|payout:2");
   });
 });
 

--- a/test/unit/product-health.test.ts
+++ b/test/unit/product-health.test.ts
@@ -2198,6 +2198,30 @@ describe("a payout shortfall pages even with every probe green", () => {
     expect(r.alert).toBe(false);
   });
 
+  it("a reward-bank floor breach reaches the page gate even with every probe green", () => {
+    const r = decideProductHealthAlert({
+      evaluation: green,
+      state: initialProductHealthAlertState(),
+      nowMs: 1_000,
+      cooldownMs: 60_000,
+      snapshot: {
+        chainId: 420420419,
+        solvency: {
+          pools: [{
+            key: "reward_bank",
+            label: "Reward bank",
+            amount: 0.32,
+            unit: "USDC",
+            floor: 2,
+            status: "red",
+          }],
+        },
+      },
+    });
+    expect(r.alert).toBe(true);
+    expect(r.state.lastRedKey).toBe("reward-bank:below:2");
+  });
+
   it("the page leads with money and stamps the monitor version", () => {
     const mixed = evaluateProductHealth([
       { name: "api_latency", status: "red", detail: "2100ms" },


### PR DESCRIPTION
## What changed
- extend the existing money-alert decision with the structured reward_bank liquid/floor reading
- page on a real liquid < floor crossing with explicit operator-top-up and no-auto-refill wording
- keep the de-dup key stable while the same breach drains, while floor changes and payout-gap changes re-page
- preserve absent/unreadable as unknown rather than substituting zero

## Why
The reward bank drained from 11.77 USDC to 0.32 USDC and no dedicated money page fired. The bank remains a deliberate hard cap; alerting a human is the remediation, not automatic replenishment.

## Checks
- npm run typecheck
- npm test: 201 files passed, 2,971 tests passed; 5 files / 37 tests intentionally skipped
- focused money-alert + page-gate tests: 209/209

## Surface
Slack operator alert decision and tests only. No platform backend, contracts, bank policy, auto-remediation, configuration, or deployment-secret changes.