### PR TITLE
B2: stop counting rejections as payout shortfall

### DIFF
--- a/packages/monitor-ui/src/components/mobile/MobileBoard.tsx
+++ b/packages/monitor-ui/src/components/mobile/MobileBoard.tsx
@@ -314,7 +314,11 @@ function FlowPanel({ health, emphasise, nowMs }: { health: ProductHealth; emphas
   const funnel = flowFunnel(health.flow);
   const evidence = payoutView(health.flow?.payout);
   const timing = lifecycleNote(health.lifecycle);
-  const mix = volumeMixNote({ lifecycle: health.lifecycle, settledCount: health.flow?.settled24h ?? null });
+  const mix = volumeMixNote({
+    lifecycle: health.lifecycle,
+    settledCount: health.flow?.paidSettled24h ?? null,
+    zeroPayCount: health.flow?.zeroPaySettled24h ?? null,
+  });
   const clock = disputeClockLine(health.externalFunnel, nowMs);
   return (
     <section

--- a/packages/monitor-ui/src/components/ops/FlowPanel.tsx
+++ b/packages/monitor-ui/src/components/ops/FlowPanel.tsx
@@ -43,10 +43,14 @@ export function FlowPanel({ flow, externalFunnel, lifecycle, nowMs }: FlowPanelP
   const clock = disputeClockLine(externalFunnel, nowMs ?? Date.now());
   // How long the funnel above actually takes, split by who posted the work.
   const timing = lifecycleNote(lifecycle);
-  // Reconciled against the LEDGER's settled count, not against itself — the
-  // split is read from the chain and the total from the product, and where
-  // they disagree that gap is the information.
-  const mix = volumeMixNote({ lifecycle, settledCount: flow?.settled24h ?? null });
+  // Reconcile chain-classified paid work only against payment-expected
+  // settlements. Deliberate zero-pay terminals stay visible but can never
+  // masquerade as unclassified paid work.
+  const mix = volumeMixNote({
+    lifecycle,
+    settledCount: flow?.paidSettled24h ?? null,
+    zeroPayCount: flow?.zeroPaySettled24h ?? null,
+  });
   const funnel = flowFunnel(flow);
   const evidence = payoutView(flow?.payout);
   const provenance = payoutProvenanceLine(flow?.payout);

--- a/packages/monitor-ui/src/components/ops/OpsBoard.test.tsx
+++ b/packages/monitor-ui/src/components/ops/OpsBoard.test.tsx
@@ -178,7 +178,8 @@ describe("OpsBoard — payout evidence", () => {
     const evidence = getByTestId("ops-evidence");
     expect(getByTestId("ops-evidence-status").textContent).toBe("CONFIRMED");
     expect(evidence.textContent).toContain("14 payouts confirmed on-chain");
-    expect(evidence.textContent).toContain("14 marked settled");
+    expect(evidence.textContent).toContain("14 expected payment");
+    expect(evidence.textContent).toContain("zero-pay settlement count unavailable");
     expect(evidence.getAttribute("data-emphasis")).toBe("off");
   });
 
@@ -191,7 +192,7 @@ describe("OpsBoard — payout evidence", () => {
     expect(within(flow).getAllByText("9").length).toBe(3); // claimed / submitted / settled
     expect(getByTestId("ops-evidence-status").textContent).toBe("SHORTFALL −2");
     expect(getByTestId("ops-evidence").textContent).toContain(
-      "2 settled jobs have no on-chain proof",
+      "2 jobs expected payment but have no on-chain proof",
     );
     expect(flow.textContent).toContain("evidence below disagrees");
   });

--- a/packages/monitor-ui/src/lib/monitor/ops-spec.test.ts
+++ b/packages/monitor-ui/src/lib/monitor/ops-spec.test.ts
@@ -383,6 +383,24 @@ describe("volumeMixNote — self-generated volume must not read as demand", () =
     expect(volumeMixNote({ lifecycle: lifecycle(18, 0), settledCount: 18 })!.tone).toBe("awaiting");
   });
 
+  test("zero-pay rejections stay visible without becoming unclassified paid work", () => {
+    const v = volumeMixNote({
+      lifecycle: lifecycle(12, 0),
+      settledCount: 12,
+      zeroPayCount: 5,
+    })!;
+
+    expect(v.text).toBe("17 settled — 12 posted by Averray · 0 external · 5 settled with zero payout (rejected)");
+    expect(v.text).not.toContain("unclassified");
+    expect(v.tone).toBe("awaiting");
+  });
+
+  test("a pre-split backend invents neither zero-pay volume nor an alarm", () => {
+    const v = volumeMixNote({ lifecycle: lifecycle(12, 0), settledCount: null })!;
+    expect(v.text).toBe("12 settled — 12 posted by Averray · 0 external");
+    expect(v.tone).toBe("awaiting");
+  });
+
   test("no lifecycle, no line — rather than a line claiming zero of everything", () => {
     expect(volumeMixNote({ lifecycle: undefined, settledCount: 18 })).toBeNull();
   });
@@ -475,7 +493,7 @@ describe("CONFIRMED says what it actually confirmed", () => {
     // with 15 and 16 on the row above it.
     const view = payoutView({ ...base, confirmedCount: 15, settledCount: 16 });
     expect(view.delta).not.toContain("no gap");
-    expect(view.delta).toContain("1 settled job not yet proven on-chain");
+    expect(view.delta).toContain("1 payment-expected job not yet proven on-chain");
     expect(view.delta).toContain("not a shortfall");
     // Still sage, still unemphasised: the tolerance exists because a job on the
     // window edge is expected, and paging for it would be a false red.
@@ -562,15 +580,18 @@ describe("payoutView — instrument broken vs money broken", () => {
     const view = payoutView({
       status: "shortfall",
       detail: "",
-      confirmedCount: 12,
+      confirmedCount: 9,
       confirmedUsdc: 1.44,
-      settledCount: 14,
+      settledCount: 12,
+      zeroPayCount: 5,
       windowBlocks: 43200,
     });
     expect(view.tone).toBe("red");
     expect(view.emphasised).toBe(true);
-    expect(view.status).toBe("SHORTFALL −2");
-    expect(view.delta).toMatch(/2 settled jobs have no on-chain proof/);
+    expect(view.status).toBe("SHORTFALL −3");
+    expect(view.line2).toContain("17 settled — 12 expected payment");
+    expect(view.line2).toContain("5 settled with zero payout (rejected)");
+    expect(view.delta).toMatch(/3 jobs expected payment but have no on-chain proof/);
   });
 
   test("no payout block at all is unverified, never confirmed", () => {
@@ -583,13 +604,15 @@ describe("payoutView — instrument broken vs money broken", () => {
     const view = payoutView({
       status: "confirmed",
       detail: "",
-      confirmedCount: 14,
+      confirmedCount: 12,
       confirmedUsdc: 1.7,
-      settledCount: 14,
+      settledCount: 12,
+      zeroPayCount: 5,
       windowBlocks: 43200,
     });
-    expect(view.line1).toContain("14 payouts confirmed on-chain");
-    expect(view.line2).toContain("14 marked settled");
+    expect(view.line1).toContain("12 payouts confirmed on-chain");
+    expect(view.line2).toContain("17 settled — 12 expected payment");
+    expect(view.line2).toContain("5 settled with zero payout (rejected)");
   });
 });
 

--- a/packages/monitor-ui/src/lib/monitor/ops-spec.ts
+++ b/packages/monitor-ui/src/lib/monitor/ops-spec.ts
@@ -578,10 +578,7 @@ export function payoutView(payout: PayoutEvidence | undefined): EvidenceView {
       : `${payout.confirmedCount} payout${payout.confirmedCount === 1 ? "" : "s"} confirmed on-chain${
           payout.confirmedUsdc == null ? "" : ` · ${formatAmount(payout.confirmedUsdc)} USDC`
         }${feeNote(payout)}`;
-  const ledgerLine =
-    payout.settledCount == null
-      ? "settled count unavailable"
-      : `${payout.settledCount} marked settled by the monitor`;
+  const ledgerLine = payoutExpectationLine(payout);
   const fit = windowFitLine(payout);
 
   // ── A DISAGREEMENT OUTRANKS BOTH VERDICTS ────────────────────────────────
@@ -615,7 +612,7 @@ export function payoutView(payout: PayoutEvidence | undefined): EvidenceView {
       tone: "red",
       line1: chainLine,
       line2: ledgerLine,
-      delta: `${gap.replace("−", "")} settled jobs have no on-chain proof — money did not move`,
+      delta: `${gap.replace("−", "")} jobs expected payment but have no on-chain proof — money did not move`,
       fit,
       emphasised: true,
     };
@@ -646,6 +643,15 @@ export function payoutView(payout: PayoutEvidence | undefined): EvidenceView {
   };
 }
 
+function payoutExpectationLine(payout: PayoutEvidence): string {
+  if (payout.settledCount == null) return "payment-expected settlement count unavailable";
+  if (payout.zeroPayCount == null) {
+    return `${payout.settledCount} expected payment · zero-pay settlement count unavailable`;
+  }
+  const totalSettled = payout.settledCount + payout.zeroPayCount;
+  return `${totalSettled} settled — ${payout.settledCount} expected payment · ${payout.zeroPayCount} settled with zero payout (rejected)`;
+}
+
 /**
  * What CONFIRMED actually means, given the numbers printed beside it.
  *
@@ -672,7 +678,7 @@ function confirmedDelta(payout: PayoutEvidence): string {
   const gap = settledCount - confirmedCount;
   if (gap === 0) return "proof matches ledger — no gap";
   if (gap > 0) {
-    return `${gap} settled job${gap === 1 ? "" : "s"} not yet proven on-chain — inside the boundary tolerance, not a shortfall`;
+    return `${gap} payment-expected job${gap === 1 ? "" : "s"} not yet proven on-chain — inside the boundary tolerance, not a shortfall`;
   }
   // More proof than ledger: normal at a window edge, where the chain read
   // reaches back slightly further than the 24h settled count.
@@ -1050,10 +1056,11 @@ export function lifecycleNote(
  *
  * ── IT RECONCILES, OR IT SAYS IT DOESN'T ──────────────────────────────────
  *
- * The parts must sum to the ledger's settled count. They come from different
- * instruments — the split is read from the CHAIN (a fee-bearing settlement is
- * an external bounty; a fee-waived one is Averray's own), the total from the
- * product's own ledger — so they can disagree, and the difference is real
+ * The chain-classified parts must sum to the ledger's payment-expected count.
+ * Deliberate zero-pay terminals are a separate visible part of the total. The
+ * split is read from the CHAIN (a fee-bearing settlement is an external bounty;
+ * a fee-waived one is Averray's own), while the expected/zero-pay counts come
+ * from the product ledger — so they can disagree, and the difference is real
  * information rather than a rounding nuisance.
  *
  * A job the chain read did not see is `unclassified`. It is never folded into
@@ -1072,8 +1079,10 @@ export function lifecycleNote(
  */
 export function volumeMixNote(input: {
   lifecycle: LifecycleView | undefined;
-  /** The product's own settled count — the total the parts must reconcile to. */
+  /** The product's payout-expected settled count — the classified parts reconcile to this. */
   settledCount: number | null | undefined;
+  /** Deliberate zero-pay terminals, visible but excluded from unclassified paid work. */
+  zeroPayCount?: number | null | undefined;
   /**
    * Gap treated as the expected window-edge artifact rather than a fault.
    *
@@ -1093,17 +1102,20 @@ export function volumeMixNote(input: {
   const self = lifecycle.selfPosted.count;
   const external = lifecycle.external.count;
   const classified = self + external;
-  if (classified === 0 && !input.settledCount) return null;
+  const zeroPay = input.zeroPayCount ?? 0;
+  if (classified === 0 && !input.settledCount && zeroPay === 0) return null;
 
-  const total = input.settledCount ?? classified;
+  const paidTotal = input.settledCount ?? classified;
+  const total = paidTotal + zeroPay;
   const parts = [
     // Spelled out rather than "self-posted": the whole point of the line is
     // that a reader who knows nothing about the system cannot mistake it.
     `${self} posted by Averray`,
     `${external} external`,
   ];
+  if (zeroPay > 0) parts.push(`${zeroPay} settled with zero payout (rejected)`);
 
-  const gap = total - classified;
+  const gap = paidTotal - classified;
   const tolerance = input.edgeTolerance ?? 1;
   let tone: OpsTone = "awaiting";
   if (gap > 0) {

--- a/packages/monitor-ui/src/lib/monitor/product-health.ts
+++ b/packages/monitor-ui/src/lib/monitor/product-health.ts
@@ -155,6 +155,8 @@ export interface MoneyPathSnapshot {
   /** Current submissions not yet settled; sustained nonzero is a backlog. */
   submittedNotSettled?: number | null;
   settled24h?: number | null;
+  paidSettled24h?: number | null;
+  zeroPaySettled24h?: number | null;
   stuck?: number | null;
   failed24h?: number | null;
   /** Epoch ms of the settlement snapshot. */
@@ -166,11 +168,11 @@ export interface MoneyPathSnapshot {
 /**
  * Evidence that rewards were actually PAID, not merely marked settled.
  *
- * The funnel counts above are job-state rows from the product's own database —
- * "9 rows say settled". That is not proof any money moved. `payout` counts
- * `ReservationSettled` logs straight off the chain, so the two numbers come
- * from independent sources and THE DISCREPANCY IS THE SIGNAL. The board renders
- * them side by side and shows the contradiction rather than averaging it away.
+ * `paidSettled24h` is the product ledger's payment-expected terminal count; it
+ * is not proof any money moved. `payout` counts `ReservationSettled` logs
+ * straight off the chain, so the two numbers come from independent sources and
+ * THE DISCREPANCY IS THE SIGNAL. Deliberate zero-pay terminals remain visible
+ * beside the comparison and never enter it.
  *
  * The three statuses are NOT a severity ramp, and the UI must never draw them
  * as one:
@@ -187,8 +189,10 @@ export interface PayoutEvidence {
   confirmedCount: number | null;
   /** Summed USDC actually transferred; null = unverified. */
   confirmedUsdc: number | null;
-  /** The product's own settled count, for the comparison. */
+  /** The product's payout-expected settled count, for the comparison. */
   settledCount: number | null;
+  /** Deliberate zero-pay terminals; displayed but never subtracted from proof. */
+  zeroPayCount?: number | null;
   /** Blocks scanned. The window is approximate — the verdict allows for it. */
   windowBlocks: number | null;
   /** Does the block window actually span the period being compared? */

--- a/packages/schemas/src/ops-verdict.ts
+++ b/packages/schemas/src/ops-verdict.ts
@@ -52,7 +52,9 @@ export interface VerdictPool {
 export interface VerdictPayout {
   status: "confirmed" | "shortfall" | "unverified";
   confirmedCount: number | null;
+  /** Payment-expected terminals only; zero-pay terminals never enter the gap. */
   settledCount: number | null;
+  zeroPayCount?: number | null;
 }
 
 /**

--- a/services/slack-operator/src/product-health.ts
+++ b/services/slack-operator/src/product-health.ts
@@ -869,6 +869,8 @@ export interface ProductHealthPayload {
     claimedNotSubmitted?: number;
     submittedNotSettled?: number;
     settled24h?: number;
+    paidSettled24h?: number;
+    zeroPaySettled24h?: number;
     stuck?: number;
     failed24h?: number;
     asOf?: string;
@@ -1478,7 +1480,7 @@ async function ethRpc(
  * recipient is checked here, and fees are reported separately rather than
  * folded into the payout total.
  */
-/** settled24h is a rolling 24h count, so that is what the window must span. */
+/** paidSettled24h is a rolling 24h count, so that is what the window must span. */
 const PAYOUT_COMPARISON_HOURS = 24;
 /** Blocks sampled to measure block time — long enough to smooth jitter. */
 const PAYOUT_BLOCK_TIME_SAMPLE = 2000;
@@ -1502,13 +1504,11 @@ function dataWord(data: unknown, index: number): string | undefined {
  * The payout verdict. PURE — the tolerance reasoning is the delicate part, so
  * it's testable without a chain.
  *
- * The two counts come from different clocks: `settled24h` is the product's
- * rolling 24h, the log read is an approximate block window. A small mismatch is
- * a boundary artifact, not a lost payout, so a shortfall inside `tolerance` is
- * still "confirmed" — crying wolf on an off-by-one would train the operator to
- * ignore the one that matters. A material shortfall is reported honestly but
- * NOT as red: the window really is approximate, and "investigate" is the true
- * instruction, not "settlement is down".
+ * The two counts come from different clocks: `paidSettled24h` is the product's
+ * rolling 24h payment-expected count, while the log read is an approximate
+ * block window. A small mismatch is a boundary artifact, not a lost payout, so
+ * a shortfall inside `tolerance` is still "confirmed" — crying wolf on an
+ * off-by-one would train the operator to ignore the one that matters.
  */
 /** How far the real span may drift from the target before we distrust it. */
 const WINDOW_FIT_TOLERANCE = 0.2;
@@ -1636,7 +1636,10 @@ async function blockTimestamp(rpcUrl: string, block: number, fetchImpl: typeof f
 export function decidePayoutEvidence(input: {
   confirmedCount: number | null;
   confirmedUsdc: number | null;
+  /** Terminal sessions for which payment is expected. */
   settledCount: number | null;
+  /** Terminal sessions which intentionally released no worker payout. */
+  zeroPayCount?: number | null;
   windowBlocks: number | null;
   tolerance: number;
   unverifiedReason?: string;
@@ -1647,6 +1650,7 @@ export function decidePayoutEvidence(input: {
     confirmedCount: input.confirmedCount,
     confirmedUsdc: input.confirmedUsdc,
     settledCount: input.settledCount,
+    zeroPayCount: input.zeroPayCount ?? null,
     windowBlocks: input.windowBlocks,
     ...(input.window ? { window: input.window } : {}),
   };
@@ -1661,9 +1665,16 @@ export function decidePayoutEvidence(input: {
     input.confirmedUsdc !== null ? ` (${input.confirmedUsdc.toFixed(2)} USDC)` : ""
   }`;
   if (input.settledCount === null) {
-    // Real evidence, nothing to compare it against — say exactly that.
-    return { ...base, status: "confirmed", detail: `${paid} · no settled count to compare` };
+    // An older backend cannot distinguish payment-expected terminals from
+    // deliberate zero-pay rejections. Never fall back to the old total-terminal
+    // arithmetic: the independent read remains real, but the comparison is not.
+    return {
+      ...base,
+      status: "unverified",
+      detail: `${paid} · payment-expected settlement count unavailable`,
+    };
   }
+  const ledger = payoutExpectationDetail(input.settledCount, input.zeroPayCount);
   // A 100% miss is overwhelmingly a MISCONFIGURED FILTER, not 100% payout
   // failure: point this at the wrong address or topic and you observe exactly
   // zero events, which is indistinguishable from total failure. That is not
@@ -1679,7 +1690,7 @@ export function decidePayoutEvidence(input: {
     return {
       ...base,
       status: "unverified",
-      detail: `no payout events found on the configured payout contract while ${input.settledCount} job${input.settledCount === 1 ? " is" : "s are"} marked settled — check the contract address and event topic before suspecting the payouts`,
+      detail: `no payout events found on the configured payout contract while ${ledger} — check the contract address and event topic before suspecting the payouts`,
     };
   }
   const shortfall = input.settledCount - input.confirmedCount;
@@ -1700,10 +1711,18 @@ export function decidePayoutEvidence(input: {
     return {
       ...base,
       status: "shortfall",
-      detail: `${input.settledCount} jobs marked settled but only ${paid} — ${shortfall} unaccounted for; windows are approximate, investigate`,
+      detail: `${paid} · ${ledger} · ${shortfall} job${shortfall === 1 ? " was" : "s were"} approved and released value on our ledger with no on-chain proof; windows are approximate, investigate`,
     };
   }
-  return { ...base, status: "confirmed", detail: `${paid} · ${input.settledCount} marked settled` };
+  return { ...base, status: "confirmed", detail: `${paid} · ${ledger}` };
+}
+
+function payoutExpectationDetail(paidSettledCount: number, zeroPayCount: number | null | undefined): string {
+  if (zeroPayCount === null || zeroPayCount === undefined) {
+    return `${paidSettledCount} expected payment · zero-pay settlement count unavailable`;
+  }
+  const totalSettledCount = paidSettledCount + zeroPayCount;
+  return `${totalSettledCount} settled — ${paidSettledCount} expected payment · ${zeroPayCount} settled with zero payout (rejected)`;
 }
 
 /**
@@ -2452,6 +2471,8 @@ export interface MoneyPathData {
   claimedNotSubmitted?: number | null;
   submittedNotSettled?: number | null;
   settled24h?: number | null;
+  paidSettled24h?: number | null;
+  zeroPaySettled24h?: number | null;
   stuck?: number | null;
   failed24h?: number | null;
   asOf?: number | null;
@@ -2462,12 +2483,11 @@ export interface MoneyPathData {
 /**
  * Evidence that rewards were actually PAID, not merely marked settled.
  *
- * `settled24h` and friends are job-state counts from the product's own
- * database — "13 rows say settled". That is not proof any money moved. This
- * reads USDC Transfer logs FROM the signer straight off the chain, so the two
- * numbers come from independent sources, and THE DISCREPANCY IS THE SIGNAL:
- * matching → genuinely paid; fewer transfers than settled jobs → jobs marked
- * settled that never paid, which nothing else on the board can currently see.
+ * `paidSettled24h` is the product ledger's count of terminal sessions expected
+ * to pay. That is not proof any money moved. This reads settlement logs straight
+ * off the chain, so the two numbers come from independent sources, and THE
+ * DISCREPANCY IS THE SIGNAL. `zeroPaySettled24h` is carried alongside for
+ * visibility and never enters the subtraction.
  *
  * `confirmedCount: null` means UNVERIFIED (disabled, unconfigured, or the log
  * read failed). It never falls back to inferring payment from job state.
@@ -2479,8 +2499,10 @@ export interface PayoutEvidence {
   confirmedCount: number | null;
   /** Summed USDC actually transferred; null = unverified. */
   confirmedUsdc: number | null;
-  /** The product's own settled count, for the comparison. */
+  /** The product's payout-expected settled count, for the comparison. */
   settledCount: number | null;
+  /** Deliberate zero-pay terminals; displayed but never subtracted from proof. */
+  zeroPayCount?: number | null;
   /** Blocks scanned. The window is approximate — the verdict allows for it. */
   windowBlocks: number | null;
   /** Does the block window actually span what it is compared against? */
@@ -2891,7 +2913,8 @@ export async function collectProductHealthProbes(
     decidePayoutEvidence({
       confirmedCount: payoutRead.count,
       confirmedUsdc: payoutRead.usdc,
-      settledCount: settlement?.settled24h ?? null,
+      settledCount: settlement?.paidSettled24h ?? null,
+      zeroPayCount: settlement?.zeroPaySettled24h ?? null,
       windowBlocks: payoutRead.windowBlocks,
       tolerance: config.payoutTolerance,
       ...(payoutRead.reason ? { unverifiedReason: payoutRead.reason } : {}),
@@ -3043,6 +3066,8 @@ export async function collectProductHealthProbes(
             claimedNotSubmitted: settlement.claimedNotSubmitted ?? null,
             submittedNotSettled: settlement.submittedNotSettled ?? null,
             settled24h: settlement.settled24h ?? null,
+            paidSettled24h: settlement.paidSettled24h ?? null,
+            zeroPaySettled24h: settlement.zeroPaySettled24h ?? null,
             stuck: settlement.stuck ?? null,
             failed24h: settlement.failed24h ?? null,
             asOf: parseHealthAsOf(settlement.asOf),

--- a/test/unit/product-health.test.ts
+++ b/test/unit/product-health.test.ts
@@ -1024,6 +1024,8 @@ describe("collectProductHealthProbes (hybrid: /health chain + RPC balances)", ()
             claimedNotSubmitted: 2,
             submittedNotSettled: 1,
             settled24h: 37,
+            paidSettled24h: 32,
+            zeroPaySettled24h: 5,
             stuck: 1,
             failed24h: 0,
             asOf: "2026-07-05T00:00:00.000Z",
@@ -1045,6 +1047,8 @@ describe("collectProductHealthProbes (hybrid: /health chain + RPC balances)", ()
     expect(snapshot.flow?.claimedNotSubmitted).toBe(2);
     expect(snapshot.flow?.submittedNotSettled).toBe(1);
     expect(snapshot.flow?.settled24h).toBe(37);
+    expect(snapshot.flow?.paidSettled24h).toBe(32);
+    expect(snapshot.flow?.zeroPaySettled24h).toBe(5);
     expect(snapshot.flow?.stuck).toBe(1);
   });
 
@@ -1745,12 +1749,12 @@ describe("decidePayoutEvidence (pure verdict)", () => {
     expect(r.detail).toContain("4.20 USDC");
   });
 
-  it("SHORTFALL when jobs are marked settled but the money never moved", () => {
+  it("SHORTFALL when payment-expected jobs have no payout proof", () => {
     // The failure nothing else on the board can see today.
     const r = decidePayoutEvidence({ ...base, confirmedCount: 9, confirmedUsdc: 2.7, settledCount: 13 });
     expect(r.status).toBe("shortfall");
-    expect(r.detail).toContain("13 jobs marked settled");
-    expect(r.detail).toContain("4 unaccounted for");
+    expect(r.detail).toContain("13 expected payment");
+    expect(r.detail).toContain("4 jobs were approved");
     expect(r.detail).toContain("investigate");
   });
 
@@ -1775,10 +1779,38 @@ describe("decidePayoutEvidence (pure verdict)", () => {
     expect(r.confirmedCount).toBeNull(); // never 0 — 0 would read as "nothing paid"
   });
 
-  it("reports real evidence even with nothing to compare against", () => {
+  it("falls back to UNVERIFIED when the backend lacks paidSettled24h", () => {
     const r = decidePayoutEvidence({ ...base, confirmedCount: 3, confirmedUsdc: 1.5, settledCount: null });
+    expect(r.status).toBe("unverified");
+    expect(r.detail).toContain("payment-expected settlement count unavailable");
+  });
+
+  it("displays zero-pay terminals but never subtracts them from payout proof", () => {
+    const r = decidePayoutEvidence({
+      ...base,
+      confirmedCount: 12,
+      confirmedUsdc: 3,
+      settledCount: 12,
+      zeroPayCount: 5,
+    });
+
     expect(r.status).toBe("confirmed");
-    expect(r.detail).toContain("no settled count to compare");
+    expect(r.detail).toContain("17 settled — 12 expected payment");
+    expect(r.detail).toContain("5 settled with zero payout (rejected)");
+  });
+
+  it("counts a real shortfall from payment-expected jobs only", () => {
+    const r = decidePayoutEvidence({
+      ...base,
+      confirmedCount: 9,
+      confirmedUsdc: 2.25,
+      settledCount: 12,
+      zeroPayCount: 5,
+    });
+
+    expect(r.status).toBe("shortfall");
+    expect(r.detail).toContain("3 jobs were approved");
+    expect(r.detail).not.toContain("8 jobs were approved");
   });
 });
 
@@ -2034,7 +2066,7 @@ describe("decidePayoutEvidence — a 100% miss is a broken filter, not lost mone
   it("but ONE observed transfer proves the filter works — then a shortfall is trustworthy", () => {
     const r = decidePayoutEvidence({ ...base, confirmedCount: 1, confirmedUsdc: 0.3, settledCount: 12 });
     expect(r.status).toBe("shortfall");
-    expect(r.detail).toContain("11 unaccounted for");
+    expect(r.detail).toContain("11 jobs were approved");
   });
 
   it("zero settled AND zero confirmed is a quiet period, not an alarm", () => {


### PR DESCRIPTION
## What changed

- compares on-chain payout proofs only with the backend's `paidSettled24h`; an older backend without that split is `unverified`, never the legacy false-shortfall arithmetic
- carries `zeroPaySettled24h` separately through the monitor payload and displays it in a neutral “settled with zero payout” line
- fixes both volume-mix render paths so zero-pay rejections remain visible but cannot become degraded `unclassified` paid work
- preserves `settled24h` as the total lifecycle-throughput figure and leaves gas cost-per-lifecycle unchanged

Review head: `af7232f9f82f0da053bbff40b76418a0627be04d`

## Acceptance evidence

- Pre-B1 compatibility: a fixture with no `paidSettled24h` returns `status: "unverified"`; it does not fall back to total-terminal arithmetic.
- Zero-pay exclusion: `12` payment-expected + `5` zero-pay with `12` confirmed renders `17 settled — 12 expected payment · 5 settled with zero payout (rejected)` and remains confirmed.
- Real shortfall: the same ledger split with `9` confirmed renders `SHORTFALL −3`, `emphasised: true`; the five zero-pay terminals never inflate it to eight.
- Second call site: the volume-mix fixture with five rejections has no `unclassified` text and remains neutral, while still displaying all five zero-pay terminals.
- Both desktop and mobile flow panels consume the split fields; a pre-split backend invents neither zero-pay volume nor an amber gap.

Checks:

```text
npm run typecheck
passed

npx vitest run test/unit/product-health.test.ts \
  packages/monitor-ui/src/lib/monitor/ops-spec.test.ts \
  packages/monitor-ui/src/components/ops/OpsBoard.test.tsx \
  packages/schemas/src/ops-verdict.test.ts \
  test/unit/money-alert.test.ts
355 passed, 0 failed
```

`npm test` was also run: 2,972 tests passed and 37 skipped. The remaining two INT-4 test cases failed because their nested runner expects `node_modules/vitest/vitest.mjs` physically inside the worktree, while this checkout resolves dependencies from the primary repo; this is an instrument-path issue outside B2. The two B2-stale OpsBoard assertions found by that run were corrected and their suite is included in the 355/355 evidence above.

## Surfaces and rollout

- Affects slack-operator product-health comparison, monitor UI, and shared verdict typing/tests.
- No ops, compose, database, secrets/config, MCP mutation, or deployment changes.
- Independently mergeable before B1 deploys: absence of the additive backend fields degrades to `unverified`/neutral. Once B1 is live, the split appears automatically.
- Rollback: revert this PR; no stored data or migration is involved.
