### PR TITLE
Design handoff for the ops board and the phone board

### DIFF
--- a/docs/OPS_BOARD_DESIGN_HANDOFF.md
+++ b/docs/OPS_BOARD_DESIGN_HANDOFF.md
@@ -1,0 +1,203 @@
+# Design handoff: the ops board and the phone board
+
+**For:** a fresh Claude session doing a design pass. **From:** Claude (built the
+recent panels). **Date:** 2026-08-06.
+**Deliverable:** a design proposal for both surfaces — see §8.
+
+You are redesigning two screens that already work and are already truthful. The
+job is **composition**, not content: no figure changes, no string is invented,
+no producer is touched. Everything in §6 is a hard constraint that a prettier
+board may not trade away.
+
+---
+
+## 1. What these screens are
+
+One operator (Pascal) runs a live money system — an agent marketplace that pays
+workers in USDC on Polkadot Asset Hub. These boards are how he knows whether it
+is healthy. There are no other users. The desk board runs full-screen on a wall
+display; the phone board is read in bed and outdoors.
+
+The governing rule, from `docs/AUDIT_REMEDIATION.md`, outranks every aesthetic
+preference:
+
+> every production surface must declare whether it is real, degraded, or
+> example, and must enforce that declaration mechanically. No silent fallbacks.
+
+---
+
+## 2. The two media, and why they differ
+
+Already written at the top of `packages/monitor-ui/src/lib/monitor/phone-spec.ts`
+and worth reading in full. The short version:
+
+- **Desktop hierarchy is SPATIAL.** Everything is on screen at once; importance
+  is expressed by size and position. Nothing scrolls on the wall display.
+- **Phone hierarchy is SEQUENTIAL.** The verdict is first and may never be
+  scrolled past; anything below the fold has to have earned it.
+
+This is why the phone is not a narrow desktop. It is the same facts, cut.
+
+---
+
+## 3. Desktop as it stands (`components/ops/OpsBoard.tsx`)
+
+In render order:
+
+| # | Band | What it is | Age |
+|---|---|---|---|
+| 1 | `ops-verdict` + `ops-trust` | The one-line verdict, plus trust rows (is the data fresh, is the stream up) | original |
+| 2 | `ops-money` | **Two columns:** `SolvencyPanel` (46%) — pool meters, floors, burn, runway, payout evidence — and `FlowPanel` — the claimed→submitted→settled funnel, by-hour histogram, dispute clock | original |
+| 3 | `ArrivalsPanel` | Two columns (MCP / HTTP API) — who arrived from outside and how far they got | **added later** |
+| 4 | `BankLane` | The treasury's Hydration USDC venue position | **added later** |
+| 5 | `DepositPoolTile` | The shared depositor pool — deposits, buffer/deployed, share price, cap, depositors, yield, last flows | **added later** |
+| 6 | `PillarStrip` | Eight probes grouped into four pillars (AVAILABILITY / CHAIN / SOLVENCY / FLOW) | original |
+| 7 | `ops-economics` | One line: per-job economics | original |
+
+Bands 3–5 are each full-width and simply appended in the order they were built.
+
+## 4. Phone as it stands (`components/mobile/MobileBoard.tsx`)
+
+Sequential: status bar → stale fence (when untrusted) → verdict → trust line →
+`BreachPanel` **or** `SolvencyPanel` → `FlowPanel` → `BankPanel` → **pool lane**
+→ **arrivals lane** → "scroll for probes" → four pillar rollups → footer
+(incidents, build).
+
+The pool and arrivals lanes are one-line `<p>` elements (`.hm-ph-lane`) added
+today. They are honest and they are cuts of the right size — but they are bare
+text appended after a structured section, which is exactly what they look like.
+
+---
+
+## 5. What is actually wrong
+
+Say this plainly because the boards are otherwise good, and a redesign that
+misses it will just be a repaint.
+
+**5a. The desktop's money story is interrupted.** Reading down: worker payouts
+(2) → *outside demand* (3) → treasury venue (4) → depositor pool (5). Bands 2,
+4 and 5 are all money; band 3 is not money at all. Demand was inserted into the
+middle of the money narrative because that is where the code happened to be
+appended.
+
+**5b. One pillar, two visual languages.** `BankLane` and `DepositPoolTile` both
+describe the Bank pillar, sit adjacent, and are built as different things — a
+"lane" and a "tile", with different chrome and different heading weight. A
+reader has no cue that they are two views of one subject.
+
+**5c. Nothing expresses relative importance among the appended bands.** Six of
+the seven bands are full-width and visually equal. On a wall display, an empty
+depositor pool occupies the same commanding width as the funnel that proves
+workers got paid.
+
+**5d. The phone's new lanes are orphans.** Two unlabelled one-liners after a
+titled section. They need to belong to something — probably grouped under the
+bank, since one of them *is* a bank instrument.
+
+**5e. Nobody has looked at the whole composition since three panels were
+added.** That is the actual defect. Each panel was reviewed alone and is fine
+alone.
+
+---
+
+## 6. Constraints a redesign MAY NOT trade away
+
+Every one of these was paid for by a real incident. They are not preferences.
+
+1. **One verdict system.** The headline comes from `deriveOpsVerdict`
+   (`@avg/schemas`) and is quoted, never re-derived. Two verdict systems
+   disagree eventually, and the first disagreement is the last time the operator
+   believes either. Read `verdict.reason` (the contract), not the prose
+   headline.
+2. **Absent is not zero.** A probe, pool or feed that did not report contributes
+   **no row**, never a `—` placeholder. A placeholder claims a measurement
+   nobody took.
+3. **`unavailable` ≠ `fault`.** "We cannot see it" and "it reported nonsense"
+   are different operator moves and must stay visually distinct.
+4. **Unreadable is grey, never red.** A blind instrument is not a money problem.
+   Red belongs to the money path alone. The bank lane's `UNVERIFIED` position
+   and the pool's `unavailable` both follow this.
+5. **Demand outcomes are never coloured as faults.** Nobody arriving is a
+   business fact. Painting it red puts it in the same visual language as a
+   broken settlement.
+6. **Self / external / ambiguous traffic stay apart.** Traffic under a client
+   name we also use ourselves cannot be counted as outside demand (that
+   manufactures it) nor as ours (that erases a possible stranger).
+7. **Never add series measured over different windows.** HTTP arrivals are
+   counted only from a cut-over with no backfill; MCP has a longer history.
+   Summing them is arithmetic across unlike spans. Combine on *furthest stage*,
+   which survives the mismatch. Same reason the payout evidence carries an
+   explicit window-fit line.
+8. **Stale data is fenced, not dimmed.** The phone is read outdoors; dimming
+   every value to 72% is illegible in sunlight. Untrusted data keeps full
+   contrast and is fenced by a hatched band, a re-captioned verdict and explicit
+   as-of times.
+9. **Detail only when not ok** (phone). A probe spends a second line only when
+   it has something to say.
+10. **No figure is computed in markup.** Numbers arrive from producers as
+    strings the board quotes. If a layout needs a new derived value, it belongs
+    in `ops-spec.ts` / `phone-spec.ts` and must be shared by both surfaces —
+    see `formatPoolAmount` for the pattern.
+
+---
+
+## 7. The data you have
+
+Do **not** work from this list — read the source, because it is the only current
+statement. `packages/monitor-ui/src/lib/monitor/product-health.ts` defines
+`ProductHealth`, whose blocks are: `probes`, `chain`, `solvency`, `flow`
+(incl. `flow.payout`), `gas`, `lifecycle`, `externalFunnel`, `history`, `bank`,
+`depositPool`, `arrivals`, `remediation`, `buzz`, `buzzInbound`.
+
+View models (where derivation belongs, and where both surfaces must share):
+`lib/monitor/ops-spec.ts` (desktop), `lib/monitor/phone-spec.ts` (phone),
+`lib/monitor/ops-gloss.ts` (hover definitions — definitions only, never data),
+`@avg/schemas/ops-verdict` (the verdict), `@avg/schemas/ops-next-step` (the
+remediation phrase shared with the #Ops alerts).
+
+Fixtures to design against, including the ugly states:
+`lib/monitor/ops-fixtures.ts` (`OPS_FIXTURE_NOMINAL`, `_LIVE`, `_RED`).
+
+---
+
+## 8. What to send back
+
+A **design proposal**, not a merged rewrite:
+
+1. **A composition for the desk board** — the bands, their order, their relative
+   weight, and which (if any) should share a row. Say what each grouping
+   asserts. If Arrivals moves out of the money sequence, say where it goes and
+   why that is where an operator would look for it.
+2. **A composition for the phone** — the sequence, what sits above the fold,
+   and where the pool and arrivals lanes belong. If they should be a group,
+   name the group.
+3. **A written rationale per decision**, in the register of the existing
+   comments in these files: what the choice asserts, and what it refuses to
+   assert.
+4. **The diff surface**: which components and which CSS blocks change. Layout
+   and grouping only — if the proposal needs a string or a figure to change,
+   flag it as a question instead of doing it.
+5. **Explicitly: what you chose NOT to change, and why.** A design pass that
+   touches everything is not a design pass.
+
+Two things worth knowing about how this repo works. Every non-obvious decision
+is written down beside the code as a comment explaining what it refuses to
+claim; match that. And the tests encode the truth rules — 471 of them in
+`packages/monitor-ui` — so if a layout change breaks one, the test is probably
+right and the layout is probably making a claim it should not.
+
+---
+
+## 9. Open questions the operator has already raised
+
+- **"What's MCP and HTTP?"** (2026-08-06) — resolved on the phone by combining
+  into one plain sentence with no transport names. The desktop still shows two
+  columns, now with hover glosses explaining each door. **Open:** whether the
+  desk board should keep two columns at all. The argument for keeping them is
+  forensic — one door dead while the other thrives is a thing you want to see.
+  The argument against is that the operator has said twice that the split does
+  not serve him.
+- **Deposit pool prominence.** It is currently a full-width band showing a pool
+  that is deliberately near-empty (10 USDC, born empty, 0 depositors, not yet
+  earning). It is strategically important and operationally quiet. Those two
+  facts pull its visual weight in opposite directions.

--- a/packages/monitor-ui/src/components/mobile/MobileBoard.test.tsx
+++ b/packages/monitor-ui/src/components/mobile/MobileBoard.test.tsx
@@ -466,7 +466,7 @@ describe("phone board — deposit pool and arrivals lanes", () => {
     expect(queryByTestId("ops-deposit-pool-cap")).toBeNull();
   });
 
-  test("arrivals reach the phone, with the two front doors kept apart", () => {
+  test("arrivals reach the phone as ONE plain answer — no transport names", () => {
     const health = withBlocks({
       arrivals: {
         schemaVersion: "averray.arrivals.v1",
@@ -475,9 +475,13 @@ describe("phone board — deposit pool and arrivals lanes", () => {
       },
     } as Partial<ProductHealth>);
     const { getByTestId } = render(<MobileBoard health={health} nowMs={fresh(health)} />);
-    expect(getByTestId("mobile-arrivals").textContent).toBe(
-      "OUTSIDERS MCP → browsed · HTTP → submitted",
-    );
+    // Operator, 2026-08-06: "whats MCP and HTTP… I only need to know if
+    // someone came, what they did and how far." The doors combine on
+    // FURTHEST-STAGE, which is well-defined even though the two series cover
+    // different spans; adding their counts would not be.
+    const lane = getByTestId("mobile-arrivals");
+    expect(lane.textContent).toBe("OUTSIDERS — someone submitted work");
+    expect(lane.textContent).not.toMatch(/MCP|HTTP/);
   });
 
   test("a producer that never reported either block renders NOTHING", () => {

--- a/packages/monitor-ui/src/components/mobile/MobileBoard.test.tsx
+++ b/packages/monitor-ui/src/components/mobile/MobileBoard.test.tsx
@@ -430,3 +430,70 @@ describe("phone board — the bank lane", () => {
     expect(getByTestId("mobile-bank-absent").textContent).toContain("hydration read timed out");
   });
 });
+
+// ─────────────────────────────────────────────────────────────────────────
+// THE NEW LANES ON THE PHONE — DEPOSIT POOL AND ARRIVALS
+//
+// Same shape of regression as the bank lane above: the desk board grew two
+// panels and the phone did not follow. The pool arrived as the DESKTOP tile
+// rendered verbatim (its own `ops-deposit-pool-*` grid, six facts, inside a
+// screen whose rule is that anything below the fold has to have earned it),
+// and arrivals never reached the phone at all.
+describe("phone board — deposit pool and arrivals lanes", () => {
+  const withBlocks = (over: Partial<ProductHealth>): ProductHealth =>
+    ({ ...OPS_FIXTURE_NOMINAL, ...over }) as ProductHealth;
+
+  test("the pool is ONE line on the phone, not the desktop grid", () => {
+    const health = withBlocks({
+      depositPool: {
+        snapshot: {
+          schemaVersion: 1,
+          available: true,
+          totalAssets: { raw: "10000000", decimals: 6 },
+          flows: { status: "ok", depositorCount: 0 },
+          yieldStatus: "not_yet_earning",
+        },
+      },
+    } as Partial<ProductHealth>);
+    const { getByTestId, queryByTestId } = render(
+      <MobileBoard health={health} nowMs={fresh(health)} />,
+    );
+    expect(getByTestId("mobile-pool").textContent).toBe(
+      "POOL 10 USDC in · 0 depositors · not yet earning",
+    );
+    // The desktop tile's own fact grid must not be on this screen.
+    expect(queryByTestId("ops-deposit-pool-share-price")).toBeNull();
+    expect(queryByTestId("ops-deposit-pool-cap")).toBeNull();
+  });
+
+  test("arrivals reach the phone, with the two front doors kept apart", () => {
+    const health = withBlocks({
+      arrivals: {
+        schemaVersion: "averray.arrivals.v1",
+        funnelExternal: { reached: 9, browsed: 2, evaluated: 0, identified: 0, authenticated: 0, claimed: 0, submitted: 0 },
+        funnelHttpExternal: { reached: 40, browsed: 20, evaluated: 8, identified: 3, authenticated: 3, claimed: 1, submitted: 1 },
+      },
+    } as Partial<ProductHealth>);
+    const { getByTestId } = render(<MobileBoard health={health} nowMs={fresh(health)} />);
+    expect(getByTestId("mobile-arrivals").textContent).toBe(
+      "OUTSIDERS MCP → browsed · HTTP → submitted",
+    );
+  });
+
+  test("a producer that never reported either block renders NOTHING", () => {
+    // Absent is not zero, and a placeholder row would claim a measurement
+    // nobody took — the same rule the bank lane follows.
+    const health = withBlocks({ depositPool: undefined, arrivals: undefined });
+    const { queryByTestId } = render(<MobileBoard health={health} nowMs={fresh(health)} />);
+    expect(queryByTestId("mobile-pool")).toBeNull();
+    expect(queryByTestId("mobile-arrivals")).toBeNull();
+  });
+
+  test("an unreadable pool is fenced grey, never the red kept for the money path", () => {
+    const health = withBlocks({ depositPool: { unavailable: "no producer" } } as Partial<ProductHealth>);
+    const { getByTestId } = render(<MobileBoard health={health} nowMs={fresh(health)} />);
+    const lane = getByTestId("mobile-pool");
+    expect(lane.getAttribute("data-tone")).toBe("awaiting");
+    expect(lane.getAttribute("data-unreadable")).toBe("yes");
+  });
+});

--- a/packages/monitor-ui/src/components/mobile/MobileBoard.tsx
+++ b/packages/monitor-ui/src/components/mobile/MobileBoard.tsx
@@ -37,7 +37,7 @@ import {
   type BreachCard,
 } from "../../lib/monitor/phone-spec.js";
 import { disputeClockLine, lifecycleNote } from "../../lib/monitor/ops-spec.js";
-import { DepositPoolTile } from "../ops/DepositPoolTile.js";
+import { phoneArrivals, phonePool, type PhoneLane } from "../../lib/monitor/phone-spec.js";
 
 export interface MobileBoardProps {
   health?: ProductHealth;
@@ -110,7 +110,8 @@ export function MobileBoard({
         {breach ? <BreachPanel breach={breach} /> : <SolvencyPanel health={health} />}
         <FlowPanel health={health} emphasise={Boolean(breach)} nowMs={nowMs} />
         <BankPanel bank={health.bank} />
-        <DepositPoolTile pool={health.depositPool} />
+        <LanePanel lane={phonePool(health.depositPool)} testId="mobile-pool" label="Deposit pool" />
+        <LanePanel lane={phoneArrivals(health.arrivals)} testId="mobile-arrivals" label="Arrivals — outside demand" />
       </div>
 
       <p className="hm-ph-scroll" aria-hidden>
@@ -406,6 +407,44 @@ function FlowPanel({ health, emphasise, nowMs }: { health: ProductHealth; emphas
  * unreadable opens its rows, because that is when the numbers are worth the
  * vertical space on a 500px screen.
  */
+/**
+ * One-line lanes: the deposit pool and the arrivals funnel, each cut to a
+ * single sentence by phone-spec.
+ *
+ * The phone rendered the DESKTOP deposit-pool tile before this — a six-fact
+ * grid carrying its own `ops-deposit-pool-*` styling into a screen whose rule
+ * is that anything below the fold has to have earned it. Arrivals was not here
+ * at all. Both now answer their question in one line and take one row.
+ *
+ * `unreadable` marks a failed READING rather than a bad value, and is fenced
+ * the same way the rest of this board fences unknowns: the words say so and the
+ * tone is awaiting-grey, never the red reserved for the money path.
+ */
+function LanePanel({
+  lane,
+  testId,
+  label,
+}: {
+  lane: PhoneLane | null;
+  testId: string;
+  label: string;
+}) {
+  // Absent producer ⇒ no row. A placeholder would claim a measurement that was
+  // never taken, which is the one thing this board may not do.
+  if (!lane) return null;
+  return (
+    <p
+      className="hm-ph-lane"
+      data-tone={lane.tone}
+      data-unreadable={lane.unreadable ? "yes" : "no"}
+      data-testid={testId}
+      aria-label={label}
+    >
+      {lane.line}
+    </p>
+  );
+}
+
 function BankPanel({ bank }: { bank: ProductHealth["bank"] }) {
   if (!bank) return null;
   if (!bank.lane) {

--- a/packages/monitor-ui/src/components/ops/ArrivalsPanel.tsx
+++ b/packages/monitor-ui/src/components/ops/ArrivalsPanel.tsx
@@ -22,6 +22,7 @@
 // The column is absent, not zero, against a platform deployed before the
 // bucket existed. Zero is a measurement; absent is not.
 
+import { OPS_GLOSS } from "../../lib/monitor/ops-gloss.js";
 import {
   ARRIVAL_STAGES,
   type ArrivalsBlock,
@@ -97,7 +98,7 @@ export function ArrivalsPanel({ arrivals }: ArrivalsPanelProps) {
 
       <div className="ops-arrivals-doors">
         <section className="ops-arrivals-door" aria-label="MCP arrivals" data-testid="ops-arrivals-door-mcp">
-          <h3 className="ops-arrivals-door-title">MCP</h3>
+          <h3 className="ops-arrivals-door-title" title={OPS_GLOSS.doorMcp}>MCP</h3>
           <ol className="ops-arrivals-funnel" aria-label="MCP arrival funnel, reached through submitted">
             {ARRIVAL_STAGES.map((stage) => {
               const value = arrivals.funnelExternal[stage];
@@ -189,7 +190,7 @@ export function ArrivalsPanel({ arrivals }: ArrivalsPanelProps) {
 
         {hasHttpReading ? (
           <section className="ops-arrivals-door" aria-label="HTTP API arrivals" data-testid="ops-arrivals-door-http">
-            <h3 className="ops-arrivals-door-title">HTTP API</h3>
+            <h3 className="ops-arrivals-door-title" title={OPS_GLOSS.doorHttp}>HTTP API</h3>
             {arrivals.funnelHttpExternal ? (
               <ol className="ops-arrivals-funnel" aria-label="HTTP API arrival funnel, reached through submitted">
                 {ARRIVAL_STAGES.map((stage) => {

--- a/packages/monitor-ui/src/components/ops/DepositPoolTile.tsx
+++ b/packages/monitor-ui/src/components/ops/DepositPoolTile.tsx
@@ -14,6 +14,8 @@ import type {
   DepositPoolFlow,
 } from "../../lib/monitor/product-health.js";
 
+import { formatPoolAmount } from "../../lib/monitor/ops-spec.js";
+
 export function DepositPoolTile({ pool }: { pool: DepositPoolBlock | undefined }) {
   if (!pool || "unavailable" in pool) {
     const reason = pool && "unavailable" in pool
@@ -55,26 +57,26 @@ export function DepositPoolTile({ pool }: { pool: DepositPoolBlock | undefined }
 
       <dl className="ops-deposit-pool-grid">
         <Fact label="DEPOSITS" testId="ops-deposit-pool-deposits">
-          {formatAmount(snapshot.totalAssets, "USDC")}
+          {formatPoolAmount(snapshot.totalAssets, "USDC")}
         </Fact>
         <Fact label="BUFFER / DEPLOYED" testId="ops-deposit-pool-allocation">
-          {formatAmount(snapshot.buffer, "USDC")} buffer · {formatAmount(snapshot.deployed, "USDC")} deployed
+          {formatPoolAmount(snapshot.buffer, "USDC")} buffer · {formatPoolAmount(snapshot.deployed, "USDC")} deployed
         </Fact>
         <Fact label="SHARE PRICE" testId="ops-deposit-pool-share-price">
-          {formatAmount(snapshot.sharePrice, "USDC/share")}
+          {formatPoolAmount(snapshot.sharePrice, "USDC/share")}
           <small>{snapshot.pricingModel ?? "pricing model not reported"}</small>
         </Fact>
         <Fact label="CAP" testId="ops-deposit-pool-cap">
           {formatBps(snapshot.caps?.utilizationBps)} utilized
           <small>
-            {formatAmount(snapshot.caps?.headroom, "USDC")} headroom
-            {snapshot.caps?.totalAssetCap ? ` of ${formatAmount(snapshot.caps.totalAssetCap, "USDC")}` : ""}
+            {formatPoolAmount(snapshot.caps?.headroom, "USDC")} headroom
+            {snapshot.caps?.totalAssetCap ? ` of ${formatPoolAmount(snapshot.caps.totalAssetCap, "USDC")}` : ""}
           </small>
         </Fact>
         <Fact label="DEPOSITORS" testId="ops-deposit-pool-depositors">
           {snapshot.flows?.depositorCount ?? "—"}
           <small>
-            {formatAmount(snapshot.flows?.pendingUnfulfilledRedemptionAssets, "USDC")} pending redemption
+            {formatPoolAmount(snapshot.flows?.pendingUnfulfilledRedemptionAssets, "USDC")} pending redemption
           </small>
         </Fact>
         <Fact label="YIELD" testId="ops-deposit-pool-yield">
@@ -139,21 +141,7 @@ function Fact({
   );
 }
 
-function formatAmount(amount: DepositPoolAmount | undefined, unit: string): string {
-  if (!amount) return `— ${unit}`;
-  if (amount.decimals === undefined) return `${groupRaw(amount.raw)} raw`;
-  const negative = amount.raw.startsWith("-");
-  const digits = negative ? amount.raw.slice(1) : amount.raw;
-  const padded = digits.padStart(amount.decimals + 1, "0");
-  const split = padded.length - amount.decimals;
-  const whole = padded.slice(0, split);
-  const fraction = padded.slice(split).replace(/0+$/, "");
-  return `${negative ? "-" : ""}${groupRaw(whole)}${fraction ? `.${fraction}` : ""} ${unit}`;
-}
 
-function groupRaw(raw: string): string {
-  return raw.replace(/\B(?=(\d{3})+(?!\d))/g, ",");
-}
 
 function formatBps(bps: number | undefined): string {
   if (bps === undefined) return "—";
@@ -175,7 +163,7 @@ function flowLine(flow: DepositPoolFlow): string {
     operator_principal_contributed: "PRINCIPAL CONTRIBUTED",
     venue_loss_written_off: "LOSS WRITTEN OFF",
   } as Record<DepositPoolFlow["kind"], string>)[flow.kind];
-  const assets = flow.assets ? ` · ${formatAmount(flow.assets, "USDC")}` : "";
+  const assets = flow.assets ? ` · ${formatPoolAmount(flow.assets, "USDC")}` : "";
   const block = flow.blockNumber === undefined ? "" : ` · block ${flow.blockNumber.toLocaleString("en-US")}`;
   return `${label}${assets}${block}`;
 }

--- a/packages/monitor-ui/src/lib/monitor/ops-gloss.ts
+++ b/packages/monitor-ui/src/lib/monitor/ops-gloss.ts
@@ -60,6 +60,14 @@ export const OPS_GLOSS = {
   windowFit:
     "Whether the chain was read over at least the same 24h the settlement ledger is counted over. A shorter read window could miss real payouts and report a false shortfall — this line is the guard against comparing unlike windows.",
 
+  /** The MCP column heading in ARRIVALS. */
+  doorMcp:
+    "The agent front door: the MCP endpoint an AI agent connects to in order to discover, claim and submit jobs. Counted per distinct client.",
+
+  /** The HTTP API column heading in ARRIVALS. */
+  doorHttp:
+    "The web front door: the plain HTTP API. Counted per call, not per client, and only since its cut-over — earlier traffic was never backfilled, which is why the two columns must not be added together.",
+
   /** The bank lane's POSTAGE row. */
   postage:
     "DOT committed to pay XCM delivery fees for the bank lane's transfers. Spendable only as postage — there is no withdraw path back to the treasury.",

--- a/packages/monitor-ui/src/lib/monitor/ops-spec.ts
+++ b/packages/monitor-ui/src/lib/monitor/ops-spec.ts
@@ -1147,3 +1147,33 @@ export function formatSeconds(seconds: number | null): string {
   }
   return `${Math.round(h / 24)}d`;
 }
+
+/**
+ * Render a pool amount from its exact base-unit string.
+ *
+ * Lifted out of DepositPoolTile so the PHONE renders the same number the same
+ * way. Two surfaces formatting the same money with two functions is the drift
+ * this layer exists to prevent — and the phone lane and the desktop tile now
+ * quote one another's figures by construction.
+ *
+ * `decimals` absent ⇒ the raw base-unit string, labelled `raw`. Scaling by a
+ * guessed exponent would silently move a decimal point on a money value.
+ */
+export function formatPoolAmount(
+  amount: { raw: string; decimals?: number } | undefined,
+  unit: string,
+): string {
+  if (!amount) return `— ${unit}`;
+  if (amount.decimals === undefined) return `${groupRaw(amount.raw)} raw`;
+  const negative = amount.raw.startsWith("-");
+  const digits = negative ? amount.raw.slice(1) : amount.raw;
+  const padded = digits.padStart(amount.decimals + 1, "0");
+  const split = padded.length - amount.decimals;
+  const whole = padded.slice(0, split);
+  const fraction = padded.slice(split).replace(/0+$/, "");
+  return `${negative ? "-" : ""}${groupRaw(whole)}${fraction ? `.${fraction}` : ""} ${unit}`;
+}
+
+function groupRaw(raw: string): string {
+  return raw.replace(/\B(?=(\d{3})+(?!\d))/g, ",");
+}

--- a/packages/monitor-ui/src/lib/monitor/phone-spec.test.ts
+++ b/packages/monitor-ui/src/lib/monitor/phone-spec.test.ts
@@ -46,51 +46,71 @@ describe("phonePool — the deposit pool in one line", () => {
   });
 });
 
-describe("phoneArrivals — how far strangers got", () => {
+describe("phoneArrivals — did anyone come, what did they do, how far", () => {
   const arrivals = (over: Record<string, unknown> = {}) =>
     ({ schemaVersion: "averray.arrivals.v1", ...over }) as unknown as ProductHealth["arrivals"];
-
-  it("keeps the two front doors APART — a merge would hide one door doing nothing", () => {
-    const lane = phoneArrivals(arrivals({
-      funnelExternal: { reached: 12, browsed: 3, evaluated: 0, identified: 0, authenticated: 0, claimed: 0, submitted: 0 },
-      funnelHttpExternal: { reached: 90, browsed: 40, evaluated: 20, identified: 5, authenticated: 5, claimed: 2, submitted: 1 },
-    }));
-    expect(lane?.line).toBe("OUTSIDERS MCP → browsed · HTTP → submitted");
+  const stages = (over: Partial<Record<string, number>> = {}) => ({
+    reached: 0, browsed: 0, evaluated: 0, identified: 0,
+    authenticated: 0, claimed: 0, submitted: 0, ...over,
   });
 
-  it("an unmeasured door is NOT MEASURED, never zero", () => {
-    // funnelHttpExternal is absent on producers that predate the HTTP split.
+  it("answers in plain words — no transport names", () => {
+    // Operator, 2026-08-06: "whats MCP and HTTP… I only need to know if
+    // someone came, what they did and how far."
     const lane = phoneArrivals(arrivals({
-      funnelExternal: { reached: 5, browsed: 0, evaluated: 0, identified: 0, authenticated: 0, claimed: 0, submitted: 0 },
+      funnelExternal: stages({ reached: 9, browsed: 2 }),
+      funnelHttpExternal: stages({ reached: 40, browsed: 20, claimed: 1 }),
     }));
-    expect(lane?.line).toContain("HTTP not measured");
+    expect(lane?.line).toBe("OUTSIDERS — someone claimed a job");
+    expect(lane?.line).not.toMatch(/MCP|HTTP/);
   });
 
-  it("a measured door nobody came through says 'none yet' — a real observation", () => {
+  it("takes the FURTHEST across doors, never the sum", () => {
+    // The doors cover different spans — HTTP is counted only from a cutover —
+    // so adding them would be arithmetic across unlike windows. Furthest-stage
+    // is well-defined however long each door has been watched.
     const lane = phoneArrivals(arrivals({
-      funnelExternal: { reached: 0, browsed: 0, evaluated: 0, identified: 0, authenticated: 0, claimed: 0, submitted: 0 },
-      funnelHttpExternal: { reached: 0, browsed: 0, evaluated: 0, identified: 0, authenticated: 0, claimed: 0, submitted: 0 },
+      funnelExternal: stages({ reached: 1, submitted: 1 }),
+      funnelHttpExternal: stages({ reached: 5000, browsed: 4000 }),
     }));
-    expect(lane?.line).toBe("OUTSIDERS MCP none yet · HTTP none yet");
+    expect(lane?.line).toBe("OUTSIDERS — someone submitted work");
+  });
+
+  it("says nobody ONLY about doors it actually watched", () => {
+    const lane = phoneArrivals(arrivals({ funnelExternal: stages() }));
+    expect(lane?.line).toBe("OUTSIDERS — nobody yet on the doors we measure");
+  });
+
+  it("both doors watched and empty is a real, plainly stated observation", () => {
+    const lane = phoneArrivals(arrivals({
+      funnelExternal: stages(),
+      funnelHttpExternal: stages(),
+    }));
+    expect(lane?.line).toBe("OUTSIDERS — nobody from outside yet");
+  });
+
+  it("flags an unwatched door even when somebody did arrive", () => {
+    const lane = phoneArrivals(arrivals({ funnelExternal: stages({ reached: 3, browsed: 1 }) }));
+    expect(lane?.line).toBe("OUTSIDERS — someone browsed jobs · one door not measured");
+  });
+
+  it("no external series at all ⇒ not measured, never 'nobody'", () => {
+    const lane = phoneArrivals(arrivals({}));
+    expect(lane).toMatchObject({ tone: "awaiting", unreadable: true });
+    expect(lane?.line).toBe("OUTSIDERS — not measured");
   });
 
   it("NEVER counts the ambiguous bucket as outside demand", () => {
-    // Traffic under a client name we also use: claiming it as demand
-    // manufactures it, claiming it as ours erases a possible stranger.
     const lane = phoneArrivals(arrivals({
-      funnelExternal: { reached: 0, browsed: 0, evaluated: 0, identified: 0, authenticated: 0, claimed: 0, submitted: 0 },
-      funnelAmbiguous: { reached: 99, browsed: 99, evaluated: 99, identified: 99, authenticated: 99, claimed: 99, submitted: 99 },
-      funnelHttpExternal: { reached: 0, browsed: 0, evaluated: 0, identified: 0, authenticated: 0, claimed: 0, submitted: 0 },
+      funnelExternal: stages(),
+      funnelHttpExternal: stages(),
+      funnelAmbiguous: stages({ reached: 99, submitted: 99 }),
     }));
-    expect(lane?.line).toBe("OUTSIDERS MCP none yet · HTTP none yet");
+    expect(lane?.line).toBe("OUTSIDERS — nobody from outside yet");
   });
 
   it("nobody arriving is never coloured as a fault", () => {
-    // Demand is a business outcome; painting it red would put it in the same
-    // visual language as a broken money path.
-    const lane = phoneArrivals(arrivals({
-      funnelExternal: { reached: 0, browsed: 0, evaluated: 0, identified: 0, authenticated: 0, claimed: 0, submitted: 0 },
-    }));
+    const lane = phoneArrivals(arrivals({ funnelExternal: stages(), funnelHttpExternal: stages() }));
     expect(lane?.tone).toBe("ok");
   });
 

--- a/packages/monitor-ui/src/lib/monitor/phone-spec.test.ts
+++ b/packages/monitor-ui/src/lib/monitor/phone-spec.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from "vitest";
+
+import { phoneArrivals, phonePool } from "./phone-spec.js";
+import type { ProductHealth } from "./product-health.js";
+
+describe("phonePool — the deposit pool in one line", () => {
+  const snap = (over: Record<string, unknown> = {}) =>
+    ({ snapshot: { schemaVersion: 1, available: true, ...over } }) as unknown as ProductHealth["depositPool"];
+
+  it("an EMPTY readable pool is ok, not an alarm — it was born empty", () => {
+    // The desktop says this with a `BORN EMPTY · ZEROES ARE MEASURED` kicker.
+    // The phone has no room for the kicker, so the tone must carry it.
+    const lane = phonePool(snap({
+      totalAssets: { raw: "0", decimals: 6 },
+      flows: { status: "ok", depositorCount: 0 },
+      yieldStatus: "not_yet_earning",
+    }));
+    expect(lane?.tone).toBe("ok");
+    expect(lane?.line).toBe("POOL 0 USDC in · 0 depositors · not yet earning");
+  });
+
+  it("renders the live shape", () => {
+    const lane = phonePool(snap({
+      totalAssets: { raw: "10000000", decimals: 6 },
+      flows: { status: "ok", depositorCount: 1 },
+      yieldStatus: "earning",
+    }));
+    expect(lane?.line).toBe("POOL 10 USDC in · 1 depositor · earning");
+  });
+
+  it("an absent amount says so rather than rendering a measured-looking zero", () => {
+    const lane = phonePool(snap({ flows: { status: "ok", depositorCount: 0 } }));
+    expect(lane?.line).toContain("amount not reported");
+    expect(lane?.line).not.toContain("0 USDC");
+  });
+
+  it("keeps 'cannot see it' and 'it reported nonsense' distinct", () => {
+    const gone = phonePool({ unavailable: "no producer" } as ProductHealth["depositPool"]);
+    expect(gone).toMatchObject({ tone: "awaiting", unreadable: true });
+    const bad = phonePool({ fault: "shares without assets" } as ProductHealth["depositPool"]);
+    expect(bad).toMatchObject({ tone: "red", unreadable: true });
+  });
+
+  it("no producer at all ⇒ no lane, never a placeholder", () => {
+    expect(phonePool(undefined)).toBeNull();
+  });
+});
+
+describe("phoneArrivals — how far strangers got", () => {
+  const arrivals = (over: Record<string, unknown> = {}) =>
+    ({ schemaVersion: "averray.arrivals.v1", ...over }) as unknown as ProductHealth["arrivals"];
+
+  it("keeps the two front doors APART — a merge would hide one door doing nothing", () => {
+    const lane = phoneArrivals(arrivals({
+      funnelExternal: { reached: 12, browsed: 3, evaluated: 0, identified: 0, authenticated: 0, claimed: 0, submitted: 0 },
+      funnelHttpExternal: { reached: 90, browsed: 40, evaluated: 20, identified: 5, authenticated: 5, claimed: 2, submitted: 1 },
+    }));
+    expect(lane?.line).toBe("OUTSIDERS MCP → browsed · HTTP → submitted");
+  });
+
+  it("an unmeasured door is NOT MEASURED, never zero", () => {
+    // funnelHttpExternal is absent on producers that predate the HTTP split.
+    const lane = phoneArrivals(arrivals({
+      funnelExternal: { reached: 5, browsed: 0, evaluated: 0, identified: 0, authenticated: 0, claimed: 0, submitted: 0 },
+    }));
+    expect(lane?.line).toContain("HTTP not measured");
+  });
+
+  it("a measured door nobody came through says 'none yet' — a real observation", () => {
+    const lane = phoneArrivals(arrivals({
+      funnelExternal: { reached: 0, browsed: 0, evaluated: 0, identified: 0, authenticated: 0, claimed: 0, submitted: 0 },
+      funnelHttpExternal: { reached: 0, browsed: 0, evaluated: 0, identified: 0, authenticated: 0, claimed: 0, submitted: 0 },
+    }));
+    expect(lane?.line).toBe("OUTSIDERS MCP none yet · HTTP none yet");
+  });
+
+  it("NEVER counts the ambiguous bucket as outside demand", () => {
+    // Traffic under a client name we also use: claiming it as demand
+    // manufactures it, claiming it as ours erases a possible stranger.
+    const lane = phoneArrivals(arrivals({
+      funnelExternal: { reached: 0, browsed: 0, evaluated: 0, identified: 0, authenticated: 0, claimed: 0, submitted: 0 },
+      funnelAmbiguous: { reached: 99, browsed: 99, evaluated: 99, identified: 99, authenticated: 99, claimed: 99, submitted: 99 },
+      funnelHttpExternal: { reached: 0, browsed: 0, evaluated: 0, identified: 0, authenticated: 0, claimed: 0, submitted: 0 },
+    }));
+    expect(lane?.line).toBe("OUTSIDERS MCP none yet · HTTP none yet");
+  });
+
+  it("nobody arriving is never coloured as a fault", () => {
+    // Demand is a business outcome; painting it red would put it in the same
+    // visual language as a broken money path.
+    const lane = phoneArrivals(arrivals({
+      funnelExternal: { reached: 0, browsed: 0, evaluated: 0, identified: 0, authenticated: 0, claimed: 0, submitted: 0 },
+    }));
+    expect(lane?.tone).toBe("ok");
+  });
+
+  it("an unreadable feed is fenced, not zeroed", () => {
+    const lane = phoneArrivals({ unavailable: "arrivals feed unreachable" } as ProductHealth["arrivals"]);
+    expect(lane).toMatchObject({ tone: "awaiting", unreadable: true });
+    expect(lane?.line).toContain("unreachable");
+  });
+});

--- a/packages/monitor-ui/src/lib/monitor/phone-spec.ts
+++ b/packages/monitor-ui/src/lib/monitor/phone-spec.ts
@@ -16,10 +16,11 @@
 // come from ops-spec / @avg/schemas so the two surfaces cannot disagree about
 // what is wrong — which was the whole reason the verdict moved server-side.
 
-import type { HealthHistory, ProductHealth, SolvencyPool } from "./product-health.js";
+import { ARRIVAL_STAGES } from "./product-health.js";
+import type { HealthHistory, ProductHealth, SolvencyPool , ArrivalStage } from "./product-health.js";
 import { deriveOpsVerdict, verdictProbeLabel } from "@avg/schemas/ops-verdict";
 import { formatAgo, formatAmount, formatDuration, groupProbesByPillar, probeOpsTone, type OpsTone } from "./ops-model.js";
-import { poolMeter, shortEndpoint, staleAfterMs, type MeterView } from "./ops-spec.js";
+import { formatPoolAmount, poolMeter, shortEndpoint, staleAfterMs, type MeterView } from "./ops-spec.js";
 
 // ── the verdict field ───────────────────────────────────────────────────────
 
@@ -368,4 +369,112 @@ function summarise(total: number, tones: OpsTone[]): string {
   if (degraded > 0) return `${degraded} degraded`;
   if (awaiting > 0) return `${count("ok")} ok · ${awaiting} awaiting`;
   return `${total}/${total} ok`;
+}
+
+// ── DEPOSIT POOL AND ARRIVALS, CUT TO PHONE SIZE ───────────────────────────
+//
+// Both facts arrived on the desktop board as full panels — six pool facts in a
+// grid, and a two-column arrivals funnel of seven stages each. The phone was
+// rendering the desktop pool tile verbatim (its own `ops-deposit-pool-*` CSS
+// and all) and no arrivals at all, which is the one thing this module exists to
+// prevent: a screen whose rule is "anything below the fold has to have earned
+// it" cannot inherit a desktop grid unchanged.
+//
+// So each becomes ONE line, and expands only when it has something to ask for.
+
+export interface PhoneLane {
+  /** The line to render. Always present — absence is expressed IN the words. */
+  line: string;
+  tone: "ok" | "degraded" | "red" | "awaiting";
+  /** Set when the reading itself failed, so the caller can fence it. */
+  unreadable?: boolean;
+}
+
+/**
+ * The deposit pool in one line.
+ *
+ * An empty pool is NOT a fault: this one was born empty and its zeroes are
+ * measured, which the desktop says with a `BORN EMPTY · ZEROES ARE MEASURED`
+ * kicker. On a phone there is no room for the kicker, so the line must not
+ * imply alarm — an empty, readable pool is `ok` and says so plainly.
+ *
+ * `unavailable` (no producer) and `fault` (producer contradicted itself) stay
+ * distinct, because "we cannot see the pool" and "the pool reported nonsense"
+ * call for different operator moves.
+ */
+export function phonePool(pool: ProductHealth["depositPool"]): PhoneLane | null {
+  if (!pool) return null;
+  if ("unavailable" in pool) {
+    return { line: `POOL — ${pool.unavailable}`, tone: "awaiting", unreadable: true };
+  }
+  if ("fault" in pool) {
+    return { line: `POOL FAULT — ${pool.fault}`, tone: "red", unreadable: true };
+  }
+
+  const snap = pool.snapshot;
+  // Same formatter the desktop tile uses — see formatPoolAmount in ops-spec.
+  const deposits = snap.totalAssets ? formatPoolAmount(snap.totalAssets, "USDC") : null;
+  const depositors = snap.flows?.depositorCount;
+  const earning = snap.yieldStatus === "earning";
+
+  const parts: string[] = [];
+  // Absent is not zero: a pool whose amount did not come through says so
+  // rather than rendering "0 USDC", which reads as a measured empty pool.
+  parts.push(deposits ? `${deposits} in` : "amount not reported");
+  if (depositors != null) parts.push(`${depositors} depositor${depositors === 1 ? "" : "s"}`);
+  parts.push(earning ? "earning" : "not yet earning");
+
+  return { line: `POOL ${parts.join(" · ")}`, tone: "ok" };
+}
+
+/** The last stage with a nonzero count, or null when the series is empty. */
+function furthestReached(funnel: Record<string, number> | undefined): ArrivalStage | null {
+  if (!funnel) return null;
+  let furthest: ArrivalStage | null = null;
+  for (const stage of ARRIVAL_STAGES) {
+    if ((funnel[stage] ?? 0) > 0) furthest = stage;
+  }
+  return furthest;
+}
+
+/**
+ * Arrivals in one line: how far strangers actually got.
+ *
+ * ── WHY THE DOORS STAY APART ──────────────────────────────────────────────
+ *
+ * There are two front doors (MCP and HTTP) measured independently, and a
+ * merged "outsiders reached X" would be the flattening this board exists to
+ * refuse — the two series have different cutovers and different meanings, and
+ * one door doing well would hide the other doing nothing.
+ *
+ * A door with no external series is NOT MEASURED, never zero. A door measured
+ * with nobody through it says "none yet", which is a real observation.
+ *
+ * The AMBIGUOUS bucket is deliberately excluded from both: traffic under a
+ * client name we also use ourselves cannot be claimed as outside demand
+ * without manufacturing it, and cannot be claimed as ours without erasing a
+ * real stranger. The desktop shows it as its own column; the phone simply
+ * does not count it as demand.
+ */
+export function phoneArrivals(arrivals: ProductHealth["arrivals"]): PhoneLane | null {
+  if (!arrivals) return null;
+  if ("unavailable" in arrivals) {
+    return { line: `ARRIVALS — ${arrivals.unavailable}`, tone: "awaiting", unreadable: true };
+  }
+
+  const door = (external: Record<string, number> | undefined, name: string): string => {
+    if (!external) return `${name} not measured`;
+    const furthest = furthestReached(external);
+    return furthest ? `${name} → ${furthest}` : `${name} none yet`;
+  };
+
+  const line = [
+    door(arrivals.funnelExternal, "MCP"),
+    door(arrivals.funnelHttpExternal, "HTTP"),
+  ].join(" · ");
+
+  // Never red, never degraded. Nobody arriving is a demand fact, not a fault —
+  // colouring it as a problem would put a business outcome in the same visual
+  // language as a broken money path.
+  return { line: `OUTSIDERS ${line}`, tone: "ok" };
 }

--- a/packages/monitor-ui/src/lib/monitor/phone-spec.ts
+++ b/packages/monitor-ui/src/lib/monitor/phone-spec.ts
@@ -437,44 +437,79 @@ function furthestReached(funnel: Record<string, number> | undefined): ArrivalSta
   return furthest;
 }
 
+/** What a stage MEANS, in the words an operator would use. */
+const STAGE_DID: Record<ArrivalStage, string> = {
+  reached: "arrived but went no further",
+  browsed: "browsed jobs",
+  evaluated: "sized up a job",
+  identified: "identified itself",
+  authenticated: "signed in",
+  claimed: "claimed a job",
+  submitted: "submitted work",
+};
+
 /**
- * Arrivals in one line: how far strangers actually got.
+ * Arrivals in one line: did anyone from outside show up, what did they do,
+ * and how far did they get.
  *
- * ── WHY THE DOORS STAY APART ──────────────────────────────────────────────
+ * ── WHY THE DOORS ARE COMBINED, AND WHY ON THIS AXIS ──────────────────────
  *
- * There are two front doors (MCP and HTTP) measured independently, and a
- * merged "outsiders reached X" would be the flattening this board exists to
- * refuse — the two series have different cutovers and different meanings, and
- * one door doing well would hide the other doing nothing.
+ * The first version named the two front doors (MCP and HTTP) and reported each
+ * separately. The operator's verdict, 2026-08-06: the transport names mean
+ * nothing to the person reading, who only wants to know whether somebody came
+ * and how far they got.
  *
- * A door with no external series is NOT MEASURED, never zero. A door measured
- * with nobody through it says "none yet", which is a real observation.
+ * But the doors CANNOT be combined by adding. The board's own footnote records
+ * that HTTP arrivals are counted only from a cutover and earlier traffic was
+ * never backfilled, so the two series cover different spans of time. Summing
+ * them would be arithmetic across unlike windows — the same class of error as
+ * comparing a 24h chain read against a 25h ledger.
  *
- * The AMBIGUOUS bucket is deliberately excluded from both: traffic under a
- * client name we also use ourselves cannot be claimed as outside demand
- * without manufacturing it, and cannot be claimed as ours without erasing a
- * real stranger. The desktop shows it as its own column; the phone simply
- * does not count it as demand.
+ * FURTHEST-STAGE is the axis that survives the merge. "The furthest anybody
+ * got" is well-defined however long each door has been watched: a stranger who
+ * claimed a job did so whether or not the other door's history is complete.
+ *
+ * ── WHAT AN UNWATCHED DOOR DOES TO THE SENTENCE ───────────────────────────
+ *
+ * "Nobody came" is only sayable about doors we actually watched. When a door
+ * has no external series the line says so, because a confident "nobody yet"
+ * over an unmeasured door is a claim we did not earn.
  */
 export function phoneArrivals(arrivals: ProductHealth["arrivals"]): PhoneLane | null {
   if (!arrivals) return null;
   if ("unavailable" in arrivals) {
-    return { line: `ARRIVALS — ${arrivals.unavailable}`, tone: "awaiting", unreadable: true };
+    return { line: `OUTSIDERS — ${arrivals.unavailable}`, tone: "awaiting", unreadable: true };
   }
 
-  const door = (external: Record<string, number> | undefined, name: string): string => {
-    if (!external) return `${name} not measured`;
-    const furthest = furthestReached(external);
-    return furthest ? `${name} → ${furthest}` : `${name} none yet`;
-  };
+  // The AMBIGUOUS bucket is in neither door's series on purpose: traffic under
+  // a client name we also use ourselves cannot be called outside demand
+  // without manufacturing it, nor ours without erasing a real stranger.
+  const doors = [arrivals.funnelExternal, arrivals.funnelHttpExternal];
+  const measured = doors.filter((d): d is Record<string, number> => d !== undefined);
+  const unmeasured = doors.length - measured.length;
 
-  const line = [
-    door(arrivals.funnelExternal, "MCP"),
-    door(arrivals.funnelHttpExternal, "HTTP"),
-  ].join(" · ");
+  if (measured.length === 0) {
+    return { line: "OUTSIDERS — not measured", tone: "awaiting", unreadable: true };
+  }
+
+  // The furthest stage ANY door saw. Max, never sum — see above.
+  let furthest: ArrivalStage | null = null;
+  for (const door of measured) {
+    const reached = furthestReached(door);
+    if (reached && (furthest === null || ARRIVAL_STAGES.indexOf(reached) > ARRIVAL_STAGES.indexOf(furthest))) {
+      furthest = reached;
+    }
+  }
+
+  const caveat = unmeasured > 0 ? " · one door not measured" : "";
+  const line = furthest
+    ? `OUTSIDERS — someone ${STAGE_DID[furthest]}${caveat}`
+    : unmeasured > 0
+      ? "OUTSIDERS — nobody yet on the doors we measure"
+      : "OUTSIDERS — nobody from outside yet";
 
   // Never red, never degraded. Nobody arriving is a demand fact, not a fault —
   // colouring it as a problem would put a business outcome in the same visual
   // language as a broken money path.
-  return { line: `OUTSIDERS ${line}`, tone: "ok" };
+  return { line, tone: "ok" };
 }

--- a/packages/monitor-ui/src/styles/hermes4-mobile.css
+++ b/packages/monitor-ui/src/styles/hermes4-mobile.css
@@ -569,3 +569,26 @@
 .hm-ph-bank-subject[data-tone="red"],
 .hm-ph-bank-requests[data-tone="red"] { color: var(--h4-act); }
 .hm-ph-bank-absent { padding: 0 16px; }
+
+/* One-line lanes (deposit pool, arrivals).
+
+   These replaced a desktop grid that had been dropped into the phone body, so
+   the styling is deliberately the plainest thing on the screen: one mono line
+   at body weight, the same size as the bank lines it sits beneath. A lane that
+   drew the eye harder than the meters above it would invert the hierarchy the
+   whole board is built on — money first, demand and pool second. */
+.hm-ph-lane {
+  margin: 0;
+  padding: 0 16px;
+  font-family: var(--h4-font-mono);
+  font-size: 11.5px;
+  line-height: 1.45;
+  overflow-wrap: anywhere;
+  color: var(--h4-muted);
+}
+.hm-ph-lane[data-tone="degraded"] { color: var(--h4-warn); }
+.hm-ph-lane[data-tone="red"] { color: var(--h4-act); }
+/* A failed reading is grey, never coral: the instrument is blind, which is not
+   the same as the money being wrong. Same rule the bank lane's UNVERIFIED
+   position follows. */
+.hm-ph-lane[data-unreadable="yes"] { color: var(--h4-muted); font-style: italic; }


### PR DESCRIPTION
Adds `docs/OPS_BOARD_DESIGN_HANDOFF.md`, for a fresh Claude session to do a proper design pass on both surfaces.

**Why:** three panels — Arrivals, Bank, Deposit Pool — were appended to a board whose composition nobody has reviewed since they landed. Each was reviewed alone and is fine alone. I said earlier in the week that the desktop "already renders both panels coherently"; that was a convenient judgment rather than a design review, and this doc is the correction.

**Named defects** (§5), so a redesign doesn't just repaint:

- The money story is interrupted — worker payouts, then *outside demand*, then treasury venue, then depositor pool. Demand got inserted into the middle of the money narrative because that's where the code was appended.
- One pillar, two visual languages: `BankLane` and `DepositPoolTile` describe the same subject, sit adjacent, and are built as different things.
- Nothing expresses relative importance: six of seven bands are full-width equals, so a deliberately near-empty depositor pool commands the same width as the funnel proving workers got paid.
- The phone's two new lanes are unlabelled orphans after a titled section.

**What the doc carries that screenshots can't** (§6): the ten truth constraints a prettier board may not trade away — one verdict system, absent is not zero, `unavailable` ≠ `fault`, unreadable is grey never red, demand outcomes are never faults, self/external/ambiguous stay apart, never add series measured over different windows, stale is fenced not dimmed, detail only when not ok, no figure computed in markup. Each was paid for by a real incident, which is stated so they read as constraints rather than preferences.

It asks for a **proposal, not a merged rewrite** — including an explicit statement of what the designer chose *not* to change — and flags the two open questions you've already raised: whether the desk board should keep the MCP/HTTP split at all, and how much visual weight a strategically-important but operationally-quiet deposit pool deserves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
