### PR TITLE
Display HTTP arrivals as an independent front door

### DIFF
--- a/packages/monitor-ui/src/components/ops/ArrivalsPanel.test.tsx
+++ b/packages/monitor-ui/src/components/ops/ArrivalsPanel.test.tsx
@@ -51,6 +51,32 @@ const arrivals: ArrivalsSnapshot = {
   clients: [],
 };
 
+const arrivalsWithHttp: ArrivalsSnapshot = {
+  ...arrivals,
+  funnelHttp: {
+    reached: 13, browsed: 8, evaluated: 5, identified: 3, authenticated: 2, claimed: 1, submitted: 1,
+  },
+  funnelHttpExternal: {
+    reached: 7, browsed: 4, evaluated: 2, identified: 1, authenticated: 1, claimed: 1, submitted: 1,
+  },
+  funnelHttpSelf: {
+    reached: 2, browsed: 2, evaluated: 1, identified: 1, authenticated: 1, claimed: 0, submitted: 0,
+  },
+  funnelHttpAmbiguous: {
+    reached: 1, browsed: 1, evaluated: 1, identified: 0, authenticated: 0, claimed: 0, submitted: 0,
+  },
+  attributionSourceTotals: {
+    mcp: { siwe_wallet: 3, client_name: 4, ip_only: 9 },
+    http: { siwe_wallet: 17, client_name: 6, ip_only: 41 },
+  },
+  httpCutover: {
+    atMs: 1_786_200_000_000,
+    at: "2026-08-09T01:20:00.000Z",
+    backfilled: false,
+    note: "HTTP arrivals are measured from this cut-over only; earlier HTTP traffic was not backfilled.",
+  },
+};
+
 describe("ArrivalsPanel", () => {
   // The headline is what an outsider did. Our own probes reach the same door
   // and were once added to these bars, which is how this panel came to say
@@ -165,6 +191,54 @@ describe("ArrivalsPanel", () => {
   test("an older product-health payload is also a named non-reading", () => {
     const { getByTestId } = render(<ArrivalsPanel arrivals={undefined} />);
     expect(getByTestId("ops-arrivals-unreachable").textContent).toContain("feed not present");
+  });
+
+  test("a pre-cut-over snapshot renders MCP normally and makes no HTTP zero claim", () => {
+    const { getByTestId, queryByTestId, queryAllByTestId } = render(<ArrivalsPanel arrivals={arrivals} />);
+
+    expect(getByTestId("ops-arrival-stage-browsed").querySelector("strong")?.textContent).toBe("10");
+    expect(queryByTestId("ops-arrivals-unreachable")).toBeNull();
+    expect(queryByTestId("ops-arrivals-door-http")).toBeNull();
+    expect(queryAllByTestId(/^ops-arrival-http-stage-/)).toHaveLength(0);
+  });
+});
+
+describe("ArrivalsPanel — independent HTTP front door", () => {
+  test("shows the measured HTTP series beside MCP without a combined headline", () => {
+    const { getByTestId, queryByText } = render(<ArrivalsPanel arrivals={arrivalsWithHttp} />);
+
+    expect(getByTestId("ops-arrivals-door-mcp")).toBeTruthy();
+    expect(getByTestId("ops-arrivals-door-http")).toBeTruthy();
+    expect(getByTestId("ops-arrival-stage-reached").querySelector("strong")?.textContent).toBe("20");
+    expect(getByTestId("ops-arrival-http-stage-reached").querySelector("strong")?.textContent).toBe("7");
+    expect(getByTestId("ops-arrival-http-self-browsed").textContent).toBe("+2");
+    expect(getByTestId("ops-arrival-http-ambiguous-browsed").textContent).toBe("?1");
+    expect(queryByText(/combined/i)).toBeNull();
+    expect(getByTestId("ops-arrivals").textContent).not.toContain("27");
+  });
+
+  test("promotes SIWE wallet attribution rather than the inferred IP count", () => {
+    const { getByTestId } = render(<ArrivalsPanel arrivals={arrivalsWithHttp} />);
+    const measured = getByTestId("ops-arrivals-http-measured");
+
+    expect(measured.textContent).toContain("MEASURED (SIWE WALLET)");
+    expect(measured.querySelector("strong")?.textContent).toBe("17");
+    expect(measured.textContent).not.toContain("41");
+  });
+
+  test("renders the producer's cut-over note verbatim and names recovered blindness", () => {
+    const { getByTestId } = render(<ArrivalsPanel arrivals={arrivalsWithHttp} />);
+    const cutover = getByTestId("ops-arrivals-http-cutover");
+
+    expect(cutover.querySelectorAll("p")[0]?.textContent).toBe(arrivalsWithHttp.httpCutover?.note);
+    expect(cutover.textContent).toContain("a larger number here is recovered blindness, not growth.");
+  });
+
+  test("keeps the existing furthest-stage reading on the MCP distinct shape", () => {
+    const { getByTestId } = render(<ArrivalsPanel arrivals={arrivalsWithHttp} />);
+
+    expect(getByTestId("ops-arrivals-furthest").textContent).toContain("authenticated");
+    expect(getByTestId("ops-arrivals-furthest").textContent).not.toContain("submitted");
   });
 });
 

--- a/packages/monitor-ui/src/components/ops/ArrivalsPanel.tsx
+++ b/packages/monitor-ui/src/components/ops/ArrivalsPanel.tsx
@@ -1,4 +1,4 @@
-// ARRIVALS — who has actually crossed the public MCP front door, and how far.
+// ARRIVALS — who has actually crossed either public front door, and how far.
 //
 // The platform owns these counts. This component only renders its versioned
 // snapshot; it never infers a later stage from calls or client names. Most
@@ -34,9 +34,9 @@ export interface ArrivalsPanelProps {
 export function ArrivalsPanel({ arrivals }: ArrivalsPanelProps) {
   if (!arrivals || "unavailable" in arrivals) {
     return (
-      <section className="ops-arrivals" aria-label="Arrivals — MCP front door" data-testid="ops-arrivals">
+      <section className="ops-arrivals" aria-label="Arrivals — public front doors" data-testid="ops-arrivals">
         <header className="ops-panel-head">
-          <h2 className="ops-panel-title">ARRIVALS — MCP FRONT DOOR</h2>
+          <h2 className="ops-panel-title">ARRIVALS — PUBLIC FRONT DOORS</h2>
         </header>
         <p className="ops-arrivals-unreachable" data-tone="awaiting" role="status" data-testid="ops-arrivals-unreachable">
           <strong>UNREACHABLE</strong> — {arrivals?.unavailable ?? "feed not present in this product-health snapshot"}
@@ -53,6 +53,16 @@ export function ArrivalsPanel({ arrivals }: ArrivalsPanelProps) {
   // different thing from a platform reporting none — so the column appears
   // only when there is actually a reading behind it.
   const ambiguousCounts = arrivals.funnelAmbiguous;
+  const hasHttpReading =
+    arrivals.funnelHttp !== undefined ||
+    arrivals.funnelHttpExternal !== undefined ||
+    arrivals.funnelHttpSelf !== undefined ||
+    arrivals.funnelHttpAmbiguous !== undefined ||
+    arrivals.attributionSourceTotals !== undefined ||
+    arrivals.httpCutover !== undefined;
+  const httpPeak = arrivals.funnelHttpExternal
+    ? Math.max(1, ...ARRIVAL_STAGES.map((stage) => arrivals.funnelHttpExternal?.[stage] ?? 0))
+    : 1;
   // Calls the platform counted before it split the funnel. Their actor was
   // never recorded and cannot be recovered, so they sit in none of the
   // columns. They have to be named: the furthest-stage figures come from the
@@ -63,6 +73,9 @@ export function ArrivalsPanel({ arrivals }: ArrivalsPanelProps) {
   // Ambiguous calls are subtracted here too. They are unattributed in the
   // ordinary sense, but they do NOT predate the split — saying so on screen
   // would be a false explanation of a real number.
+  // `funnel` is MCP-only. Keep this subtraction pinned to that door: folding
+  // HTTP into it would relabel newly recovered HTTP visibility as old,
+  // unattributed MCP history.
   const unattributed = ARRIVAL_STAGES.reduce(
     (total, stage) =>
       total +
@@ -74,104 +87,167 @@ export function ArrivalsPanel({ arrivals }: ArrivalsPanelProps) {
   );
 
   return (
-    <section className="ops-arrivals" aria-label="Arrivals — MCP front door" data-testid="ops-arrivals">
+    <section className="ops-arrivals" aria-label="Arrivals — public front doors" data-testid="ops-arrivals">
       <header className="ops-panel-head">
-        <h2 className="ops-panel-title">ARRIVALS — MCP FRONT DOOR</h2>
+        <h2 className="ops-panel-title">ARRIVALS — PUBLIC FRONT DOORS</h2>
         <span className="ops-panel-note">
-          reached → submitted · outsiders, with ours and the unclaimable counted apart
+          reached → submitted · two independent series · outsiders, ours and the unclaimable kept apart
         </span>
       </header>
 
-      <ol className="ops-arrivals-funnel" aria-label="Arrival funnel, reached through submitted">
-        {ARRIVAL_STAGES.map((stage) => {
-          const value = arrivals.funnelExternal[stage];
-          const ours = arrivals.funnelSelf[stage];
-          const unclear = ambiguousCounts?.[stage];
-          return (
-            <li
-              key={stage}
-              data-testid={`ops-arrival-stage-${stage}`}
-              aria-label={
-                `${stage}: ${value} external, ${ours} ours` +
-                (unclear === undefined ? "" : `, ${unclear} unattributable`)
-              }
-            >
-              <span className="ops-arrivals-stage">{stage}</span>
-              <span className="ops-arrivals-track" aria-hidden>
-                <i style={{ width: `${(value / peak) * 100}%` }} />
-              </span>
-              <strong>{value}</strong>
-              <span className="ops-arrivals-self" data-testid={`ops-arrival-self-${stage}`} aria-hidden>
-                {ours > 0 ? `+${ours}` : ""}
-              </span>
-              {/* Beside the headline, never inside it. Rendered only when the
-                  platform actually reports the bucket. */}
-              {unclear !== undefined ? (
-                <span
-                  className="ops-arrivals-ambiguous"
-                  data-testid={`ops-arrival-ambiguous-${stage}`}
-                  aria-hidden
+      <div className="ops-arrivals-doors">
+        <section className="ops-arrivals-door" aria-label="MCP arrivals" data-testid="ops-arrivals-door-mcp">
+          <h3 className="ops-arrivals-door-title">MCP</h3>
+          <ol className="ops-arrivals-funnel" aria-label="MCP arrival funnel, reached through submitted">
+            {ARRIVAL_STAGES.map((stage) => {
+              const value = arrivals.funnelExternal[stage];
+              const ours = arrivals.funnelSelf[stage];
+              const unclear = ambiguousCounts?.[stage];
+              return (
+                <li
+                  key={stage}
+                  data-testid={`ops-arrival-stage-${stage}`}
+                  aria-label={
+                    `${stage}: ${value} external, ${ours} ours` +
+                    (unclear === undefined ? "" : `, ${unclear} unattributable`)
+                  }
                 >
-                  {unclear > 0 ? `?${unclear}` : ""}
+                  <span className="ops-arrivals-stage">{stage}</span>
+                  <span className="ops-arrivals-track" aria-hidden>
+                    <i style={{ width: `${(value / peak) * 100}%` }} />
+                  </span>
+                  <strong>{value}</strong>
+                  <span className="ops-arrivals-self" data-testid={`ops-arrival-self-${stage}`} aria-hidden>
+                    {ours > 0 ? `+${ours}` : ""}
+                  </span>
+                  {/* Beside the headline, never inside it. Rendered only when
+                      the platform actually reports the bucket. */}
+                  {unclear !== undefined ? (
+                    <span
+                      className="ops-arrivals-ambiguous"
+                      data-testid={`ops-arrival-ambiguous-${stage}`}
+                      aria-hidden
+                    >
+                      {unclear > 0 ? `?${unclear}` : ""}
+                    </span>
+                  ) : null}
+                </li>
+              );
+            })}
+          </ol>
+
+          <div className="ops-arrivals-summary">
+            <div className="ops-arrivals-distinct" aria-label="Distinct arrival clients">
+              <span>DECLARED <strong>{arrivals.distinct.declared}</strong></span>
+              <span>ANONYMOUS <strong>{arrivals.distinct.anonymous}</strong></span>
+              <span>OURS <strong>{arrivals.distinct.self}</strong></span>
+              {arrivals.distinct.ambiguous === undefined ? null : (
+                <span data-testid="ops-arrivals-distinct-ambiguous">
+                  UNCLAIMABLE <strong>{arrivals.distinct.ambiguous}</strong>
                 </span>
+              )}
+            </div>
+            <div
+              className="ops-arrivals-furthest"
+              data-advanced={advanced ? "yes" : "no"}
+              data-testid="ops-arrivals-furthest"
+            >
+              {/* `distinct`, including furthestExternal, is the established
+                  MCP client view. Do not repoint this to distinctAgents: that
+                  is a different producer shape with different semantics. */}
+              <span>FURTHEST MCP STAGE AN OUTSIDER REACHED</span>
+              <strong>{arrivals.distinct.furthestExternal}</strong>
+              {arrivals.distinct.furthestAmbiguous === undefined ? null : (
+                <span className="ops-arrivals-furthest-ambiguous" data-testid="ops-arrivals-furthest-ambiguous">
+                  possibly, unclaimable client <strong>{arrivals.distinct.furthestAmbiguous}</strong>
+                </span>
+              )}
+            </div>
+          </div>
+
+          {ambiguousCounts ? (
+            <p className="ops-arrivals-ambiguous-note" data-testid="ops-arrivals-ambiguous-note">
+              <strong>UNCLAIMABLE</strong> — calls under a client name we use ourselves. A declared name
+              identifies the client software, not the operator, so our own session and a stranger's are
+              indistinguishable. Counted as outsiders they would manufacture demand; counted as ours they
+              would erase real users. They are neither, and are shown apart.
+            </p>
+          ) : null}
+
+          {unattributed > 0 ? (
+            <p
+              className="ops-arrivals-unattributed"
+              data-tone="awaiting"
+              data-testid="ops-arrivals-unattributed"
+            >
+              <strong>UNATTRIBUTED</strong> — {unattributed} call{unattributed === 1 ? "" : "s"} predate the
+              external/self split and belong to neither MCP column. The MCP stage counts above begin at the
+              split; the furthest MCP stage does not, and may run ahead of them.
+            </p>
+          ) : null}
+        </section>
+
+        {hasHttpReading ? (
+          <section className="ops-arrivals-door" aria-label="HTTP API arrivals" data-testid="ops-arrivals-door-http">
+            <h3 className="ops-arrivals-door-title">HTTP API</h3>
+            {arrivals.funnelHttpExternal ? (
+              <ol className="ops-arrivals-funnel" aria-label="HTTP API arrival funnel, reached through submitted">
+                {ARRIVAL_STAGES.map((stage) => {
+                  const value = arrivals.funnelHttpExternal?.[stage] ?? 0;
+                  const ours = arrivals.funnelHttpSelf?.[stage];
+                  const unclear = arrivals.funnelHttpAmbiguous?.[stage];
+                  return (
+                    <li
+                      key={stage}
+                      data-testid={`ops-arrival-http-stage-${stage}`}
+                      aria-label={
+                        `${stage}: ${value} external` +
+                        (ours === undefined ? "" : `, ${ours} ours`) +
+                        (unclear === undefined ? "" : `, ${unclear} unattributable`)
+                      }
+                    >
+                      <span className="ops-arrivals-stage">{stage}</span>
+                      <span className="ops-arrivals-track" aria-hidden>
+                        <i style={{ width: `${(value / httpPeak) * 100}%` }} />
+                      </span>
+                      <strong>{value}</strong>
+                      {ours === undefined ? null : (
+                        <span className="ops-arrivals-self" data-testid={`ops-arrival-http-self-${stage}`} aria-hidden>
+                          {ours > 0 ? `+${ours}` : ""}
+                        </span>
+                      )}
+                      {unclear === undefined ? null : (
+                        <span
+                          className="ops-arrivals-ambiguous"
+                          data-testid={`ops-arrival-http-ambiguous-${stage}`}
+                          aria-hidden
+                        >
+                          {unclear > 0 ? `?${unclear}` : ""}
+                        </span>
+                      )}
+                    </li>
+                  );
+                })}
+              </ol>
+            ) : null}
+
+            <div className="ops-arrivals-http-summary">
+              {arrivals.attributionSourceTotals ? (
+                <p className="ops-arrivals-http-measured" data-testid="ops-arrivals-http-measured">
+                  <span>MEASURED (SIWE WALLET)</span>
+                  <strong>{arrivals.attributionSourceTotals.http.siwe_wallet}</strong>
+                </p>
               ) : null}
-            </li>
-          );
-        })}
-      </ol>
-
-      <div className="ops-arrivals-summary">
-        <div className="ops-arrivals-distinct" aria-label="Distinct arrival clients">
-          <span>DECLARED <strong>{arrivals.distinct.declared}</strong></span>
-          <span>ANONYMOUS <strong>{arrivals.distinct.anonymous}</strong></span>
-          <span>OURS <strong>{arrivals.distinct.self}</strong></span>
-          {arrivals.distinct.ambiguous === undefined ? null : (
-            <span data-testid="ops-arrivals-distinct-ambiguous">
-              UNCLAIMABLE <strong>{arrivals.distinct.ambiguous}</strong>
-            </span>
-          )}
-        </div>
-        <div
-          className="ops-arrivals-furthest"
-          data-advanced={advanced ? "yes" : "no"}
-          data-testid="ops-arrivals-furthest"
-        >
-          {/* An OUTSIDER, not "any arrival" — our own probes walk the whole
-              funnel routinely, so the old wording turned a green board into a
-              statement about ourselves. */}
-          <span>FURTHEST STAGE AN OUTSIDER REACHED</span>
-          <strong>{arrivals.distinct.furthestExternal}</strong>
-          {/* Shown beside it, because narrowing the claim must not throw the
-              signal away: this may well have been an outsider, and the honest
-              statement is that we cannot tell. */}
-          {arrivals.distinct.furthestAmbiguous === undefined ? null : (
-            <span className="ops-arrivals-furthest-ambiguous" data-testid="ops-arrivals-furthest-ambiguous">
-              possibly, unclaimable client <strong>{arrivals.distinct.furthestAmbiguous}</strong>
-            </span>
-          )}
-        </div>
+              {arrivals.httpCutover ? (
+                <div className="ops-arrivals-http-cutover" data-testid="ops-arrivals-http-cutover">
+                  <p>{arrivals.httpCutover.note}</p>
+                  <p>a larger number here is recovered blindness, not growth.</p>
+                </div>
+              ) : null}
+            </div>
+          </section>
+        ) : null}
       </div>
-
-      {ambiguousCounts ? (
-        <p className="ops-arrivals-ambiguous-note" data-testid="ops-arrivals-ambiguous-note">
-          <strong>UNCLAIMABLE</strong> — calls under a client name we use ourselves. A declared name
-          identifies the client software, not the operator, so our own session and a stranger's are
-          indistinguishable. Counted as outsiders they would manufacture demand; counted as ours they
-          would erase real users. They are neither, and are shown apart.
-        </p>
-      ) : null}
-
-      {unattributed > 0 ? (
-        <p
-          className="ops-arrivals-unattributed"
-          data-tone="awaiting"
-          data-testid="ops-arrivals-unattributed"
-        >
-          <strong>UNATTRIBUTED</strong> — {unattributed} call{unattributed === 1 ? "" : "s"} predate the
-          external/self split and belong to neither column. The stage counts above begin at the split;
-          the furthest stage does not, and may run ahead of them.
-        </p>
-      ) : null}
     </section>
   );
 }

--- a/packages/monitor-ui/src/lib/monitor/product-health.ts
+++ b/packages/monitor-ui/src/lib/monitor/product-health.ts
@@ -292,6 +292,24 @@ export const ARRIVAL_STAGES = [
 
 export type ArrivalStage = (typeof ARRIVAL_STAGES)[number];
 
+export interface ArrivalAttributionCounts {
+  siwe_wallet: number;
+  client_name: number;
+  ip_only: number;
+}
+
+export interface ArrivalAttributionSourceTotals {
+  mcp: ArrivalAttributionCounts;
+  http: ArrivalAttributionCounts;
+}
+
+export interface HttpArrivalCutover {
+  atMs: number;
+  at: string;
+  backfilled: boolean;
+  note: string;
+}
+
 export interface ArrivalClient {
   key: string;
   name: string | null;
@@ -328,6 +346,13 @@ export interface ArrivalsSnapshot {
    * zero, because a zero here would be a measurement we did not make.
    */
   funnelAmbiguous?: Record<ArrivalStage, number>;
+  /** The separately measured HTTP front door; absent on older producers. */
+  funnelHttp?: Record<ArrivalStage, number>;
+  funnelHttpExternal?: Record<ArrivalStage, number>;
+  funnelHttpSelf?: Record<ArrivalStage, number>;
+  funnelHttpAmbiguous?: Record<ArrivalStage, number>;
+  attributionSourceTotals?: ArrivalAttributionSourceTotals;
+  httpCutover?: HttpArrivalCutover;
   distinct: {
     declared: number;
     anonymous: number;

--- a/packages/monitor-ui/src/styles/hermes4-ops.css
+++ b/packages/monitor-ui/src/styles/hermes4-ops.css
@@ -922,13 +922,13 @@ body,
 .ops-pillar-trend > span { min-width: 0; }
 
 /* ---- ARRIVALS ---------------------------------------------------
-   Public MCP-front-door funnel. The seven bars keep the producer's
-   reached→submitted order and exact counts; no stage is inferred here.
+   Independent public MCP and HTTP funnels. The seven bars keep each
+   producer series' reached→submitted order; no stage is inferred here.
    A failed read occupies the same named panel and says UNREACHABLE,
    because seven quiet zeroes would falsely claim nobody arrived. */
 .ops-arrivals {
   display: grid;
-  grid-template-columns: minmax(0, 2fr) minmax(calc(260 * var(--ops-u)), 1fr);
+  grid-template-columns: minmax(0, 1fr);
   gap: calc(8 * var(--ops-u)) calc(18 * var(--ops-u));
   padding: calc(9 * var(--ops-u)) calc(14 * var(--ops-u));
   border: 1px solid var(--ops-rule);
@@ -936,6 +936,32 @@ body,
 .ops-arrivals > .ops-panel-head,
 .ops-arrivals-unreachable {
   grid-column: 1 / -1;
+}
+.ops-arrivals-doors {
+  grid-column: 1 / -1;
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: calc(18 * var(--ops-u));
+}
+.ops-arrivals-door {
+  display: grid;
+  align-content: start;
+  gap: calc(8 * var(--ops-u));
+  min-width: 0;
+}
+.ops-arrivals-door + .ops-arrivals-door {
+  padding-left: calc(18 * var(--ops-u));
+  border-left: 1px solid var(--ops-rule);
+}
+.ops-arrivals-door-title {
+  margin: 0;
+  padding-bottom: calc(6 * var(--ops-u));
+  border-bottom: 1px solid var(--ops-hair);
+  font-family: var(--h4-font-display);
+  font-size: calc(16 * var(--ops-u));
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  color: var(--h4-ink);
 }
 .ops-arrivals-funnel {
   display: grid;
@@ -998,8 +1024,8 @@ body,
   display: grid;
   align-content: stretch;
   gap: calc(8 * var(--ops-u));
-  padding-left: calc(16 * var(--ops-u));
-  border-left: 1px solid var(--ops-hair);
+  padding-top: calc(8 * var(--ops-u));
+  border-top: 1px solid var(--ops-hair);
 }
 .ops-arrivals-distinct {
   display: flex;
@@ -1085,6 +1111,42 @@ body,
 }
 .ops-arrivals-ambiguous-note strong {
   letter-spacing: 0.08em;
+  color: var(--h4-tel);
+}
+.ops-arrivals-http-summary {
+  display: grid;
+  gap: calc(8 * var(--ops-u));
+  padding-top: calc(8 * var(--ops-u));
+  border-top: 1px solid var(--ops-hair);
+}
+.ops-arrivals-http-measured {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: calc(12 * var(--ops-u));
+  margin: 0;
+  font-family: var(--h4-font-mono);
+  color: var(--h4-muted);
+}
+.ops-arrivals-http-measured span {
+  font-size: calc(9 * var(--ops-u));
+  letter-spacing: 0.08em;
+}
+.ops-arrivals-http-measured strong {
+  font-size: calc(22 * var(--ops-u));
+  color: var(--h4-ok);
+}
+.ops-arrivals-http-cutover {
+  padding-top: calc(8 * var(--ops-u));
+  border-top: 1px solid var(--ops-hair);
+  font-family: var(--h4-font-mono);
+  font-size: calc(9 * var(--ops-u));
+  line-height: 1.5;
+  color: var(--h4-muted);
+}
+.ops-arrivals-http-cutover p { margin: 0; }
+.ops-arrivals-http-cutover p + p {
+  margin-top: calc(5 * var(--ops-u));
   color: var(--h4-tel);
 }
 
@@ -1251,14 +1313,15 @@ body,
     border-bottom: 1px solid var(--ops-rule);
   }
   .ops-arrivals { grid-template-columns: 1fr; }
+  .ops-arrivals-doors { grid-template-columns: 1fr; }
+  .ops-arrivals-door + .ops-arrivals-door {
+    padding: calc(14 * var(--ops-u)) 0 0;
+    border-left: 0;
+    border-top: 1px solid var(--ops-rule);
+  }
   .ops-arrivals > .ops-panel-head,
   .ops-arrivals-unattributed,
   .ops-arrivals-unreachable { grid-column: auto; }
-  .ops-arrivals-summary {
-    padding: calc(8 * var(--ops-u)) 0 0;
-    border-left: 0;
-    border-top: 1px solid var(--ops-hair);
-  }
   .ops-pillars { grid-template-columns: repeat(2, 1fr); }
   .ops-pillar:nth-child(3) { border-left: 0; }
   .ops-foot { flex-wrap: wrap; }

--- a/services/slack-operator/src/arrivals-feed.ts
+++ b/services/slack-operator/src/arrivals-feed.ts
@@ -35,6 +35,24 @@ export const ARRIVAL_STAGES = [
 
 export type ArrivalStage = (typeof ARRIVAL_STAGES)[number];
 
+export interface ArrivalAttributionCounts {
+  siwe_wallet: number;
+  client_name: number;
+  ip_only: number;
+}
+
+export interface ArrivalAttributionSourceTotals {
+  mcp: ArrivalAttributionCounts;
+  http: ArrivalAttributionCounts;
+}
+
+export interface HttpArrivalCutover {
+  atMs: number;
+  at: string;
+  backfilled: boolean;
+  note: string;
+}
+
 export interface ArrivalClient {
   key: string;
   name: string | null;
@@ -66,6 +84,13 @@ export interface ArrivalsSnapshot {
    * before the bucket existed — absent, never zero.
    */
   funnelAmbiguous?: Record<ArrivalStage, number>;
+  /** HTTP is a separate front door; every field is absent on older producers. */
+  funnelHttp?: Record<ArrivalStage, number>;
+  funnelHttpExternal?: Record<ArrivalStage, number>;
+  funnelHttpSelf?: Record<ArrivalStage, number>;
+  funnelHttpAmbiguous?: Record<ArrivalStage, number>;
+  attributionSourceTotals?: ArrivalAttributionSourceTotals;
+  httpCutover?: HttpArrivalCutover;
   distinct: {
     declared: number;
     anonymous: number;
@@ -146,6 +171,29 @@ export function normalizeArrivalsFeed(body: unknown): ArrivalsBlock {
   if (funnelAmbiguous && "unavailable" in funnelAmbiguous) return funnelAmbiguous;
   const ambiguousCounts = funnelAmbiguous && "counts" in funnelAmbiguous ? funnelAmbiguous.counts : undefined;
 
+  // HTTP arrived later and remains optional across the independent platform
+  // and board deploys. Present fields are real observations; absent fields
+  // stay absent instead of being rewritten as zeroes.
+  const funnelHttp = optionalStageCounts(value.funnelHttp, "funnelHttp");
+  if (funnelHttp && "unavailable" in funnelHttp) return funnelHttp;
+  const funnelHttpExternal = optionalStageCounts(value.funnelHttpExternal, "funnelHttpExternal");
+  if (funnelHttpExternal && "unavailable" in funnelHttpExternal) return funnelHttpExternal;
+  const funnelHttpSelf = optionalStageCounts(value.funnelHttpSelf, "funnelHttpSelf");
+  if (funnelHttpSelf && "unavailable" in funnelHttpSelf) return funnelHttpSelf;
+  const funnelHttpAmbiguous = optionalStageCounts(value.funnelHttpAmbiguous, "funnelHttpAmbiguous");
+  if (funnelHttpAmbiguous && "unavailable" in funnelHttpAmbiguous) return funnelHttpAmbiguous;
+  const httpCounts = funnelHttp && "counts" in funnelHttp ? funnelHttp.counts : undefined;
+  const httpExternalCounts =
+    funnelHttpExternal && "counts" in funnelHttpExternal ? funnelHttpExternal.counts : undefined;
+  const httpSelfCounts = funnelHttpSelf && "counts" in funnelHttpSelf ? funnelHttpSelf.counts : undefined;
+  const httpAmbiguousCounts =
+    funnelHttpAmbiguous && "counts" in funnelHttpAmbiguous ? funnelHttpAmbiguous.counts : undefined;
+
+  const attributionSourceTotals = normalizeAttributionSourceTotals(value.attributionSourceTotals);
+  if (attributionSourceTotals && "unavailable" in attributionSourceTotals) return attributionSourceTotals;
+  const httpCutover = normalizeHttpCutover(value.httpCutover);
+  if (httpCutover && "unavailable" in httpCutover) return httpCutover;
+
   // External, self and ambiguous are disjoint subsets of the total, so no one
   // of them can exceed it and together they cannot either. A producer that
   // says otherwise is describing a funnel we do not understand, and the safe
@@ -163,6 +211,22 @@ export function normalizeArrivalsFeed(body: unknown): ArrivalsBlock {
   if (incoherent) {
     return {
       unavailable: `arrivals feed unreadable — ${incoherent} external plus self plus ambiguous exceeds the total`,
+    };
+  }
+
+  // This is deliberately a second coherence check. HTTP is not part of the
+  // MCP `funnel`, and comparing or summing the two doors would invent a
+  // combined series that the producer does not report.
+  const incoherentHttp = httpCounts && ARRIVAL_STAGES.find(
+    (stage) =>
+      (httpExternalCounts?.[stage] ?? 0) +
+        (httpSelfCounts?.[stage] ?? 0) +
+        (httpAmbiguousCounts?.[stage] ?? 0) >
+      httpCounts[stage],
+  );
+  if (incoherentHttp) {
+    return {
+      unavailable: `arrivals feed unreadable — funnelHttp.${incoherentHttp} external plus self plus ambiguous exceeds the HTTP total`,
     };
   }
 
@@ -210,6 +274,14 @@ export function normalizeArrivalsFeed(body: unknown): ArrivalsBlock {
     funnelSelf: funnelSelf.counts,
     // Omitted, not zero-filled, when the producer did not supply it.
     ...(ambiguousCounts === undefined ? {} : { funnelAmbiguous: ambiguousCounts }),
+    ...(httpCounts === undefined ? {} : { funnelHttp: httpCounts }),
+    ...(httpExternalCounts === undefined ? {} : { funnelHttpExternal: httpExternalCounts }),
+    ...(httpSelfCounts === undefined ? {} : { funnelHttpSelf: httpSelfCounts }),
+    ...(httpAmbiguousCounts === undefined ? {} : { funnelHttpAmbiguous: httpAmbiguousCounts }),
+    ...(attributionSourceTotals && "value" in attributionSourceTotals
+      ? { attributionSourceTotals: attributionSourceTotals.value }
+      : {}),
+    ...(httpCutover && "value" in httpCutover ? { httpCutover: httpCutover.value } : {}),
     distinct: {
       declared,
       anonymous,
@@ -237,6 +309,68 @@ function stageCounts(
     return { unavailable: `arrivals feed unreadable — ${field}.${invalid[0]} is invalid` };
   }
   return { counts: Object.fromEntries(entries) as Record<ArrivalStage, number> };
+}
+
+function optionalStageCounts(
+  raw: unknown,
+  field: string,
+): { counts: Record<ArrivalStage, number> } | { unavailable: string } | undefined {
+  return raw === undefined ? undefined : stageCounts(raw, field);
+}
+
+function normalizeAttributionSourceTotals(
+  raw: unknown,
+): { value: ArrivalAttributionSourceTotals } | { unavailable: string } | undefined {
+  if (raw === undefined) return undefined;
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
+    return { unavailable: "arrivals feed unreadable — attributionSourceTotals is invalid" };
+  }
+  const value = raw as Record<string, unknown>;
+  const mcp = attributionCounts(value.mcp, "mcp");
+  if ("unavailable" in mcp) return mcp;
+  const http = attributionCounts(value.http, "http");
+  if ("unavailable" in http) return http;
+  return { value: { mcp: mcp.counts, http: http.counts } };
+}
+
+function attributionCounts(
+  raw: unknown,
+  door: string,
+): { counts: ArrivalAttributionCounts } | { unavailable: string } {
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
+    return { unavailable: `arrivals feed unreadable — attributionSourceTotals.${door} is invalid` };
+  }
+  const value = raw as Record<string, unknown>;
+  const siwe_wallet = count(value.siwe_wallet);
+  const client_name = count(value.client_name);
+  const ip_only = count(value.ip_only);
+  if (siwe_wallet === undefined || client_name === undefined || ip_only === undefined) {
+    return { unavailable: `arrivals feed unreadable — attributionSourceTotals.${door} counts are invalid` };
+  }
+  return { counts: { siwe_wallet, client_name, ip_only } };
+}
+
+function normalizeHttpCutover(
+  raw: unknown,
+): { value: HttpArrivalCutover } | { unavailable: string } | undefined {
+  if (raw === undefined) return undefined;
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
+    return { unavailable: "arrivals feed unreadable — httpCutover is invalid" };
+  }
+  const value = raw as Record<string, unknown>;
+  const atMs = count(value.atMs);
+  if (
+    atMs === undefined ||
+    typeof value.at !== "string" ||
+    !value.at.trim() ||
+    Number.isNaN(Date.parse(value.at)) ||
+    typeof value.backfilled !== "boolean" ||
+    typeof value.note !== "string" ||
+    !value.note.trim()
+  ) {
+    return { unavailable: "arrivals feed unreadable — httpCutover fields are invalid" };
+  }
+  return { value: { atMs, at: value.at, backfilled: value.backfilled, note: value.note } };
 }
 
 function normalizeClient(raw: unknown): { client: ArrivalClient } | { unavailable: string } {

--- a/services/slack-operator/test/unit/arrivals-feed.test.ts
+++ b/services/slack-operator/test/unit/arrivals-feed.test.ts
@@ -57,6 +57,31 @@ const good = {
   }],
 };
 
+const httpFields = {
+  funnelHttp: {
+    reached: 40, browsed: 20, evaluated: 12, identified: 8, authenticated: 6, claimed: 4, submitted: 3,
+  },
+  funnelHttpExternal: {
+    reached: 31, browsed: 15, evaluated: 9, identified: 5, authenticated: 4, claimed: 3, submitted: 2,
+  },
+  funnelHttpSelf: {
+    reached: 2, browsed: 1, evaluated: 1, identified: 1, authenticated: 1, claimed: 1, submitted: 1,
+  },
+  funnelHttpAmbiguous: {
+    reached: 1, browsed: 1, evaluated: 0, identified: 0, authenticated: 0, claimed: 0, submitted: 0,
+  },
+  attributionSourceTotals: {
+    mcp: { siwe_wallet: 3, client_name: 9, ip_only: 12 },
+    http: { siwe_wallet: 17, client_name: 6, ip_only: 41 },
+  },
+  httpCutover: {
+    atMs: 1_786_200_000_000,
+    at: "2026-08-09T01:20:00.000Z",
+    backfilled: false,
+    note: "HTTP arrivals are measured from this cut-over only; earlier HTTP traffic was not backfilled.",
+  },
+};
+
 describe("readArrivalsFeed", () => {
   test("reads the public platform route from the configured API base", async () => {
     let requested = "";
@@ -168,6 +193,47 @@ describe("normalizeArrivalsFeed", () => {
   test("a schema drift is visible by version", () => {
     const result = normalizeArrivalsFeed({ ...good, schemaVersion: "averray.arrivals.v2" });
     expect("unavailable" in result && result.unavailable).toContain("schemaVersion averray.arrivals.v1");
+  });
+});
+
+describe("normalizeArrivalsFeed — HTTP front door", () => {
+  test("round-trips all six optional HTTP observations without changing their producer names", () => {
+    const result = normalizeArrivalsFeed({ ...good, ...httpFields });
+
+    expect("unavailable" in result).toBe(false);
+    if ("unavailable" in result) return;
+    expect(result.funnelHttp).toEqual(httpFields.funnelHttp);
+    expect(result.funnelHttpExternal).toEqual(httpFields.funnelHttpExternal);
+    expect(result.funnelHttpSelf).toEqual(httpFields.funnelHttpSelf);
+    expect(result.funnelHttpAmbiguous).toEqual(httpFields.funnelHttpAmbiguous);
+    expect(result.attributionSourceTotals).toEqual(httpFields.attributionSourceTotals);
+    expect(result.httpCutover).toEqual(httpFields.httpCutover);
+  });
+
+  test("a pre-cut-over producer keeps every HTTP observation absent, never zero-filled", () => {
+    const result = normalizeArrivalsFeed(good);
+
+    expect("unavailable" in result).toBe(false);
+    expect("funnelHttp" in result).toBe(false);
+    expect("funnelHttpExternal" in result).toBe(false);
+    expect("funnelHttpSelf" in result).toBe(false);
+    expect("funnelHttpAmbiguous" in result).toBe(false);
+    expect("attributionSourceTotals" in result).toBe(false);
+    expect("httpCutover" in result).toBe(false);
+  });
+
+  test("checks the HTTP split against the HTTP total, not the smaller MCP total", () => {
+    const coherent = normalizeArrivalsFeed({ ...good, ...httpFields });
+    expect("unavailable" in coherent).toBe(false);
+
+    const incoherent = normalizeArrivalsFeed({
+      ...good,
+      ...httpFields,
+      funnelHttpExternal: { ...httpFields.funnelHttpExternal, claimed: 5 },
+    });
+    expect("unavailable" in incoherent && incoherent.unavailable).toContain(
+      "funnelHttp.claimed external plus self plus ambiguous exceeds the HTTP total",
+    );
   });
 });
 


### PR DESCRIPTION
## What changed

- carry the six optional HTTP-arrival producer fields through the board normalizer without zero-filling absent observations
- validate HTTP attribution/cut-over fields and enforce the HTTP subset inequality independently from the MCP funnel
- display separately labelled MCP and HTTP API doors, promoting measured `siwe_wallet` attribution
- render the producer's cut-over note verbatim and explicitly explain that a larger post-cut-over reading can be recovered blindness rather than growth
- retain the established MCP `distinct.furthestExternal` semantics and MCP-only unattributed arithmetic; no combined headline exists

## Acceptance evidence

- Pre-#1071 producer: normalizer tests assert all six HTTP properties remain absent; panel renders the MCP funnel normally, without UNREACHABLE or HTTP zeroes.
- Producer contract: normalization round-trips `funnelHttp`, `funnelHttpExternal`, `funnelHttpSelf`, `funnelHttpAmbiguous`, `attributionSourceTotals`, and `httpCutover`.
- Independent coherence: a large valid HTTP funnel is accepted even when it exceeds MCP; an HTTP split exceeding `funnelHttp` is refused.
- Attribution: panel test proves `attributionSourceTotals.http.siwe_wallet = 17` is promoted and `ip_only = 41` is not.
- Cut-over: panel test compares the first rendered paragraph exactly with `httpCutover.note`, then asserts “a larger number here is recovered blindness, not growth.”
- No flattening: tests assert MCP 20 and HTTP 7 remain separate and the summed 27 is absent; source contains no `funnelCombined`.
- Shape traps: the component remains on legacy MCP `distinct.furthestExternal`; it does not consume `distinctAgents`. The unattributed calculation is explicitly documented and implemented as MCP-only.

## Checks

- `npm run typecheck` — passed
- `npm test -- services/slack-operator/test/unit/arrivals-feed.test.ts packages/monitor-ui/src/components/ops/ArrivalsPanel.test.tsx packages/monitor-ui/src/components/ops/OpsBoard.test.tsx` — 72 passed
- `npm test` — 2,978 passed, 37 skipped; only 2 existing INT-4 execution-drill tests failed because their nested process requires a physical worktree-local `node_modules/vitest/vitest.mjs` while dependencies resolve from the primary checkout

## Scope

Board repository only: slack-operator arrivals normalization, monitor UI types/component/tests/styles. No platform producer or deployment changes. No environment or secret changes.
