### PR TITLE
Add deposit pool observability to Bank pillar

### DIFF
--- a/packages/monitor-ui/src/components/mobile/MobileBoard.tsx
+++ b/packages/monitor-ui/src/components/mobile/MobileBoard.tsx
@@ -37,6 +37,7 @@ import {
   type BreachCard,
 } from "../../lib/monitor/phone-spec.js";
 import { disputeClockLine, lifecycleNote } from "../../lib/monitor/ops-spec.js";
+import { DepositPoolTile } from "../ops/DepositPoolTile.js";
 
 export interface MobileBoardProps {
   health?: ProductHealth;
@@ -109,6 +110,7 @@ export function MobileBoard({
         {breach ? <BreachPanel breach={breach} /> : <SolvencyPanel health={health} />}
         <FlowPanel health={health} emphasise={Boolean(breach)} nowMs={nowMs} />
         <BankPanel bank={health.bank} />
+        <DepositPoolTile pool={health.depositPool} />
       </div>
 
       <p className="hm-ph-scroll" aria-hidden>

--- a/packages/monitor-ui/src/components/ops/DepositPoolTile.test.tsx
+++ b/packages/monitor-ui/src/components/ops/DepositPoolTile.test.tsx
@@ -1,0 +1,69 @@
+// @vitest-environment jsdom
+import { cleanup, render, within } from "@testing-library/react";
+import { afterEach, describe, expect, test } from "vitest";
+
+import type { DepositPoolBlock } from "../../lib/monitor/product-health.js";
+import { DepositPoolTile } from "./DepositPoolTile.js";
+
+afterEach(cleanup);
+
+const amount = (raw: string) => ({ raw, decimals: 6 });
+
+describe("DepositPoolTile truth states", () => {
+  test("real zero measurements render as zeros with the born-empty annotation", () => {
+    const pool: DepositPoolBlock = {
+      snapshot: {
+        schemaVersion: 1,
+        available: true,
+        pricingModel: "principal-cost-basis",
+        totalAssets: amount("0"),
+        totalShares: amount("0"),
+        sharePrice: amount("1000000"),
+        buffer: amount("0"),
+        deployed: amount("0"),
+        reconciled: true,
+        caps: {
+          totalAssetCap: amount("10000000"),
+          headroom: amount("10000000"),
+          utilizationBps: 0,
+        },
+        yieldStatus: "not_yet_earning",
+        flows: {
+          status: "ok",
+          depositorCount: 0,
+          pendingUnfulfilledRedemptionAssets: amount("0"),
+          recent: [],
+          window: { fromBlock: 100, toBlock: 101, maxBlocks: 2, recentLimit: 8 },
+        },
+      },
+    };
+    const { getByTestId } = render(<DepositPoolTile pool={pool} />);
+
+    expect(getByTestId("ops-deposit-pool-born-empty").textContent).toContain("BORN EMPTY");
+    expect(getByTestId("ops-deposit-pool-deposits").textContent).toContain("0 USDC");
+    expect(getByTestId("ops-deposit-pool-allocation").textContent).toContain("0 USDC buffer");
+    expect(getByTestId("ops-deposit-pool-allocation").textContent).toContain("0 USDC deployed");
+    expect(getByTestId("ops-deposit-pool-depositors").textContent).toContain("0");
+    expect(getByTestId("ops-deposit-pool-cap").textContent).toContain("0.00%");
+    expect(getByTestId("ops-deposit-pool-flow-window").textContent).toContain("blocks 100–101");
+  });
+
+  test("a missing pre-5a endpoint renders UNAVAILABLE, visually distinct from zero", () => {
+    const { getByTestId, queryByTestId } = render(
+      <DepositPoolTile pool={{ unavailable: "deposit pool unreachable — platform returned HTTP 404" }} />,
+    );
+    const tile = getByTestId("ops-deposit-pool");
+    expect(within(tile).getByText("UNAVAILABLE")).toBeTruthy();
+    expect(tile.textContent).toContain("HTTP 404");
+    expect(queryByTestId("ops-deposit-pool-born-empty")).toBeNull();
+    expect(queryByTestId("ops-deposit-pool-deposits")).toBeNull();
+  });
+
+  test("an incoherent producer renders a labeled FAULT and no impossible figures", () => {
+    const { getByTestId, queryByTestId } = render(
+      <DepositPoolTile pool={{ fault: "deposit pool incoherent — buffer plus deployed does not equal total assets" }} />,
+    );
+    expect(getByTestId("ops-deposit-pool").textContent).toContain("FAULT");
+    expect(queryByTestId("ops-deposit-pool-deposits")).toBeNull();
+  });
+});

--- a/packages/monitor-ui/src/components/ops/DepositPoolTile.tsx
+++ b/packages/monitor-ui/src/components/ops/DepositPoolTile.tsx
@@ -1,0 +1,181 @@
+// BANK — the shared deposit pool, reconstructed from the platform's read-only
+// snapshot and rendered without a second arithmetic opinion.
+//
+// Two zero/absence rules are intentionally both stated here:
+//   1. Real zero readings render as 0 and carry BORN EMPTY while depositorCount
+//      is zero. On this surface zero is a measurement, never missing data.
+//   2. A missing endpoint/profile renders UNAVAILABLE. It never gets defaulted
+//      into zero. An incoherent payload is a separate, labeled FAULT and none of
+//      its impossible figures render.
+
+import type {
+  DepositPoolAmount,
+  DepositPoolBlock,
+  DepositPoolFlow,
+} from "../../lib/monitor/product-health.js";
+
+export function DepositPoolTile({ pool }: { pool: DepositPoolBlock | undefined }) {
+  if (!pool || "unavailable" in pool) {
+    const reason = pool && "unavailable" in pool
+      ? pool.unavailable
+      : "deposit pool snapshot is not supplied by this monitor build";
+    return (
+      <section className="ops-deposit-pool" data-tone="awaiting" data-testid="ops-deposit-pool">
+        <Header />
+        <p className="ops-deposit-pool-state" data-tone="awaiting">
+          <strong>UNAVAILABLE</strong> — {reason}
+        </p>
+      </section>
+    );
+  }
+  if ("fault" in pool) {
+    return (
+      <section className="ops-deposit-pool" data-tone="red" data-testid="ops-deposit-pool">
+        <Header />
+        <p className="ops-deposit-pool-state" data-tone="red">
+          <strong>FAULT</strong> — {pool.fault}
+        </p>
+      </section>
+    );
+  }
+
+  const snapshot = pool.snapshot;
+  const bornEmpty = snapshot.flows?.depositorCount === 0;
+  return (
+    <section className="ops-deposit-pool" data-tone="ok" data-testid="ops-deposit-pool">
+      <Header
+        right={bornEmpty ? (
+          <span className="ops-deposit-pool-born-empty" data-testid="ops-deposit-pool-born-empty">
+            BORN EMPTY · ZEROES ARE MEASURED
+          </span>
+        ) : snapshot.block?.number !== undefined ? (
+          <span>BLOCK {snapshot.block.number.toLocaleString("en-US")}</span>
+        ) : undefined}
+      />
+
+      <dl className="ops-deposit-pool-grid">
+        <Fact label="DEPOSITS" testId="ops-deposit-pool-deposits">
+          {formatAmount(snapshot.totalAssets, "USDC")}
+        </Fact>
+        <Fact label="BUFFER / DEPLOYED" testId="ops-deposit-pool-allocation">
+          {formatAmount(snapshot.buffer, "USDC")} buffer · {formatAmount(snapshot.deployed, "USDC")} deployed
+        </Fact>
+        <Fact label="SHARE PRICE" testId="ops-deposit-pool-share-price">
+          {formatAmount(snapshot.sharePrice, "USDC/share")}
+          <small>{snapshot.pricingModel ?? "pricing model not reported"}</small>
+        </Fact>
+        <Fact label="CAP" testId="ops-deposit-pool-cap">
+          {formatBps(snapshot.caps?.utilizationBps)} utilized
+          <small>
+            {formatAmount(snapshot.caps?.headroom, "USDC")} headroom
+            {snapshot.caps?.totalAssetCap ? ` of ${formatAmount(snapshot.caps.totalAssetCap, "USDC")}` : ""}
+          </small>
+        </Fact>
+        <Fact label="DEPOSITORS" testId="ops-deposit-pool-depositors">
+          {snapshot.flows?.depositorCount ?? "—"}
+          <small>
+            {formatAmount(snapshot.flows?.pendingUnfulfilledRedemptionAssets, "USDC")} pending redemption
+          </small>
+        </Fact>
+        <Fact label="YIELD" testId="ops-deposit-pool-yield">
+          {snapshot.yieldStatus === "earning"
+            ? "EARNING"
+            : snapshot.yieldStatus === "not_yet_earning"
+              ? "NOT YET EARNING"
+              : "—"}
+          {snapshot.yieldStatusText ? <small>{snapshot.yieldStatusText}</small> : null}
+        </Fact>
+      </dl>
+
+      <div className="ops-deposit-pool-flows" data-tone={snapshot.flows?.status === "unavailable" ? "awaiting" : "ok"}>
+        <div className="ops-deposit-pool-flow-head">
+          <span>LAST FLOWS</span>
+          <span data-testid="ops-deposit-pool-flow-window">{flowWindow(snapshot.flows?.window)}</span>
+        </div>
+        {snapshot.flows?.status === "unavailable" ? (
+          <p>
+            <strong>FLOWS UNAVAILABLE</strong>
+            {snapshot.flows.lastError ? ` — ${snapshot.flows.lastError}` : ""}
+          </p>
+        ) : snapshot.flows?.recent?.length ? (
+          <ul>
+            {snapshot.flows.recent.slice(0, 6).map((flow, index) => (
+              <li key={`${flow.transactionHash ?? flow.blockNumber ?? "flow"}-${flow.logIndex ?? index}`}>
+                {flowLine(flow)}
+              </li>
+            ))}
+          </ul>
+        ) : (
+          <p>no recent flows in the bounded window</p>
+        )}
+      </div>
+    </section>
+  );
+}
+
+function Header({ right }: { right?: React.ReactNode }) {
+  return (
+    <div className="ops-deposit-pool-head">
+      <h2>BANK — DEPOSIT POOL</h2>
+      {right ? <span>{right}</span> : null}
+    </div>
+  );
+}
+
+function Fact({
+  label,
+  testId,
+  children,
+}: {
+  label: string;
+  testId: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div data-testid={testId}>
+      <dt>{label}</dt>
+      <dd>{children}</dd>
+    </div>
+  );
+}
+
+function formatAmount(amount: DepositPoolAmount | undefined, unit: string): string {
+  if (!amount) return `— ${unit}`;
+  if (amount.decimals === undefined) return `${groupRaw(amount.raw)} raw`;
+  const negative = amount.raw.startsWith("-");
+  const digits = negative ? amount.raw.slice(1) : amount.raw;
+  const padded = digits.padStart(amount.decimals + 1, "0");
+  const split = padded.length - amount.decimals;
+  const whole = padded.slice(0, split);
+  const fraction = padded.slice(split).replace(/0+$/, "");
+  return `${negative ? "-" : ""}${groupRaw(whole)}${fraction ? `.${fraction}` : ""} ${unit}`;
+}
+
+function groupRaw(raw: string): string {
+  return raw.replace(/\B(?=(\d{3})+(?!\d))/g, ",");
+}
+
+function formatBps(bps: number | undefined): string {
+  if (bps === undefined) return "—";
+  return `${Math.floor(bps / 100)}.${String(bps % 100).padStart(2, "0")}%`;
+}
+
+function flowWindow(window: { fromBlock?: number; toBlock?: number; maxBlocks?: number } | undefined): string {
+  if (window?.fromBlock === undefined || window.toBlock === undefined) return "bounded window not reported";
+  return `blocks ${window.fromBlock.toLocaleString("en-US")}–${window.toBlock.toLocaleString("en-US")}` +
+    (window.maxBlocks === undefined ? "" : ` · max ${window.maxBlocks.toLocaleString("en-US")}`);
+}
+
+function flowLine(flow: DepositPoolFlow): string {
+  const label = ({
+    deposit: "DEPOSIT",
+    withdraw: "WITHDRAW",
+    redeem_requested: "REDEEM REQUESTED",
+    redeem_fulfilled: "REDEEM FULFILLED",
+    operator_principal_contributed: "PRINCIPAL CONTRIBUTED",
+    venue_loss_written_off: "LOSS WRITTEN OFF",
+  } as Record<DepositPoolFlow["kind"], string>)[flow.kind];
+  const assets = flow.assets ? ` · ${formatAmount(flow.assets, "USDC")}` : "";
+  const block = flow.blockNumber === undefined ? "" : ` · block ${flow.blockNumber.toLocaleString("en-US")}`;
+  return `${label}${assets}${block}`;
+}

--- a/packages/monitor-ui/src/components/ops/OpsBoard.tsx
+++ b/packages/monitor-ui/src/components/ops/OpsBoard.tsx
@@ -26,6 +26,7 @@ import { PillarStrip } from "./PillarStrip.js";
 import { SolvencyPanel } from "./SolvencyPanel.js";
 import { BankLane } from "./BankLane.js";
 import { ArrivalsPanel } from "./ArrivalsPanel.js";
+import { DepositPoolTile } from "./DepositPoolTile.js";
 
 export interface OpsBoardProps {
   health: ProductHealth;
@@ -126,6 +127,11 @@ export function OpsBoard({
         {/* The treasury's own money path, under the one that pays workers.
             Renders nothing at all when no feed is configured. */}
         <BankLane bank={health.bank} />
+
+        {/* The shared depositor pool is a Bank-pillar instrument, but unlike
+            the treasury venue lane it is always explicit: pre-5a is
+            UNAVAILABLE, never an absent/empty pool. */}
+        <DepositPoolTile pool={health.depositPool} />
 
         <PillarStrip probes={health.probes} history={health.history} />
 

--- a/packages/monitor-ui/src/lib/monitor/product-health.ts
+++ b/packages/monitor-ui/src/lib/monitor/product-health.ts
@@ -284,6 +284,72 @@ export interface BankBlock {
   unavailable?: string;
 }
 
+/** Exact token quantity from the pool endpoint. Strings preserve base-unit precision. */
+export interface DepositPoolAmount {
+  raw: string;
+  decimals?: number;
+}
+
+export type DepositPoolFlowKind =
+  | "deposit"
+  | "withdraw"
+  | "redeem_requested"
+  | "redeem_fulfilled"
+  | "operator_principal_contributed"
+  | "venue_loss_written_off";
+
+export interface DepositPoolFlow {
+  kind: DepositPoolFlowKind;
+  blockNumber?: number;
+  transactionHash?: string;
+  logIndex?: number;
+  assets?: DepositPoolAmount;
+  sharesRaw?: string;
+  requestId?: string;
+  tier?: string;
+  unlockAt?: string;
+}
+
+export interface DepositPoolSnapshot {
+  schemaVersion: 1;
+  available: true;
+  pool?: string;
+  asset?: string;
+  block?: { number?: number; hash?: string; timestamp?: number };
+  pricingModel?: string;
+  totalAssets?: DepositPoolAmount;
+  totalShares?: DepositPoolAmount;
+  sharePrice?: DepositPoolAmount;
+  buffer?: DepositPoolAmount;
+  deployed?: DepositPoolAmount;
+  reconciled?: boolean;
+  caps?: {
+    totalAssetCap?: DepositPoolAmount;
+    perAgentAssetCap?: DepositPoolAmount;
+    headroom?: DepositPoolAmount;
+    utilizationBps?: number;
+  };
+  yieldStatus?: "not_yet_earning" | "earning";
+  yieldStatusText?: string;
+  flows?: {
+    status: "ok" | "unavailable";
+    depositorCount?: number;
+    depositorCountModel?: string;
+    pendingUnfulfilledRedemptionShares?: DepositPoolAmount;
+    pendingUnfulfilledRedemptionAssets?: DepositPoolAmount;
+    recent: DepositPoolFlow[];
+    sharePriceQualifyingEvents?: DepositPoolFlow[];
+    window?: { fromBlock?: number; toBlock?: number; maxBlocks?: number; recentLimit?: number };
+    lastError?: string;
+  };
+}
+
+/** Missing producer and impossible producer state remain visually distinct. */
+export type DepositPoolBlock =
+  | { snapshot: DepositPoolSnapshot }
+  | { unavailable: string }
+  | { fault: string };
+
 export const ARRIVAL_STAGES = [
   "reached",
   "browsed",
@@ -507,6 +573,8 @@ export interface ProductHealth {
    * not render at all, and says nothing. Only `unavailable` is a fault.
    */
   bank?: BankBlock;
+  /** Always explicit on Packet 5b monitors; absent only on older snapshots. */
+  depositPool?: DepositPoolBlock;
   /** Public MCP-front-door arrivals, or why that feed could not be read. */
   arrivals?: ArrivalsBlock;
   remediation?: RemediationStatus;

--- a/packages/monitor-ui/src/styles/hermes4-ops.css
+++ b/packages/monitor-ui/src/styles/hermes4-ops.css
@@ -1238,6 +1238,105 @@ body,
   color: var(--tone, var(--h4-tel));
 }
 
+/* ---- BANK / deposit pool ---------------------------------------
+   Unlike the venue lane above, this instrument always occupies its slot:
+   a pre-endpoint deploy says UNAVAILABLE so nobody can read missing data as
+   an empty pool. Real zeroes use the normal ink plus the born-empty badge. */
+.ops-deposit-pool {
+  display: flex;
+  flex-direction: column;
+  gap: calc(8 * var(--ops-u));
+  padding: calc(10 * var(--ops-u)) calc(14 * var(--ops-u));
+  border: 1px solid var(--ops-rule);
+}
+.ops-deposit-pool[data-tone="red"] { border-color: var(--h4-act); }
+.ops-deposit-pool[data-tone="awaiting"] { border-color: var(--h4-tel); }
+.ops-deposit-pool-head,
+.ops-deposit-pool-flow-head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: calc(12 * var(--ops-u));
+}
+.ops-deposit-pool-head h2 {
+  margin: 0;
+  font-family: var(--h4-font-display);
+  font-size: calc(12.5 * var(--ops-u));
+  font-weight: 600;
+  letter-spacing: 0.1em;
+  color: var(--h4-ink);
+}
+.ops-deposit-pool-head > span,
+.ops-deposit-pool-flow-head {
+  font-family: var(--h4-font-mono);
+  font-size: calc(9 * var(--ops-u));
+  letter-spacing: 0.1em;
+  color: var(--h4-tel);
+}
+.ops-deposit-pool-born-empty {
+  color: var(--h4-ok);
+}
+.ops-deposit-pool-state {
+  margin: 0;
+  padding: calc(8 * var(--ops-u)) 0;
+  font-family: var(--h4-font-mono);
+  font-size: calc(11 * var(--ops-u));
+  line-height: 1.45;
+  color: var(--tone, var(--h4-tel));
+}
+.ops-deposit-pool-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: calc(12 * var(--ops-u));
+  margin: 0;
+}
+.ops-deposit-pool-grid > div {
+  min-width: 0;
+  padding-top: calc(6 * var(--ops-u));
+  border-top: 1px solid var(--ops-hair);
+}
+.ops-deposit-pool-grid dt,
+.ops-deposit-pool-flow-head > span:first-child {
+  font-family: var(--h4-font-mono);
+  font-size: calc(9 * var(--ops-u));
+  letter-spacing: 0.12em;
+  color: var(--h4-tel);
+}
+.ops-deposit-pool-grid dd {
+  margin: calc(3 * var(--ops-u)) 0 0;
+  font-family: var(--h4-font-mono);
+  font-size: calc(12 * var(--ops-u));
+  line-height: 1.4;
+  color: var(--h4-ink-2);
+}
+.ops-deposit-pool-grid small {
+  display: block;
+  margin-top: calc(2 * var(--ops-u));
+  font-size: calc(9.5 * var(--ops-u));
+  color: var(--h4-tel);
+}
+.ops-deposit-pool-flows {
+  padding-top: calc(7 * var(--ops-u));
+  border-top: 1px solid var(--ops-hair);
+  font-family: var(--h4-font-mono);
+  font-size: calc(10 * var(--ops-u));
+  color: var(--tone, var(--h4-ink-2));
+}
+.ops-deposit-pool-flows p { margin: calc(6 * var(--ops-u)) 0 0; }
+.ops-deposit-pool-flows ul {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: calc(3 * var(--ops-u)) calc(16 * var(--ops-u));
+  margin: calc(6 * var(--ops-u)) 0 0;
+  padding: 0;
+  list-style: none;
+}
+
+@media (max-width: 760px) {
+  .ops-deposit-pool-grid { grid-template-columns: 1fr 1fr; }
+  .ops-deposit-pool-flows ul { grid-template-columns: 1fr; }
+}
+
 /* ---- per-job economics -------------------------------------------
    What one job costs and earns, on one line between the probes and
    the footer. Also shipped unstyled; also monospace now, because it

--- a/services/slack-operator/src/deposit-pool-feed.ts
+++ b/services/slack-operator/src/deposit-pool-feed.ts
@@ -1,0 +1,515 @@
+// The Bank pillar's deposit-pool snapshot, read from the independently
+// deployed platform.
+//
+// This follows the arrivals-feed boundary: fields are allowlisted, additions
+// are optional during staggered deploys, and values are reconstructed from
+// decimal strings rather than trusting JavaScript numbers with token amounts.
+// A real zero is a measurement. Only a missing endpoint/profile is
+// UNAVAILABLE; malformed or arithmetically impossible core values are a FAULT.
+// A log-read failure is narrower: it degrades `flows` while retaining the live
+// balances, because losing history cannot make the current pool unreadable.
+
+export const DEPOSIT_POOL_SCHEMA_VERSION = 1;
+export const DEPOSIT_POOL_FEED_TIMEOUT_MS = 4000;
+
+/**
+ * The pool endpoint is intentionally internal. Reuse the Bank feed's already
+ * configured `agent-mainnet-internal` origin and replace its path; NEVER fall
+ * back to public PRODUCT_HEALTH_API_BASE_URL, where Caddy correctly returns
+ * 404 for this route.
+ */
+export function depositPoolUrlFromBankFeed(bankFeedUrl: string | undefined): string | undefined {
+  const source = bankFeedUrl?.trim();
+  if (!source) return undefined;
+  try {
+    return new URL("/monitor/deposit-pool", source).toString();
+  } catch {
+    return undefined;
+  }
+}
+
+export interface TokenAmount {
+  /** Exact, canonical, non-negative integer in token base units. */
+  raw: string;
+  /** Absent only when a raw-only cap arrived before an asset read. */
+  decimals?: number;
+}
+
+export type DepositPoolFlowKind =
+  | "deposit"
+  | "withdraw"
+  | "redeem_requested"
+  | "redeem_fulfilled"
+  | "operator_principal_contributed"
+  | "venue_loss_written_off";
+
+export interface DepositPoolFlow {
+  kind: DepositPoolFlowKind;
+  blockNumber?: number;
+  transactionHash?: string;
+  logIndex?: number;
+  assets?: TokenAmount;
+  /** Kept exact; share decimals may be absent on partial producer payloads. */
+  sharesRaw?: string;
+  requestId?: string;
+  tier?: string;
+  unlockAt?: string;
+}
+
+export interface DepositPoolFlowWindow {
+  fromBlock?: number;
+  toBlock?: number;
+  maxBlocks?: number;
+  recentLimit?: number;
+}
+
+export interface DepositPoolFlows {
+  status: "ok" | "unavailable";
+  depositorCount?: number;
+  depositorCountModel?: string;
+  pendingUnfulfilledRedemptionShares?: TokenAmount;
+  pendingUnfulfilledRedemptionAssets?: TokenAmount;
+  recent: DepositPoolFlow[];
+  /** Complete qualifying set from the bounded window, separate from recent flows. */
+  sharePriceQualifyingEvents?: DepositPoolFlow[];
+  window?: DepositPoolFlowWindow;
+  lastError?: string;
+}
+
+export interface DepositPoolSnapshot {
+  schemaVersion: typeof DEPOSIT_POOL_SCHEMA_VERSION;
+  available: true;
+  pool?: string;
+  asset?: string;
+  block?: { number?: number; hash?: string; timestamp?: number };
+  pricingModel?: string;
+  totalAssets?: TokenAmount;
+  totalShares?: TokenAmount;
+  sharePrice?: TokenAmount;
+  buffer?: TokenAmount;
+  deployed?: TokenAmount;
+  reconciled?: boolean;
+  caps?: {
+    totalAssetCap?: TokenAmount;
+    perAgentAssetCap?: TokenAmount;
+    headroom?: TokenAmount;
+    utilizationBps?: number;
+  };
+  yieldStatus?: "not_yet_earning" | "earning";
+  yieldStatusText?: string;
+  flows?: DepositPoolFlows;
+}
+
+export type DepositPoolBlock =
+  | { snapshot: DepositPoolSnapshot }
+  | { unavailable: string }
+  | { fault: string };
+
+export async function readDepositPoolFeed(input: {
+  /** Exact URL derived from PRODUCT_HEALTH_BANK_FEED_URL's internal origin. */
+  url?: string;
+  fetchImpl: typeof fetch;
+  timeoutMs?: number;
+}): Promise<DepositPoolBlock> {
+  const url = input.url?.trim();
+  if (!url) {
+    return { unavailable: "deposit pool unreachable — internal Bank feed URL is not configured" };
+  }
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), input.timeoutMs ?? DEPOSIT_POOL_FEED_TIMEOUT_MS);
+  try {
+    const response = await input.fetchImpl(url, { signal: controller.signal });
+    if (!response.ok) {
+      return { unavailable: `deposit pool unreachable — platform returned HTTP ${response.status}` };
+    }
+    return normalizeDepositPoolFeed(await response.json());
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return { unavailable: `deposit pool unreachable — ${message}` };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/** Shape and arithmetic checks for the cross-repo v1 payload. */
+export function normalizeDepositPoolFeed(body: unknown): DepositPoolBlock {
+  if (!record(body)) return { fault: "deposit pool unreadable — payload was not an object" };
+  if (body.schemaVersion !== DEPOSIT_POOL_SCHEMA_VERSION) {
+    return { fault: `deposit pool unreadable — expected schemaVersion ${DEPOSIT_POOL_SCHEMA_VERSION}` };
+  }
+  if (body.available === false) {
+    const reason = nonEmptyString(body.reason) ?? "deposit_pool_not_configured";
+    return { unavailable: `deposit pool unavailable — ${reason}` };
+  }
+  if (body.available !== true) {
+    return { fault: "deposit pool unreadable — available must be true or false" };
+  }
+
+  const amountFields = ["totalAssets", "totalShares", "sharePrice", "buffer", "deployed"] as const;
+  const amounts: Partial<Record<(typeof amountFields)[number], TokenAmount>> = {};
+  for (const field of amountFields) {
+    const parsed = optionalAmount(body[field], field);
+    if (parsed.fault) return { fault: parsed.fault };
+    if (parsed.value) amounts[field] = parsed.value;
+  }
+
+  const block = optionalBlock(body.block);
+  if (block.fault) return { fault: block.fault };
+  const reconciliation = optionalReconciliation(body.reconciliation);
+  if (reconciliation.fault) return { fault: reconciliation.fault };
+  const caps = optionalCaps(body.caps);
+  if (caps.fault) return { fault: caps.fault };
+
+  if (body.reconciled !== undefined && typeof body.reconciled !== "boolean") {
+    return { fault: "deposit pool unreadable — reconciled is invalid" };
+  }
+  if (body.reconciled === false) {
+    return { fault: "deposit pool incoherent — producer reported reconciliation failure" };
+  }
+  if (reconciliation.value?.differenceRaw !== undefined && reconciliation.value.differenceRaw !== "0") {
+    return { fault: "deposit pool incoherent — producer reported a non-zero reconciliation difference" };
+  }
+  if (
+    amounts.buffer && amounts.deployed && amounts.totalAssets &&
+    !amountSumEquals(amounts.buffer, amounts.deployed, amounts.totalAssets)
+  ) {
+    return { fault: "deposit pool incoherent — buffer plus deployed does not equal total assets" };
+  }
+  if (
+    amounts.totalAssets && amounts.totalShares && amounts.sharePrice &&
+    !sharePriceIsConsistent(amounts.totalAssets, amounts.totalShares, amounts.sharePrice)
+  ) {
+    return { fault: "deposit pool incoherent — share price is inconsistent with total assets and shares" };
+  }
+
+  const yieldStatus = body.yieldStatus === undefined
+    ? undefined
+    : body.yieldStatus === "not_yet_earning" || body.yieldStatus === "earning"
+      ? body.yieldStatus
+      : null;
+  if (yieldStatus === null) return { fault: "deposit pool unreadable — yieldStatus is invalid" };
+  if (body.pool !== undefined && !nonEmptyString(body.pool)) {
+    return { fault: "deposit pool unreadable — pool is invalid" };
+  }
+  if (body.asset !== undefined && !nonEmptyString(body.asset)) {
+    return { fault: "deposit pool unreadable — asset is invalid" };
+  }
+  if (body.pricingModel !== undefined && !nonEmptyString(body.pricingModel)) {
+    return { fault: "deposit pool unreadable — pricingModel is invalid" };
+  }
+  if (body.yieldStatusText !== undefined && typeof body.yieldStatusText !== "string") {
+    return { fault: "deposit pool unreadable — yieldStatusText is invalid" };
+  }
+
+  const flows = optionalFlows(body.flows, amounts.totalAssets?.decimals);
+  const snapshot: DepositPoolSnapshot = {
+    schemaVersion: DEPOSIT_POOL_SCHEMA_VERSION,
+    available: true,
+    ...(body.pool === undefined ? {} : { pool: body.pool as string }),
+    ...(body.asset === undefined ? {} : { asset: body.asset as string }),
+    ...(block.value ? { block: block.value } : {}),
+    ...(body.pricingModel === undefined ? {} : { pricingModel: body.pricingModel as string }),
+    ...amounts,
+    ...(body.reconciled === undefined ? {} : { reconciled: body.reconciled }),
+    ...(caps.value ? { caps: caps.value } : {}),
+    ...(yieldStatus === undefined ? {} : { yieldStatus }),
+    ...(body.yieldStatusText === undefined ? {} : { yieldStatusText: body.yieldStatusText as string }),
+    ...(flows ? { flows } : {}),
+  };
+  return { snapshot };
+}
+
+function optionalAmount(raw: unknown, field: string): { value?: TokenAmount; fault?: string } {
+  if (raw === undefined) return {};
+  if (!record(raw)) return { fault: `deposit pool unreadable — ${field} is invalid` };
+  const amountRaw = decimalRaw(raw.raw);
+  const decimals = safeCount(raw.decimals);
+  if (amountRaw === undefined || decimals === undefined || decimals > 36) {
+    return { fault: `deposit pool unreadable — ${field} needs decimal-string raw and decimals` };
+  }
+  return { value: { raw: amountRaw, decimals } };
+}
+
+function optionalBlock(raw: unknown): {
+  value?: { number?: number; hash?: string; timestamp?: number };
+  fault?: string;
+} {
+  if (raw === undefined) return {};
+  if (!record(raw)) return { fault: "deposit pool unreadable — block is invalid" };
+  const number = optionalSafeCount(raw.number);
+  const timestamp = optionalSafeCount(raw.timestamp);
+  if (
+    number === null || timestamp === null ||
+    (raw.hash !== undefined && raw.hash !== null && !nonEmptyString(raw.hash))
+  ) {
+    return { fault: "deposit pool unreadable — block fields are invalid" };
+  }
+  return {
+    value: {
+      ...(number === undefined ? {} : { number }),
+      ...(raw.hash === undefined || raw.hash === null ? {} : { hash: raw.hash as string }),
+      ...(timestamp === undefined ? {} : { timestamp }),
+    },
+  };
+}
+
+function optionalReconciliation(raw: unknown): {
+  value?: { equation?: string; accountedRaw?: string; differenceRaw?: string };
+  fault?: string;
+} {
+  if (raw === undefined) return {};
+  if (!record(raw)) {
+    return { fault: "deposit pool unreadable — reconciliation is invalid" };
+  }
+  const equation = raw.equation === undefined ? undefined : nonEmptyString(raw.equation);
+  const accountedRaw = raw.accountedRaw === undefined ? undefined : decimalRaw(raw.accountedRaw);
+  const differenceRaw = raw.differenceRaw === undefined ? undefined : signedDecimalRaw(raw.differenceRaw);
+  if (
+    (raw.equation !== undefined && equation === undefined) ||
+    (raw.accountedRaw !== undefined && accountedRaw === undefined) ||
+    (raw.differenceRaw !== undefined && differenceRaw === undefined)
+  ) {
+    return { fault: "deposit pool unreadable — reconciliation fields are invalid" };
+  }
+  return {
+    value: {
+      ...(equation === undefined ? {} : { equation }),
+      ...(accountedRaw === undefined ? {} : { accountedRaw }),
+      ...(differenceRaw === undefined ? {} : { differenceRaw }),
+    },
+  };
+}
+
+function optionalCaps(raw: unknown): {
+  value?: DepositPoolSnapshot["caps"];
+  fault?: string;
+} {
+  if (raw === undefined) return {};
+  if (!record(raw)) return { fault: "deposit pool unreadable — caps is invalid" };
+  const names = ["totalAssetCap", "perAgentAssetCap", "headroom"] as const;
+  const value: NonNullable<DepositPoolSnapshot["caps"]> = {};
+  for (const field of names) {
+    const parsed = optionalAmount(raw[field], `caps.${field}`);
+    if (parsed.fault) return { fault: parsed.fault };
+    if (parsed.value) value[field] = parsed.value;
+  }
+  if (raw.utilizationBps !== undefined) {
+    const utilizationBps = raw.utilizationBps === null
+      ? undefined
+      : typeof raw.utilizationBps === "string" && /^\d+$/.test(raw.utilizationBps)
+        ? Number(raw.utilizationBps)
+        : safeCount(raw.utilizationBps);
+    if (utilizationBps === undefined || utilizationBps > 10_000) {
+      if (raw.utilizationBps !== null) {
+        return { fault: "deposit pool unreadable — caps.utilizationBps is invalid" };
+      }
+    } else {
+      value.utilizationBps = utilizationBps;
+    }
+  }
+  return { value };
+}
+
+function optionalFlows(
+  raw: unknown,
+  assetDecimals: number | undefined,
+): DepositPoolFlows | undefined {
+  if (raw === undefined) return undefined;
+  if (!record(raw)) return unavailableFlows("flows payload is invalid");
+  const status = raw.status === "ok" || raw.status === "unavailable" ? raw.status : null;
+  if (status === null) return unavailableFlows("flows.status is invalid");
+  const depositorCount = raw.depositorCount === null ? undefined : optionalSafeCount(raw.depositorCount);
+  if (depositorCount === null) return unavailableFlows("flows.depositorCount is invalid", raw);
+  const depositorCountModel = raw.depositorCountModel === undefined
+    ? undefined
+    : nonEmptyString(raw.depositorCountModel);
+  if (raw.depositorCountModel !== undefined && depositorCountModel === undefined) {
+    return unavailableFlows("flows.depositorCountModel is invalid", raw);
+  }
+  const pendingShares = nullableAmount(
+    raw.pendingUnfulfilledRedemptionShares,
+    "flows.pendingUnfulfilledRedemptionShares",
+  );
+  const pendingAssets = nullableAmount(
+    raw.pendingUnfulfilledRedemptionAssets,
+    "flows.pendingUnfulfilledRedemptionAssets",
+  );
+  if (pendingShares.fault) return unavailableFlows(pendingShares.fault, raw);
+  if (pendingAssets.fault) return unavailableFlows(pendingAssets.fault, raw);
+  const window = normalizeFlowWindow(raw.window);
+  if (window === null) return unavailableFlows("flows.window is invalid", raw);
+  if (raw.recent !== undefined && raw.recent !== null && !Array.isArray(raw.recent)) {
+    return unavailableFlows("flows.recent is invalid", raw);
+  }
+  const recent: DepositPoolFlow[] = [];
+  for (const entry of (raw.recent as unknown[] | null | undefined) ?? []) {
+    const flow = normalizeFlow(entry, assetDecimals);
+    if (flow) recent.push(flow);
+  }
+  if (
+    raw.sharePriceQualifyingEvents !== undefined &&
+    raw.sharePriceQualifyingEvents !== null &&
+    !Array.isArray(raw.sharePriceQualifyingEvents)
+  ) {
+    return unavailableFlows("flows.sharePriceQualifyingEvents is invalid", raw);
+  }
+  let sharePriceQualifyingEvents: DepositPoolFlow[] | undefined =
+    raw.sharePriceQualifyingEvents === undefined || raw.sharePriceQualifyingEvents === null ? undefined : [];
+  for (const entry of (raw.sharePriceQualifyingEvents as unknown[] | null | undefined) ?? []) {
+    const flow = normalizeFlow(entry, assetDecimals);
+    if (!flow) {
+      // An explicitly supplied but malformed proof list cannot prove absence.
+      // Disable the tombstone conclusion for this observation rather than
+      // laundering a bad entry into an empty qualifying set.
+      sharePriceQualifyingEvents = undefined;
+      break;
+    }
+    if (PRICE_QUALIFYING_FLOW_KINDS.has(flow.kind)) sharePriceQualifyingEvents?.push(flow);
+  }
+  const lastError = nonEmptyString(raw.lastError);
+  return {
+    status,
+    ...(depositorCount === undefined ? {} : { depositorCount }),
+    ...(depositorCountModel === undefined ? {} : { depositorCountModel }),
+    ...(pendingShares.value ? { pendingUnfulfilledRedemptionShares: pendingShares.value } : {}),
+    ...(pendingAssets.value ? { pendingUnfulfilledRedemptionAssets: pendingAssets.value } : {}),
+    recent,
+    ...(sharePriceQualifyingEvents ? { sharePriceQualifyingEvents } : {}),
+    ...(window === undefined ? {} : { window }),
+    ...(lastError ? { lastError } : {}),
+  };
+}
+
+function unavailableFlows(reason: string, raw?: Record<string, unknown>): DepositPoolFlows {
+  const window = normalizeFlowWindow(raw?.window);
+  return {
+    status: "unavailable",
+    recent: [],
+    ...(window && window !== null ? { window } : {}),
+    lastError: `deposit pool flows unreadable — ${reason}`,
+  };
+}
+
+function normalizeFlowWindow(raw: unknown): DepositPoolFlowWindow | undefined | null {
+  if (raw === undefined) return undefined;
+  if (!record(raw)) return null;
+  const value: DepositPoolFlowWindow = {};
+  for (const field of ["fromBlock", "toBlock", "maxBlocks", "recentLimit"] as const) {
+    if (raw[field] === undefined) continue;
+    const parsed = safeCount(raw[field]);
+    if (parsed === undefined) return null;
+    value[field] = parsed;
+  }
+  if (
+    value.fromBlock !== undefined && value.toBlock !== undefined && value.fromBlock > value.toBlock
+  ) return null;
+  return value;
+}
+
+function normalizeFlow(raw: unknown, assetDecimals: number | undefined): DepositPoolFlow | undefined {
+  if (!record(raw)) return undefined;
+  const kind = flowKind(raw.event ?? raw.type ?? raw.name);
+  if (!kind) return undefined;
+  const blockNumber = optionalSafeCount(raw.blockNumber);
+  const logIndex = optionalSafeCount(raw.logIndex);
+  const assetsRaw = raw.assetsRaw === undefined ? undefined : decimalRaw(raw.assetsRaw);
+  const sharesRaw = raw.sharesRaw === undefined ? undefined : decimalRaw(raw.sharesRaw);
+  if (blockNumber === null || logIndex === null) return undefined;
+  if (raw.assetsRaw !== undefined && assetsRaw === undefined) return undefined;
+  if (raw.sharesRaw !== undefined && sharesRaw === undefined) return undefined;
+  const transactionHash = nonEmptyString(raw.transactionHash ?? raw.txHash);
+  const requestId = raw.requestId === undefined ? undefined : nonEmptyString(raw.requestId);
+  const tier = raw.tier === undefined ? undefined : decimalRaw(raw.tier);
+  const unlockAt = raw.unlockAt === undefined ? undefined : decimalRaw(raw.unlockAt);
+  if (raw.requestId !== undefined && requestId === undefined) return undefined;
+  if (raw.tier !== undefined && tier === undefined) return undefined;
+  if (raw.unlockAt !== undefined && unlockAt === undefined) return undefined;
+  return {
+    kind,
+    ...(blockNumber === undefined ? {} : { blockNumber }),
+    ...(transactionHash ? { transactionHash } : {}),
+    ...(logIndex === undefined ? {} : { logIndex }),
+    ...(assetsRaw === undefined
+      ? {}
+      : { assets: { raw: assetsRaw, ...(assetDecimals === undefined ? {} : { decimals: assetDecimals }) } }),
+    ...(sharesRaw === undefined ? {} : { sharesRaw }),
+    ...(requestId === undefined ? {} : { requestId }),
+    ...(tier === undefined ? {} : { tier }),
+    ...(unlockAt === undefined ? {} : { unlockAt }),
+  };
+}
+
+function flowKind(value: unknown): DepositPoolFlowKind | undefined {
+  if (typeof value !== "string") return undefined;
+  const key = value.replace(/[^a-zA-Z0-9]/g, "").toLowerCase();
+  return ({
+    deposit: "deposit",
+    withdraw: "withdraw",
+    redeemrequested: "redeem_requested",
+    redeemfulfilled: "redeem_fulfilled",
+    operatorprincipalcontributed: "operator_principal_contributed",
+    venuelosswrittenoff: "venue_loss_written_off",
+  } as Record<string, DepositPoolFlowKind>)[key];
+}
+
+const PRICE_QUALIFYING_FLOW_KINDS = new Set<DepositPoolFlowKind>([
+  "operator_principal_contributed",
+  "redeem_fulfilled",
+  "venue_loss_written_off",
+]);
+
+function nullableAmount(raw: unknown, field: string): { value?: TokenAmount; fault?: string } {
+  if (raw === undefined || raw === null) return {};
+  return optionalAmount(raw, field);
+}
+
+function amountSumEquals(a: TokenAmount, b: TokenAmount, total: TokenAmount): boolean {
+  if (a.decimals === undefined || b.decimals === undefined || total.decimals === undefined) return false;
+  const scale = Math.max(a.decimals, b.decimals, total.decimals);
+  return scaledRaw(a, scale) + scaledRaw(b, scale) === scaledRaw(total, scale);
+}
+
+function sharePriceIsConsistent(assets: TokenAmount, shares: TokenAmount, price: TokenAmount): boolean {
+  if (assets.decimals === undefined || shares.decimals === undefined || price.decimals === undefined) return false;
+  const shareRaw = BigInt(shares.raw);
+  // A born-empty pool has no ratio to reconstruct. Its initial quoted price is
+  // still a live contract read and is rendered as such; the first non-zero
+  // share observation makes this check determinate.
+  if (shareRaw === 0n) return true;
+  const numerator = BigInt(assets.raw) * 10n ** BigInt(price.decimals + shares.decimals);
+  const denominator = shareRaw * 10n ** BigInt(assets.decimals);
+  const expected = numerator / denominator;
+  const actual = BigInt(price.raw);
+  const difference = actual >= expected ? actual - expected : expected - actual;
+  return difference <= 1n;
+}
+
+function scaledRaw(amount: TokenAmount, decimals: number): bigint {
+  return BigInt(amount.raw) * 10n ** BigInt(decimals - (amount.decimals ?? decimals));
+}
+
+function decimalRaw(value: unknown): string | undefined {
+  if (typeof value !== "string" || !/^\d+$/.test(value)) return undefined;
+  return BigInt(value).toString();
+}
+
+function signedDecimalRaw(value: unknown): string | undefined {
+  if (typeof value !== "string" || !/^-?\d+$/.test(value)) return undefined;
+  return BigInt(value).toString();
+}
+
+function safeCount(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isSafeInteger(value) && value >= 0 ? value : undefined;
+}
+
+function optionalSafeCount(value: unknown): number | null | undefined {
+  return value === undefined ? undefined : safeCount(value) ?? null;
+}
+
+function nonEmptyString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function record(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}

--- a/services/slack-operator/src/index.ts
+++ b/services/slack-operator/src/index.ts
@@ -201,6 +201,7 @@ import type { TransportFailureRun } from "./probe-transport.js";
 import { deriveOpsVerdict } from "@avg/schemas";
 import { appendIncidents, readIncidents, reconcileIncidents } from "./product-health-incidents.js";
 import { readArrivalsFeed } from "./arrivals-feed.js";
+import { depositPoolUrlFromBankFeed, readDepositPoolFeed } from "./deposit-pool-feed.js";
 import {
   loadRemediationConfig,
   decideRpcRemediation,
@@ -911,6 +912,14 @@ async function handleHttpRequest(request: http.IncomingMessage, response: http.S
         unavailable: routineConfig.productHealth.enabled
           ? "arrivals feed unreachable — awaiting the first product-health read"
           : "arrivals feed unreachable — product-health heartbeat is disabled",
+      },
+      // Packet 5b is intentionally deployable before the platform endpoint.
+      // Always state the missing reading: omission and a born-empty pool must
+      // never collapse into the same visual state.
+      depositPool: productHealthSnapshotBlocks?.depositPool ?? {
+        unavailable: routineConfig.productHealth.enabled
+          ? "deposit pool unreachable — awaiting the first product-health read"
+          : "deposit pool unreachable — product-health heartbeat is disabled",
       },
       // History-derived Trends + Incidents (uptime% / latency / balance series +
       // incident episodes) from the rolling buffer. Always present — the series
@@ -3678,7 +3687,7 @@ function startOperatorRoutines() {
       const activeRpc = remediationConfig.endpoints[rpcRemediationState.activeIndex] ?? phConfig.rpcUrl;
       // One /health fetch feeds product_api + chain_height; the block-advance tracker
       // persists across ticks to catch a frozen chain. Balances come from direct RPC.
-      const [collection, arrivals] = await Promise.all([
+      const [collection, arrivals, depositPool] = await Promise.all([
         collectProductHealthProbes({ ...phConfig, signerAddress, rpcUrl: activeRpc }, fetch, {
           advance: productHealthChainAdvance,
           nowMs: Date.now(),
@@ -3689,10 +3698,17 @@ function startOperatorRoutines() {
         // Same public platform, separate contract. Read beside the heartbeat so
         // one slow arrivals response does not serialize every money-path probe.
         readArrivalsFeed({ baseUrl: phConfig.apiBaseUrl, fetchImpl: fetch }),
+        // Same platform, independent endpoint and failure boundary. A pre-5a
+        // 404 becomes an explicit UNAVAILABLE pool tile without affecting the
+        // rest of the heartbeat.
+        readDepositPoolFeed({
+          url: depositPoolUrlFromBankFeed(phConfig.bankFeedUrl),
+          fetchImpl: fetch,
+        }),
       ]);
       productHealthChainAdvance = collection.chainAdvance;
       productHealthTransportRun = collection.transportRun;
-      productHealthSnapshotBlocks = { ...collection.snapshot, arrivals };
+      productHealthSnapshotBlocks = { ...collection.snapshot, arrivals, depositPool };
       // Decide + apply RPC auto-remediation from this cycle's read health. Pure
       // decision; the only effect is rotating which endpoint we read next tick
       // (state.activeIndex) + dispatching an audit (failover) or page (escalate).
@@ -3724,7 +3740,7 @@ function startOperatorRoutines() {
         runProbes: async () => collection.probes,
         // Money signals that are not probes (payout evidence) + the monitor's
         // own version reach the alert path through here.
-        getSnapshot: () => collection.snapshot,
+        getSnapshot: () => productHealthSnapshotBlocks,
         alert: (payload) => alertChannel.dispatch(payload),
         boardUrl:
           optionalEnv("SLACK_OPERATOR_MONITOR_URL", "https://monitor.averray.com/monitor") ??

--- a/services/slack-operator/src/money-alert.ts
+++ b/services/slack-operator/src/money-alert.ts
@@ -22,6 +22,7 @@
 //     longer exists, and you cannot judge that from the message text alone.
 
 import type { ProductHealthSnapshotBlocks } from "./product-health.js";
+import type { DepositPoolFlow, DepositPoolSnapshot, TokenAmount } from "./deposit-pool-feed.js";
 
 export interface MoneyAlert {
   /** Money-blocking lines, most consequential first. Empty ⇒ nothing to page. */
@@ -31,6 +32,172 @@ export interface MoneyAlert {
    * caller can fold it into the existing rising-edge/cooldown logic.
    */
   key: string;
+}
+
+export interface DepositPoolAlertObservation {
+  sharePriceRaw?: string;
+  sharePriceDecimals?: number;
+  pricingModel?: string;
+  blockNumber?: number;
+  depositorCount?: number;
+}
+
+export interface DepositPoolAlertState {
+  previous?: DepositPoolAlertObservation;
+  /** Durable for this monitor process: a later withdrawal must not re-arm joy. */
+  firstDepositPaged: boolean;
+}
+
+export interface DepositPoolAlertDecision {
+  criticalLines: string[];
+  positiveLines: string[];
+  /** Conditions that remain true until repaired (plus critical transitions). */
+  criticalKey: string;
+  /** One-shot milestones; never becomes part of the ongoing red-set key. */
+  positiveKey: string;
+  /** Stable key folded into product-health's existing rising-edge/cooldown gate. */
+  key: string;
+  state: DepositPoolAlertState;
+}
+
+export function initialDepositPoolAlertState(): DepositPoolAlertState {
+  return { firstDepositPaged: false };
+}
+
+const SHARE_PRICE_QUALIFYING_EVENTS = new Set([
+  "operator_principal_contributed",
+  "redeem_fulfilled",
+  "venue_loss_written_off",
+]);
+
+/**
+ * The deposit pool's stateful money-page conditions. PURE.
+ *
+ * The tombstone detector only concludes "no qualifying event" when the
+ * producer says the flows read succeeded AND its stated bounded window covers
+ * the two observations. A log blind spot is not proof of an attack signature.
+ * Buffer-floor paging is deliberately keyed to `yieldStatus === "earning"`:
+ * the ceremony flips the platform's one signal and the already-deployed board
+ * starts enforcing it on the next observation.
+ */
+export function decideDepositPoolAlerts(input: {
+  current: DepositPoolSnapshot;
+  state: DepositPoolAlertState;
+}): DepositPoolAlertDecision {
+  const { current } = input;
+  const previous = input.state.previous;
+  const criticalLines: string[] = [];
+  const positiveLines: string[] = [];
+  const criticalKeys: string[] = [];
+  const positiveKeys: string[] = [];
+
+  if (
+    previous?.pricingModel === "principal-cost-basis" &&
+    current.pricingModel === "principal-cost-basis" &&
+    previous.sharePriceRaw !== undefined &&
+    previous.sharePriceDecimals !== undefined &&
+    current.sharePrice?.decimals !== undefined &&
+    !sameAmount(
+      { raw: previous.sharePriceRaw, decimals: previous.sharePriceDecimals },
+      current.sharePrice,
+    ) &&
+    windowCoversObservations(previous.blockNumber, current.block?.number, current) &&
+    current.flows?.sharePriceQualifyingEvents !== undefined &&
+    !hasQualifyingEventBetween(
+      current.flows.sharePriceQualifyingEvents,
+      previous.blockNumber,
+      current.block?.number,
+    )
+  ) {
+    criticalLines.push(
+      "• 🚨 CRITICAL #1051 tombstone probe: principal-cost-basis share price moved without OperatorPrincipalContributed, RedeemFulfilled, or VenueLossWrittenOff (owner loss write-off) in the same observed window",
+    );
+    criticalKeys.push(
+      `deposit-pool:tombstone:${previous.blockNumber ?? "?"}:${current.block?.number ?? "?"}:` +
+      `${previous.sharePriceRaw}->${current.sharePrice.raw}`,
+    );
+  }
+
+  const pending = current.flows?.pendingUnfulfilledRedemptionAssets;
+  if (
+    current.yieldStatus === "earning" &&
+    current.buffer && pending &&
+    compareAmounts(current.buffer, pending) < 0
+  ) {
+    criticalLines.push(
+      "• 🔴 deposit pool buffer below pending unfulfilled redemptions while yield is earning — restore liquid coverage",
+    );
+    // The crossing is the alert. Do not churn the key as amounts move while it
+    // remains breached; product health's cooldown owns reminders.
+    criticalKeys.push("deposit-pool:buffer-floor");
+  }
+
+  const depositorCount = current.flows?.depositorCount;
+  const firstDeposit =
+    !input.state.firstDepositPaged &&
+    previous?.depositorCount === 0 &&
+    depositorCount === 1;
+  if (firstDeposit) {
+    positiveLines.push("• 🌱 first deposit observed — the pool has crossed from born empty to one depositor");
+    positiveKeys.push("deposit-pool:first-deposit");
+  }
+
+  return {
+    criticalLines,
+    positiveLines,
+    criticalKey: criticalKeys.join("|"),
+    positiveKey: positiveKeys.join("|"),
+    key: [...criticalKeys, ...positiveKeys].join("|"),
+    state: {
+      previous: nextObservation(previous, current),
+      firstDepositPaged: input.state.firstDepositPaged || firstDeposit,
+    },
+  };
+}
+
+function nextObservation(
+  previous: DepositPoolAlertObservation | undefined,
+  current: DepositPoolSnapshot,
+): DepositPoolAlertObservation {
+  const next = { ...(previous ?? {}) };
+  // A failed/old producer log read cannot prove whether a price movement had a
+  // qualifying event. Keep the last comparable baseline so a later successful
+  // bounded window can still adjudicate the movement instead of erasing it.
+  if (
+    current.flows?.status === "ok" &&
+    current.flows.sharePriceQualifyingEvents !== undefined &&
+    current.flows.window?.fromBlock !== undefined &&
+    current.flows.window.toBlock !== undefined &&
+    current.sharePrice?.decimals !== undefined &&
+    current.block?.number !== undefined
+  ) {
+    next.sharePriceRaw = current.sharePrice.raw;
+    next.sharePriceDecimals = current.sharePrice.decimals;
+    if (current.pricingModel === undefined) delete next.pricingModel;
+    else next.pricingModel = current.pricingModel;
+    next.blockNumber = current.block.number;
+  }
+  // Likewise, an unavailable flow read must not erase the 0 needed to observe
+  // the later 0→1 milestone.
+  if (current.flows?.depositorCount !== undefined) {
+    next.depositorCount = current.flows.depositorCount;
+  }
+  return next;
+}
+
+function hasQualifyingEventBetween(
+  events: DepositPoolFlow[],
+  previousBlock: number | undefined,
+  currentBlock: number | undefined,
+): boolean {
+  if (previousBlock === undefined || currentBlock === undefined) return false;
+  return events.some(
+    (flow) =>
+      SHARE_PRICE_QUALIFYING_EVENTS.has(flow.kind) &&
+      flow.blockNumber !== undefined &&
+      flow.blockNumber > previousBlock &&
+      flow.blockNumber <= currentBlock,
+  );
 }
 
 /**
@@ -102,4 +269,30 @@ export function alertProvenance(snapshot?: ProductHealthSnapshotBlocks): string 
 
 function short(sha: string | null): string {
   return sha ? sha.slice(0, 8) : "unknown";
+}
+
+function windowCoversObservations(
+  previousBlock: number | undefined,
+  currentBlock: number | undefined,
+  pool: DepositPoolSnapshot,
+): boolean {
+  if (previousBlock === undefined || currentBlock === undefined) return false;
+  if (pool.flows?.status !== "ok") return false;
+  const from = pool.flows.window?.fromBlock;
+  const to = pool.flows.window?.toBlock;
+  if (from === undefined || to === undefined) return false;
+  const firstRelevantBlock = currentBlock === previousBlock ? currentBlock : previousBlock + 1;
+  return from <= firstRelevantBlock && to >= currentBlock;
+}
+
+function sameAmount(a: TokenAmount, b: TokenAmount): boolean {
+  return compareAmounts(a, b) === 0;
+}
+
+function compareAmounts(a: TokenAmount, b: TokenAmount): number {
+  if (a.decimals === undefined || b.decimals === undefined) return Number.NaN;
+  const scale = Math.max(a.decimals, b.decimals);
+  const left = BigInt(a.raw) * 10n ** BigInt(scale - a.decimals);
+  const right = BigInt(b.raw) * 10n ** BigInt(scale - b.decimals);
+  return left < right ? -1 : left > right ? 1 : 0;
 }

--- a/services/slack-operator/src/product-health.ts
+++ b/services/slack-operator/src/product-health.ts
@@ -41,12 +41,20 @@ import { endpointHost, pinnedCompareRange, type CrossCheckView } from "./payout-
 import { burnBasisLabel, isBurnUnmeasurable, type MeasuredBurn } from "./gas-burn-rate.js";
 import { readBankFeed } from "./bank-feed-fetch.js";
 import type { ArrivalsBlock } from "./arrivals-feed.js";
+import type { DepositPoolBlock } from "./deposit-pool-feed.js";
 import { collectCredentialExpiries, credentialExpiryProbe, tlsCertReader } from "./credential-expiry.js";
 import { bankFeedIsDisabled } from "./bank-feed.js";
 import { bankLaneView, BANK_FEED_DISABLED, type BankLaneView } from "./bank-lane.js";
 import { createCrossCheckCache, type CrossCheckCache } from "./payout-crosscheck-cache.js";
 import { createGasSpendCache, type GasSpendCache, type GasSpendSnapshot, type GasUnreadable } from "./gas-spend-cache.js";
-import { alertProvenance, decideMoneyAlert } from "./money-alert.js";
+import {
+  alertProvenance,
+  decideDepositPoolAlerts,
+  decideMoneyAlert,
+  initialDepositPoolAlertState,
+  type DepositPoolAlertDecision,
+  type DepositPoolAlertState,
+} from "./money-alert.js";
 import { decideSelfFreshness, fetchSelfCompare } from "./self-freshness.js";
 import type { SelfFreshness } from "./self-freshness.js";
 import {
@@ -2704,6 +2712,8 @@ export interface ProductHealthSnapshotBlocks {
    * snapshots and older monitor builds.
    */
   arrivals?: ArrivalsBlock;
+  /** Bank-pillar depositor pool, explicit even when its platform endpoint is unavailable. */
+  depositPool?: DepositPoolBlock;
 }
 
 export interface BankBlock {
@@ -3185,6 +3195,7 @@ export function buildProductHealthAlert(
   evaluation: ProductHealthEvaluation,
   boardUrl: string,
   snapshot?: ProductHealthSnapshotBlocks,
+  poolAlerts?: Pick<DepositPoolAlertDecision, "criticalLines" | "positiveLines">,
 ): AlertPayload {
   // Money first. A red api_latency and a red money_path used to render
   // identically, so the thing that costs money could sit below the thing that
@@ -3194,13 +3205,19 @@ export function buildProductHealthAlert(
   );
   const money = decideMoneyAlert(snapshot);
   const probeLines = ordered.map((p) => `• 🔴 ${p.name}: ${p.detail}`);
-  const lines = [...money.lines, ...probeLines];
-  const count = evaluation.redProbes.length + money.lines.length;
-  const head =
-    count === 1 ? "1 money-blocking signal" : `${count} money-blocking signals`;
+  const criticalLines = poolAlerts?.criticalLines ?? [];
+  const positiveLines = poolAlerts?.positiveLines ?? [];
+  const lines = [...criticalLines, ...money.lines, ...probeLines, ...positiveLines];
+  const criticalCount = evaluation.redProbes.length + money.lines.length + criticalLines.length;
+  const count = criticalCount + positiveLines.length;
+  const head = criticalCount === 0 && positiveLines.length > 0
+    ? "first deposit observed"
+    : criticalCount === 1
+      ? "1 money-blocking signal"
+      : `${criticalCount} money-blocking signals`;
   const provenance = alertProvenance(snapshot);
   const text = [
-    `:rotating_light: Averray product health — ${head}`,
+    `${criticalCount === 0 ? ":tada:" : ":rotating_light:"} Averray product health — ${head}`,
     ...lines,
     `Inspect: ${boardUrl}`,
     ...(provenance ? [provenance] : []),
@@ -3214,10 +3231,12 @@ export interface ProductHealthAlertState {
   /** The red-set key at the previous red episode ("" when last clear). */
   lastRedKey: string;
   lastAlertAtMs: number;
+  /** Optional for stored/manual pre-pool state; initialized on first pool read. */
+  depositPool?: DepositPoolAlertState;
 }
 
 export function initialProductHealthAlertState(): ProductHealthAlertState {
-  return { lastRedKey: "", lastAlertAtMs: 0 };
+  return { lastRedKey: "", lastAlertAtMs: 0, depositPool: initialDepositPoolAlertState() };
 }
 
 /**
@@ -3232,23 +3251,61 @@ export function decideProductHealthAlert(input: {
   cooldownMs: number;
   /** Snapshot blocks, so a money signal that is not a probe can still page. */
   snapshot?: ProductHealthSnapshotBlocks;
-}): { alert: boolean; state: ProductHealthAlertState } {
+}): {
+  alert: boolean;
+  state: ProductHealthAlertState;
+  poolAlerts?: DepositPoolAlertDecision;
+} {
   const money = decideMoneyAlert(input.snapshot);
+  const poolBlock = input.snapshot?.depositPool;
+  const poolAlerts = poolBlock && "snapshot" in poolBlock
+    ? decideDepositPoolAlerts({
+        current: poolBlock.snapshot,
+        state: input.state.depositPool ?? initialDepositPoolAlertState(),
+      })
+    : undefined;
   // A payout shortfall is not a probe, so it never reached this gate: the
   // system could see "14 settled, 2 confirmed" and stay silent. Fold it in so
   // it pages on its own, and so a CHANGE in the gap re-pages.
-  const key = [redProbeKey(input.evaluation), money.key].filter(Boolean).join("|");
-  const worthPaging = input.evaluation.status === "red" || money.key !== "";
-  if (!worthPaging || key === "") {
-    return { alert: false, state: { lastRedKey: "", lastAlertAtMs: input.state.lastAlertAtMs } };
+  const key = [redProbeKey(input.evaluation), money.key, poolAlerts?.criticalKey].filter(Boolean).join("|");
+  const positiveEdge = Boolean(poolAlerts?.positiveKey);
+  const worthPaging = input.evaluation.status === "red" || money.key !== "" ||
+    Boolean(poolAlerts?.criticalKey) || positiveEdge;
+  const nextPoolState = poolAlerts?.state ?? input.state.depositPool;
+  if (!worthPaging || (key === "" && !positiveEdge)) {
+    return {
+      alert: false,
+      state: {
+        lastRedKey: "",
+        lastAlertAtMs: input.state.lastAlertAtMs,
+        ...(nextPoolState ? { depositPool: nextPoolState } : {}),
+      },
+      ...(poolAlerts ? { poolAlerts } : {}),
+    };
   }
-  const changed = key !== input.state.lastRedKey;
+  const changed = positiveEdge || key !== input.state.lastRedKey;
   const cooldownElapsed =
     input.cooldownMs > 0 && input.nowMs - input.state.lastAlertAtMs >= input.cooldownMs;
   if (changed || cooldownElapsed) {
-    return { alert: true, state: { lastRedKey: key, lastAlertAtMs: input.nowMs } };
+    return {
+      alert: true,
+      state: {
+        lastRedKey: key,
+        lastAlertAtMs: input.nowMs,
+        ...(nextPoolState ? { depositPool: nextPoolState } : {}),
+      },
+      ...(poolAlerts ? { poolAlerts } : {}),
+    };
   }
-  return { alert: false, state: { ...input.state, lastRedKey: key } };
+  return {
+    alert: false,
+    state: {
+      ...input.state,
+      lastRedKey: key,
+      ...(nextPoolState ? { depositPool: nextPoolState } : {}),
+    },
+    ...(poolAlerts ? { poolAlerts } : {}),
+  };
 }
 
 // ── Orchestrator (effect-injected; index.ts wires real probes + Slack channel) ──
@@ -3279,7 +3336,7 @@ export async function runProductHealthOnce(deps: ProductHealthDeps): Promise<Pro
   const probes = await deps.runProbes();
   const evaluation = evaluateProductHealth(probes);
   const snapshot = deps.getSnapshot?.();
-  const { alert, state } = decideProductHealthAlert({
+  const { alert, state, poolAlerts } = decideProductHealthAlert({
     evaluation,
     state: deps.getAlertState(),
     nowMs: deps.nowMs(),
@@ -3289,7 +3346,7 @@ export async function runProductHealthOnce(deps: ProductHealthDeps): Promise<Pro
   deps.setAlertState(state);
   let alerted = false;
   if (alert) {
-    await deps.alert(buildProductHealthAlert(evaluation, deps.boardUrl, snapshot));
+    await deps.alert(buildProductHealthAlert(evaluation, deps.boardUrl, snapshot, poolAlerts));
     alerted = true;
   }
   return { status: evaluation.status, evaluation, alerted };

--- a/test/unit/deposit-pool-alert.test.ts
+++ b/test/unit/deposit-pool-alert.test.ts
@@ -1,0 +1,244 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  decideDepositPoolAlerts,
+  initialDepositPoolAlertState,
+} from "../../services/slack-operator/src/money-alert.js";
+import type { DepositPoolSnapshot } from "../../services/slack-operator/src/deposit-pool-feed.js";
+import {
+  buildProductHealthAlert,
+  decideProductHealthAlert,
+  evaluateProductHealth,
+  initialProductHealthAlertState,
+} from "../../services/slack-operator/src/product-health.js";
+
+const amount = (raw: string) => ({ raw, decimals: 6 });
+
+function pool(overrides: Partial<DepositPoolSnapshot> = {}): DepositPoolSnapshot {
+  return {
+    schemaVersion: 1,
+    available: true,
+    block: { number: 100 },
+    pricingModel: "principal-cost-basis",
+    totalAssets: amount("1000000"),
+    totalShares: amount("1000000"),
+    sharePrice: amount("1000000"),
+    buffer: amount("1000000"),
+    deployed: amount("0"),
+    reconciled: true,
+    yieldStatus: "not_yet_earning",
+    flows: {
+      status: "ok",
+      depositorCount: 0,
+      pendingUnfulfilledRedemptionAssets: amount("0"),
+      recent: [],
+      sharePriceQualifyingEvents: [],
+      window: { fromBlock: 90, toBlock: 100, maxBlocks: 11, recentLimit: 8 },
+    },
+    ...overrides,
+  };
+}
+
+function observe(
+  current: DepositPoolSnapshot,
+  state = initialDepositPoolAlertState(),
+) {
+  return decideDepositPoolAlerts({ current, state });
+}
+
+describe("the #1051 tombstone probe", () => {
+  it("pages critically when cost-basis share price moves without a qualifying event", () => {
+    const first = observe(pool());
+    const moved = observe(pool({
+      block: { number: 101 },
+      totalAssets: amount("1100000"),
+      sharePrice: amount("1100000"),
+      buffer: amount("1100000"),
+      flows: {
+        ...pool().flows,
+        window: { fromBlock: 101, toBlock: 101, maxBlocks: 1, recentLimit: 8 },
+      },
+    }), first.state);
+    expect(moved.criticalLines).toHaveLength(1);
+    expect(moved.criticalLines[0]).toContain("#1051 tombstone probe");
+    expect(moved.key).toContain("deposit-pool:tombstone");
+  });
+
+  it("does not page when the same window contains a qualifying principal event", () => {
+    const first = observe(pool());
+    const moved = observe(pool({
+      block: { number: 101 },
+      totalAssets: amount("1100000"),
+      sharePrice: amount("1100000"),
+      buffer: amount("1100000"),
+      flows: {
+        ...pool().flows,
+        sharePriceQualifyingEvents: [{ kind: "operator_principal_contributed", blockNumber: 101 }],
+        window: { fromBlock: 101, toBlock: 101, maxBlocks: 1, recentLimit: 8 },
+      },
+    }), first.state);
+    expect(moved.criticalLines).toEqual([]);
+    expect(moved.key).toBe("");
+  });
+
+  it("retains the last comparable baseline across a log-read outage", () => {
+    const first = observe(pool());
+    const blind = observe(pool({
+      block: { number: 101 },
+      totalAssets: amount("1100000"),
+      sharePrice: amount("1100000"),
+      buffer: amount("1100000"),
+      flows: {
+        status: "unavailable",
+        recent: [],
+        lastError: "eth_getLogs timed out",
+        window: { fromBlock: 101, toBlock: 101, maxBlocks: 1, recentLimit: 8 },
+      },
+    }), first.state);
+    expect(blind.criticalLines).toEqual([]);
+
+    const recovered = observe(pool({
+      block: { number: 102 },
+      totalAssets: amount("1100000"),
+      sharePrice: amount("1100000"),
+      buffer: amount("1100000"),
+      flows: {
+        ...pool().flows,
+        window: { fromBlock: 101, toBlock: 102, maxBlocks: 2, recentLimit: 8 },
+      },
+    }), blind.state);
+    expect(recovered.criticalLines).toHaveLength(1);
+  });
+});
+
+describe("the buffer-floor ceremony switch", () => {
+  const underPending = {
+    buffer: amount("400000"),
+    deployed: amount("600000"),
+    flows: {
+      ...pool().flows,
+      pendingUnfulfilledRedemptionAssets: amount("500000"),
+    },
+  } satisfies Partial<DepositPoolSnapshot>;
+
+  it("is wired but OFF before yield is earning", () => {
+    expect(observe(pool({ ...underPending, yieldStatus: "not_yet_earning" })).criticalLines).toEqual([]);
+  });
+
+  it("flips on from the same yieldStatus signal, without a board release", () => {
+    const result = observe(pool({ ...underPending, yieldStatus: "earning" }));
+    expect(result.criticalLines).toHaveLength(1);
+    expect(result.criticalLines[0]).toContain("buffer below pending unfulfilled redemptions");
+  });
+});
+
+describe("the first-deposit milestone", () => {
+  it("fires exactly once across repeated observations, including a later 0 → 1", () => {
+    const zero = observe(pool());
+    const first = observe(pool({ flows: { ...pool().flows, depositorCount: 1 } }), zero.state);
+    const repeated = observe(pool({ flows: { ...pool().flows, depositorCount: 1 } }), first.state);
+    const backToZero = observe(pool(), repeated.state);
+    const secondCrossing = observe(pool({ flows: { ...pool().flows, depositorCount: 1 } }), backToZero.state);
+
+    expect(first.positiveLines).toHaveLength(1);
+    expect(first.positiveLines[0]).toContain("first deposit");
+    expect(repeated.positiveLines).toEqual([]);
+    expect(secondCrossing.positiveLines).toEqual([]);
+  });
+});
+
+describe("the existing off-device money-alert path", () => {
+  const healthy = evaluateProductHealth([{ name: "product_api", status: "ok", detail: "200" }]);
+
+  it("folds the tombstone signal into a critical product-health page", () => {
+    const baseline = decideProductHealthAlert({
+      evaluation: healthy,
+      state: initialProductHealthAlertState(),
+      nowMs: 1_000,
+      cooldownMs: 60_000,
+      snapshot: { depositPool: { snapshot: pool() } },
+    });
+    const movedPool = pool({
+      block: { number: 101 },
+      totalAssets: amount("1100000"),
+      sharePrice: amount("1100000"),
+      buffer: amount("1100000"),
+      flows: {
+        ...pool().flows,
+        window: { fromBlock: 101, toBlock: 101, maxBlocks: 1, recentLimit: 8 },
+      },
+    });
+    const moved = decideProductHealthAlert({
+      evaluation: healthy,
+      state: baseline.state,
+      nowMs: 2_000,
+      cooldownMs: 60_000,
+      snapshot: { depositPool: { snapshot: movedPool } },
+    });
+    expect(moved.alert).toBe(true);
+    const payload = buildProductHealthAlert(
+      healthy,
+      "https://monitor.example",
+      { depositPool: { snapshot: movedPool } },
+      moved.poolAlerts,
+    );
+    expect(payload.text).toContain(":rotating_light:");
+    expect(payload.text).toContain("CRITICAL #1051 tombstone probe");
+  });
+
+  it("pages the first deposit once through the same dedup state", () => {
+    const zero = decideProductHealthAlert({
+      evaluation: healthy,
+      state: initialProductHealthAlertState(),
+      nowMs: 1_000,
+      cooldownMs: 60_000,
+      snapshot: { depositPool: { snapshot: pool() } },
+    });
+    const one = pool({ flows: { ...pool().flows, depositorCount: 1 } });
+    const first = decideProductHealthAlert({
+      evaluation: healthy,
+      state: zero.state,
+      nowMs: 2_000,
+      cooldownMs: 60_000,
+      snapshot: { depositPool: { snapshot: one } },
+    });
+    const repeated = decideProductHealthAlert({
+      evaluation: healthy,
+      state: first.state,
+      nowMs: 3_000,
+      cooldownMs: 60_000,
+      snapshot: { depositPool: { snapshot: one } },
+    });
+    expect(first.alert).toBe(true);
+    expect(first.poolAlerts?.positiveLines).toHaveLength(1);
+    expect(repeated.alert).toBe(false);
+  });
+
+  it("does not re-page an unrelated ongoing red after the positive milestone clears", () => {
+    const red = evaluateProductHealth([{ name: "chain_height", status: "red", detail: "halt" }]);
+    const zero = decideProductHealthAlert({
+      evaluation: red,
+      state: initialProductHealthAlertState(),
+      nowMs: 1_000,
+      cooldownMs: 60_000,
+      snapshot: { depositPool: { snapshot: pool() } },
+    });
+    const one = pool({ flows: { ...pool().flows, depositorCount: 1 } });
+    const milestone = decideProductHealthAlert({
+      evaluation: red,
+      state: zero.state,
+      nowMs: 2_000,
+      cooldownMs: 60_000,
+      snapshot: { depositPool: { snapshot: one } },
+    });
+    const repeated = decideProductHealthAlert({
+      evaluation: red,
+      state: milestone.state,
+      nowMs: 3_000,
+      cooldownMs: 60_000,
+      snapshot: { depositPool: { snapshot: one } },
+    });
+    expect(milestone.alert).toBe(true);
+    expect(repeated.alert).toBe(false);
+  });
+});

--- a/test/unit/deposit-pool-feed.test.ts
+++ b/test/unit/deposit-pool-feed.test.ts
@@ -1,0 +1,173 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  depositPoolUrlFromBankFeed,
+  normalizeDepositPoolFeed,
+  readDepositPoolFeed,
+} from "../../services/slack-operator/src/deposit-pool-feed.js";
+import { loadProductHealthConfig } from "../../services/slack-operator/src/product-health.js";
+
+const amount = (raw: string) => ({ raw, decimals: 6 });
+
+function payload(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    schemaVersion: 1,
+    available: true,
+    pool: "0x1111111111111111111111111111111111111111",
+    asset: "0x2222222222222222222222222222222222222222",
+    block: { number: 101, hash: "0xabc", timestamp: 1_786_000_000 },
+    pricingModel: "principal-cost-basis",
+    totalAssets: amount("1500000"),
+    totalShares: amount("1000000"),
+    sharePrice: amount("1500000"),
+    buffer: amount("500000"),
+    deployed: amount("1000000"),
+    reconciled: true,
+    reconciliation: {
+      equation: "buffer + deployed = totalAssets",
+      accountedRaw: "1500000",
+      differenceRaw: "0",
+    },
+    caps: {
+      totalAssetCap: amount("10000000"),
+      perAgentAssetCap: amount("2000000"),
+      headroom: amount("8500000"),
+      utilizationBps: "1500",
+    },
+    yieldStatus: "not_yet_earning",
+    yieldStatusText: "Capital deployment has not been enabled",
+    flows: {
+      status: "ok",
+      depositorCount: 2,
+      depositorCountModel: "distinct-deposit-owners-in-event-window",
+      pendingUnfulfilledRedemptionShares: amount("0"),
+      pendingUnfulfilledRedemptionAssets: amount("0"),
+      recent: [{
+        type: "Deposit",
+        blockNumber: 101,
+        logIndex: 2,
+        txHash: "0xfeed",
+        owner: "0x3333333333333333333333333333333333333333",
+        assetsRaw: "500000",
+        sharesRaw: "333333",
+      }],
+      sharePriceQualifyingEvents: [],
+      window: { fromBlock: 90, toBlock: 101, maxBlocks: 12, recentLimit: 8 },
+      lastError: null,
+    },
+    producerMayAddThisLater: { ignored: true },
+    ...overrides,
+  };
+}
+
+describe("normalizeDepositPoolFeed", () => {
+  it("allowlists the v1 snapshot and reconstructs raw caps with the asset decimals", () => {
+    const result = normalizeDepositPoolFeed(payload());
+    expect(result).toMatchObject({
+      snapshot: {
+        schemaVersion: 1,
+        pricingModel: "principal-cost-basis",
+        totalAssets: amount("1500000"),
+        caps: {
+          totalAssetCap: amount("10000000"),
+          perAgentAssetCap: amount("2000000"),
+          headroom: amount("8500000"),
+          utilizationBps: 1500,
+        },
+        flows: {
+          status: "ok",
+          depositorCount: 2,
+          pendingUnfulfilledRedemptionAssets: amount("0"),
+          recent: [{ kind: "deposit", blockNumber: 101, assets: amount("500000"), sharesRaw: "333333" }],
+          sharePriceQualifyingEvents: [],
+          window: { fromBlock: 90, toBlock: 101, maxBlocks: 12, recentLimit: 8 },
+        },
+      },
+    });
+    expect(result).not.toHaveProperty("snapshot.flows.recent.0.owner");
+    expect(JSON.stringify(result)).not.toContain("0x3333333333333333333333333333333333333333");
+    expect(JSON.stringify(result)).not.toContain("producerMayAddThisLater");
+  });
+
+  it("turns an unconfigured profile into UNAVAILABLE, never an empty pool", () => {
+    expect(normalizeDepositPoolFeed({
+      schemaVersion: 1,
+      available: false,
+      reason: "deposit_pool_not_configured",
+    })).toEqual({ unavailable: "deposit pool unavailable — deposit_pool_not_configured" });
+  });
+
+  it("labels a reconciliation mismatch as a fault and withholds impossible numbers", () => {
+    const result = normalizeDepositPoolFeed(payload({
+      reconciled: false,
+      reconciliation: {
+        equation: "buffer + deployed = totalAssets",
+        accountedRaw: "1400000",
+        differenceRaw: "100000",
+      },
+    }));
+    expect(result).toEqual({
+      fault: "deposit pool incoherent — producer reported reconciliation failure",
+    });
+    expect(result).not.toHaveProperty("snapshot");
+  });
+
+  it("labels a share-price mismatch as a fault instead of rendering it", () => {
+    const result = normalizeDepositPoolFeed(payload({ sharePrice: amount("2000000") }));
+    expect(result).toEqual({
+      fault: "deposit pool incoherent — share price is inconsistent with total assets and shares",
+    });
+  });
+
+  it("keeps live balances when the bounded log read fails and degrades only flows", () => {
+    const result = normalizeDepositPoolFeed(payload({
+      flows: {
+        status: "unavailable",
+        depositorCount: null,
+        depositorCountModel: "distinct-deposit-owners-in-event-window",
+        pendingUnfulfilledRedemptionShares: null,
+        pendingUnfulfilledRedemptionAssets: null,
+        recent: null,
+        sharePriceQualifyingEvents: null,
+        window: { fromBlock: 90, toBlock: 101, maxBlocks: 12, recentLimit: 8 },
+        lastError: "eth_getLogs returned HTTP 429",
+      },
+    }));
+    expect(result).toMatchObject({
+      snapshot: {
+        totalAssets: amount("1500000"),
+        buffer: amount("500000"),
+        flows: {
+          status: "unavailable",
+          lastError: "eth_getLogs returned HTTP 429",
+          window: { fromBlock: 90, toBlock: 101, maxBlocks: 12, recentLimit: 8 },
+        },
+      },
+    });
+  });
+});
+
+describe("readDepositPoolFeed", () => {
+  it("derives the internal sibling URL and never uses the public API base", async () => {
+    const config = loadProductHealthConfig({
+      PRODUCT_HEALTH_API_BASE_URL: "https://api.example",
+      PRODUCT_HEALTH_BANK_FEED_URL: "http://agent-mainnet-backend:8787/monitor/bank-lane?x=1",
+    });
+    const internalUrl = depositPoolUrlFromBankFeed(config.bankFeedUrl);
+    expect(internalUrl).toBe("http://agent-mainnet-backend:8787/monitor/deposit-pool");
+    expect(internalUrl).not.toContain(config.apiBaseUrl ?? "api.example");
+    expect(depositPoolUrlFromBankFeed(undefined)).toBeUndefined();
+
+    let requested = "";
+    const result = await readDepositPoolFeed({
+      url: internalUrl,
+      fetchImpl: (async (url: RequestInfo | URL) => {
+        requested = String(url);
+        return { ok: false, status: 404 } as Response;
+      }) as typeof fetch,
+    });
+    expect(requested).toBe("http://agent-mainnet-backend:8787/monitor/deposit-pool");
+    expect(requested).not.toContain("api.example");
+    expect(result).toEqual({ unavailable: "deposit pool unreachable — platform returned HTTP 404" });
+  });
+});


### PR DESCRIPTION
## What changed

- Read and normalize the internal Packet 5a `/monitor/deposit-pool` snapshot through the existing `PRODUCT_HEALTH_BANK_FEED_URL` network seam.
- Add a Bank-pillar deposit-pool tile on desktop and mobile with deposits, buffer/deployed allocation, cost-basis share price, cap utilization/headroom, depositor count, yield status, bounded flow window, and recent flows.
- Keep real zeroes visible with `BORN EMPTY`, while missing/pre-5a endpoints render `UNAVAILABLE` and incoherent snapshots render `FAULT` without impossible figures.
- Add the #1051 tombstone critical page, yield-controlled buffer-floor page (off while `yieldStatus=not_yet_earning`), and one-shot first-deposit notification to the existing product-health money-alert path.

## Why

Packet 5 requires pool truth on the Hermes Bank pillar before external deposits are promoted. This PR is independently deployable before Packet 5a: the tile remains explicitly `UNAVAILABLE` until the internal platform endpoint exists.

## Red-before proof

Before implementation, the focused acceptance run failed because `deposit-pool-feed.ts` and `DepositPoolTile.tsx` did not exist and all five initial alert scenarios failed on the missing pool alert state machine. The same suite is now green.

## Checks

- `npm test -- --run test/unit/deposit-pool-feed.test.ts test/unit/deposit-pool-alert.test.ts packages/monitor-ui/src/components/ops/DepositPoolTile.test.tsx` — 18 passed
- `npm run typecheck` — passed
- `npm test` — 3,002 passed, 37 skipped
- `npm --workspace @avg/monitor-ui run build` — passed
- `git diff --check` — passed

## Affected surfaces

- monitor UI
- slack-operator product-health collection and money alerts
- tests

No platform repo, contracts, deployments, workflows, database, public/operator pages, or money mutation paths are changed. No new dependency or environment variable is required; the internal endpoint origin is derived from the existing Bank-feed URL.

## Rollout / rollback

- 5b may merge first. Before 5a deploys, or if the internal Bank connection is not configured, the tile reads `UNAVAILABLE` and sends no pool alert from absent data.
- Once 5a deploys, the next product-health heartbeat begins rendering and evaluating the snapshot without a board release.
- Roll back by reverting this PR; no data migration or configuration cleanup is required.

## Known limits

- Live truth only; public transparency stats, per-depositor identity display, yield-ceremony mechanics, and historical charts remain out of scope.
