### PR TITLE
Compose the desk and phone boards into five registers

### DIFF
--- a/packages/monitor-ui/src/components/mobile/MobileBoard.test.tsx
+++ b/packages/monitor-ui/src/components/mobile/MobileBoard.test.tsx
@@ -168,12 +168,13 @@ describe("phone board — the alert landing", () => {
     expect(getByTestId("mobile-breach").textContent).toContain("unknown");
   });
 
-  test("the breach card replaces the pool list — it does not sit under it", () => {
-    const { queryByTestId } = render(
+  test("the breach owns the lead slot without hiding the solvency check-in", () => {
+    const { getByTestId } = render(
       <MobileBoard health={OPS_FIXTURE_STRESS} streamDegraded nowMs={STRESS_NOW} />,
     );
-    expect(queryByTestId("mobile-breach")).toBeTruthy();
-    expect(queryByTestId("mobile-solvency")).toBeNull();
+    const breach = getByTestId("mobile-breach");
+    const solvency = getByTestId("mobile-solvency");
+    expect(breach.compareDocumentPosition(solvency)).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
   });
 
   test("the clean funnel and the shortfall proof stay in one card", () => {
@@ -374,6 +375,30 @@ describe("phone board — the bank lane", () => {
     expect(getByTestId("mobile-bank").getAttribute("data-tone")).toBe("red");
     expect(getByTestId("mobile-bank-alarm").textContent).toContain("OVERDUE");
     expect(getByTestId("mobile-bank-requests").textContent).toContain("8.7h");
+  });
+
+  test("promoting an overdue bank group leaves the verdict byte-identical", () => {
+    // Promotion changes reading order only. Comparing both orderings makes the
+    // identity check non-vacuous and refuses to let the lead slot become a
+    // second verdict now or during a later refactor.
+    const unpromoted = laneOf();
+    const first = render(<MobileBoard health={unpromoted} nowMs={fresh(unpromoted)} />);
+    const verdictBefore = first.getByTestId("mobile-verdict").textContent;
+    expect(
+      first.getByTestId("mobile-flow").compareDocumentPosition(first.getByTestId("mobile-bank-group")),
+    ).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
+    first.unmount();
+
+    const promoted = laneOf({
+      overdueRequestId: "0xb609f4d8…f57ecaac",
+      requests: { text: "1 OVERDUE · 0xb609f4d8…f57ecaac leg2-dispatched for 8.7h", tone: "red" },
+      tone: "red",
+    });
+    const second = render(<MobileBoard health={promoted} nowMs={fresh(promoted)} />);
+    expect(
+      second.getByTestId("mobile-bank-group").compareDocumentPosition(second.getByTestId("mobile-solvency")),
+    ).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
+    expect(second.getByTestId("mobile-verdict").textContent).toBe(verdictBefore);
   });
 
   test("the subject warning rides ABOVE the numbers it qualifies", () => {

--- a/packages/monitor-ui/src/components/mobile/MobileBoard.tsx
+++ b/packages/monitor-ui/src/components/mobile/MobileBoard.tsx
@@ -4,11 +4,11 @@
 //   stale band     hatched, only when the reading is not confirmable
 //   VERDICT        a solid filled field — the only filled surface in the product
 //   trust strip    desktop's 4-row panel, welded under the verdict as one line
-//   ── then ONE of ──
-//   alert landing  the breach, then the funnel + its on-chain proof
-//   check-in       floored meters, then the funnel + its on-chain proof
+//   lead slot      a breach, an overdue bank group, or nothing
+//   worker money   floored meters, then the funnel + its on-chain proof
+//   bank           venue position + the deposit-pool line in one frame
 //   ── fold ──
-//   probes         4 one-line rollups; a detail line only when not ok
+//   probes/outside 4 rollups plus the arrivals line; detail only when not ok
 //
 // Two reasons to open this: an unprompted check-in, or landing from a Buzz
 // alert. The check-in has to be answerable by shape and colour alone, before a
@@ -72,6 +72,12 @@ export function MobileBoard({
   const trust = phoneTrust({ health, streamDegraded, streamStatus, nowMs });
   const untrusted = isUntrusted({ health, streamDegraded, nowMs });
   const breach = breachCard({ health, streamDegraded, nowMs });
+  const poolLane = phonePool(health.depositPool);
+  // Promotion ranks an existing server-decided panel; it does not create a
+  // second verdict. A breached floor remains first because its inaction cost
+  // outranks an overdue request, and the bank group otherwise keeps its fixed
+  // post-flow position.
+  const promoteBank = !breach && Boolean(health.bank?.lane?.overdueRequestId);
 
   return (
     <div className="hm-ph" data-testid="mobile-board" data-untrusted={untrusted ? "yes" : "no"}>
@@ -107,11 +113,14 @@ export function MobileBoard({
       </div>
 
       <div className="hm-ph-body">
-        {breach ? <BreachPanel breach={breach} /> : <SolvencyPanel health={health} />}
+        {breach ? (
+          <BreachPanel breach={breach} />
+        ) : promoteBank ? (
+          <BankPanel bank={health.bank} pool={poolLane} />
+        ) : null}
+        <SolvencyPanel health={health} />
         <FlowPanel health={health} emphasise={Boolean(breach)} nowMs={nowMs} />
-        <BankPanel bank={health.bank} />
-        <LanePanel lane={phonePool(health.depositPool)} testId="mobile-pool" label="Deposit pool" />
-        <LanePanel lane={phoneArrivals(health.arrivals)} testId="mobile-arrivals" label="Arrivals — outside demand" />
+        {promoteBank ? null : <BankPanel bank={health.bank} pool={poolLane} />}
       </div>
 
       <p className="hm-ph-scroll" aria-hidden>
@@ -135,6 +144,15 @@ export function MobileBoard({
             ) : null}
           </div>
         ))}
+        {/* Arrivals is below the fold with the machine register, never inside
+            BANK: demand is not money and cannot borrow a money fault's rank or
+            colour. Its producer-decided one-line cut remains unchanged. */}
+        <LanePanel
+          lane={phoneArrivals(health.arrivals)}
+          testId="mobile-arrivals"
+          label="Arrivals — outside demand"
+          placement="below"
+        />
         <div className="hm-ph-foot">
           <span>INCIDENTS — {incidentLine(health, untrusted)}</span>
           <span>{buildLine(health)}</span>
@@ -424,17 +442,19 @@ function LanePanel({
   lane,
   testId,
   label,
+  placement,
 }: {
   lane: PhoneLane | null;
   testId: string;
   label: string;
+  placement: "bank" | "below";
 }) {
   // Absent producer ⇒ no row. A placeholder would claim a measurement that was
   // never taken, which is the one thing this board may not do.
   if (!lane) return null;
   return (
     <p
-      className="hm-ph-lane"
+      className={`hm-ph-lane hm-ph-lane--${placement}`}
       data-tone={lane.tone}
       data-unreadable={lane.unreadable ? "yes" : "no"}
       data-testid={testId}
@@ -445,60 +465,89 @@ function LanePanel({
   );
 }
 
-function BankPanel({ bank }: { bank: ProductHealth["bank"] }) {
-  if (!bank) return null;
-  if (!bank.lane) {
-    return (
-      <p className="hm-ph-bank-absent" data-tone="awaiting" data-testid="mobile-bank-absent">
-        BANK — {bank.unavailable ?? "lane unavailable"}
-      </p>
-    );
-  }
-
-  const { lane } = bank;
-  const open = lane.tone !== "ok";
+function BankPanel({ bank, pool }: { bank: ProductHealth["bank"]; pool: PhoneLane | null }) {
+  // The group exists when either instrument reported. An absent venue still
+  // contributes no row; it never turns the pool into evidence that a venue was
+  // configured, and the pool likewise cannot lend the venue its tone.
+  if (!bank && !pool) return null;
+  const lane = bank?.lane;
+  const open = lane?.tone !== "ok";
   return (
-    <section className="hm-ph-bank" data-tone={lane.tone} data-testid="mobile-bank" aria-label="Bank — venue position">
+    <section
+      className="hm-ph-bank"
+      data-testid="mobile-bank-group"
+      aria-labelledby="mobile-bank-group-title"
+    >
       <div className="hm-ph-sec">
-        <h2>BANK — HYDRATION USDC</h2>
+        <h2 id="mobile-bank-group-title">BANK</h2>
         {/* Hoisted above every row: an overdue request is the one state in this
             lane where doing nothing costs money. */}
-        {lane.overdueRequestId ? (
+        {lane?.overdueRequestId ? (
           <span className="hm-ph-bank-alarm" data-tone="red" data-testid="mobile-bank-alarm">
             ⏳ OVERDUE
           </span>
         ) : null}
       </div>
 
-      {/* WHAT the numbers are about, above the numbers. This lane once showed
-          four fresh, correctly-sourced, green tiles describing a wrapper
-          retired that morning — a reader who took in the float and stopped had
-          still read the wrong thing. */}
-      {lane.subject ? (
-        <p className="hm-ph-bank-subject" data-tone={lane.subject.tone} data-testid="mobile-bank-subject">
-          {lane.subject.text}
-        </p>
+      {lane ? (
+        <section
+          className="hm-ph-bank-instrument"
+          data-tone={lane.tone}
+          data-testid="mobile-bank"
+          aria-labelledby="mobile-bank-venue-title"
+        >
+          <h3 className="hm-ph-bank-instrument-title" id="mobile-bank-venue-title">
+            HYDRATION USDC
+          </h3>
+
+          {/* WHAT the numbers are about, above the numbers. This lane once
+              showed fresh readings for a retired wrapper; grouping must not
+              reorder the subject below any number it qualifies. */}
+          {lane.subject ? (
+            <p className="hm-ph-bank-subject" data-tone={lane.subject.tone} data-testid="mobile-bank-subject">
+              {lane.subject.text}
+            </p>
+          ) : null}
+
+          <p className="hm-ph-bank-requests" data-tone={lane.requests.tone} data-testid="mobile-bank-requests">
+            {lane.requests.text}
+          </p>
+
+          {open ? (
+            <dl className="hm-ph-facts" data-testid="mobile-bank-rows">
+              <dt>POSITION</dt>
+              <dd data-tone={bankPositionTone(lane.position?.status)}>
+                {lane.position
+                  ? lane.position.status === "unverified"
+                    ? `UNVERIFIED — ${lane.position.detail}`
+                    : `${lane.position.raw} raw · ${lane.position.detail}`
+                  : "not reported"}
+              </dd>
+              <dt>FLOAT</dt>
+              <dd data-tone={lane.float.tone}>{lane.float.text}</dd>
+              <dt>POSTAGE</dt>
+              <dd data-tone={lane.postage.tone}>{lane.postage.text}</dd>
+            </dl>
+          ) : null}
+        </section>
+      ) : bank ? (
+        <section className="hm-ph-bank-instrument" aria-labelledby="mobile-bank-venue-title">
+          <h3 className="hm-ph-bank-instrument-title" id="mobile-bank-venue-title">
+            HYDRATION USDC
+          </h3>
+          <p className="hm-ph-bank-absent" data-tone="awaiting" data-testid="mobile-bank-absent">
+            {bank.unavailable ?? "lane unavailable"}
+          </p>
+        </section>
       ) : null}
 
-      <p className="hm-ph-bank-requests" data-tone={lane.requests.tone} data-testid="mobile-bank-requests">
-        {lane.requests.text}
-      </p>
-
-      {open ? (
-        <dl className="hm-ph-facts" data-testid="mobile-bank-rows">
-          <dt>POSITION</dt>
-          <dd data-tone={bankPositionTone(lane.position?.status)}>
-            {lane.position
-              ? lane.position.status === "unverified"
-                ? `UNVERIFIED — ${lane.position.detail}`
-                : `${lane.position.raw} raw · ${lane.position.detail}`
-              : "not reported"}
-          </dd>
-          <dt>FLOAT</dt>
-          <dd data-tone={lane.float.tone}>{lane.float.text}</dd>
-          <dt>POSTAGE</dt>
-          <dd data-tone={lane.postage.tone}>{lane.postage.text}</dd>
-        </dl>
+      {pool ? (
+        <section className="hm-ph-bank-instrument" aria-labelledby="mobile-bank-pool-title">
+          <h3 className="hm-ph-bank-instrument-title" id="mobile-bank-pool-title">
+            DEPOSIT POOL
+          </h3>
+          <LanePanel lane={pool} testId="mobile-pool" label="Deposit pool" placement="bank" />
+        </section>
       ) : null}
     </section>
   );

--- a/packages/monitor-ui/src/components/ops/ArrivalsPanel.tsx
+++ b/packages/monitor-ui/src/components/ops/ArrivalsPanel.tsx
@@ -21,6 +21,10 @@
 //
 // The column is absent, not zero, against a platform deployed before the
 // bucket existed. Zero is a measurement; absent is not.
+//
+// This panel sits below NEXT at compact weight. Only row density changes there:
+// both doors, every series and every caveat remain because condensing a subject
+// must never become combining unlike windows or dropping attribution.
 
 import { OPS_GLOSS } from "../../lib/monitor/ops-gloss.js";
 import {

--- a/packages/monitor-ui/src/components/ops/BankLane.tsx
+++ b/packages/monitor-ui/src/components/ops/BankLane.tsx
@@ -2,8 +2,8 @@
 //
 // A second money path, next to the one the FLOW panel watches. That one pays
 // workers; this one parks the treasury's own USDC at Hydration and brings it
-// home. It has its own instruments and its own ways of lying, so it gets its
-// own strip rather than being folded into SOLVENCY.
+// home. It shares a BANK frame with the deposit pool because both describe the
+// treasury, but keeps its own tone and rows because they are not one instrument.
 //
 // ── THE LINES ARE DECIDED SERVER-SIDE ─────────────────────────────────────
 //
@@ -41,7 +41,7 @@ export function BankLane({ bank }: BankLaneProps) {
   return (
     <section className="ops-bank" data-tone={lane.tone} aria-label="Bank — venue position" data-testid="ops-bank">
       <div className="ops-bank-head">
-        <h2 className="ops-bank-title">BANK — HYDRATION USDC</h2>
+        <h3 className="ops-bank-title">HYDRATION USDC</h3>
         {/* The alarm, hoisted so it is legible before any row is read. An
             overdue request is the one state here where doing nothing costs
             money, exactly like the dispute clock in FLOW. */}

--- a/packages/monitor-ui/src/components/ops/DepositPoolTile.tsx
+++ b/packages/monitor-ui/src/components/ops/DepositPoolTile.tsx
@@ -118,7 +118,7 @@ export function DepositPoolTile({ pool }: { pool: DepositPoolBlock | undefined }
 function Header({ right }: { right?: React.ReactNode }) {
   return (
     <div className="ops-deposit-pool-head">
-      <h2>BANK — DEPOSIT POOL</h2>
+      <h3>DEPOSIT POOL</h3>
       {right ? <span>{right}</span> : null}
     </div>
   );

--- a/packages/monitor-ui/src/components/ops/OpsBoard.test.tsx
+++ b/packages/monitor-ui/src/components/ops/OpsBoard.test.tsx
@@ -13,6 +13,7 @@ import { OpsBoard } from "./OpsBoard.js";
 import {
   OPS_FIXTURE_LIVE,
   OPS_FIXTURE_NOMINAL,
+  OPS_FIXTURE_RED,
   OPS_FIXTURE_STRESS,
   OPS_FIXTURE_UNVERIFIED,
   FIXTURE_NOW,
@@ -367,6 +368,29 @@ describe("NEXT — what to do about it", () => {
     // break the promise one line below: "refresh is the only control".
     const { getByTestId } = render(<OpsBoard health={OPS_FIXTURE_STRESS} nowMs={OPS_FIXTURE_STRESS.at! + 2000} />);
     expect(getByTestId("ops-next").querySelector("button")).toBeNull();
+  });
+
+  test("nothing at or below NEXT is ever red in either incident fixture", () => {
+    // NEXT is the board's fault line. This guard asserts a positional colour
+    // vocabulary and refuses to let outside demand or the durable log borrow
+    // the money path's alarm tone merely because an incident is active.
+    for (const health of [OPS_FIXTURE_RED, OPS_FIXTURE_STRESS]) {
+      const { getByTestId, unmount } = render(
+        <OpsBoard health={health} nowMs={health.at! + 2_000} />,
+      );
+      const next = getByTestId("ops-next");
+      const arrivals = getByTestId("ops-arrivals");
+      expect(next.compareDocumentPosition(arrivals)).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
+      const content = next.parentElement!;
+      const bands = Array.from(content.children).slice(Array.from(content.children).indexOf(next));
+      const red = bands.flatMap((band) => [
+        ...(band.matches('[data-tone="red"]') ? [band] : []),
+        ...Array.from(band.querySelectorAll('[data-tone="red"]')),
+      ]);
+
+      expect(red).toHaveLength(0);
+      unmount();
+    }
   });
 });
 

--- a/packages/monitor-ui/src/components/ops/OpsBoard.tsx
+++ b/packages/monitor-ui/src/components/ops/OpsBoard.tsx
@@ -3,8 +3,11 @@
 //   meta line      what you are looking at, and when it last refreshed
 //   stale banner   only when the data is untrustworthy (hatched, overrides all)
 //   VERDICT        the one oversized element · TRUST panel beside it
-//   SOLVENCY       pools vs floors      │  FLOW  funnel + welded payout evidence
+//   WORKER MONEY   SOLVENCY │ FLOW + proof, closed by per-job economics
+//   BANK           venue position │ deposit pool, separate instruments
 //   PILLARS        the 8 probes, grouped, with their details
+//   NEXT           what to do; the fault line below which nothing is red
+//   OUTSIDE        both public arrival doors, condensed but not combined
 //   footer         incidents · LLM spend · "refresh is the only control"
 //
 // Size follows priority, not chronology: the verdict is the only thing sized to
@@ -120,33 +123,36 @@ export function OpsBoard({
         <div className="ops-money">
           <SolvencyPanel solvency={health.solvency} gas={health.gas} payout={health.flow?.payout} />
           <FlowPanel flow={health.flow} externalFunnel={health.externalFunnel} lifecycle={health.lifecycle} nowMs={nowMs} />
+
+          {/* Per-job economics closes the worker-payment band because it
+              describes that path. It keeps its own line and tone and refuses
+              to become either a funnel count or a probe. */}
+          {(() => {
+            const e = economicsLine({ payout: health.flow?.payout, gas: health.gas });
+            return e ? (
+              <div className="ops-economics" data-tone={e.tone} title={e.title}>
+                {e.text}
+              </div>
+            ) : null;
+          })()}
         </div>
 
-        <ArrivalsPanel arrivals={health.arrivals} />
-
-        {/* The treasury's own money path, under the one that pays workers.
-            Renders nothing at all when no feed is configured. */}
-        <BankLane bank={health.bank} />
-
-        {/* The shared depositor pool is a Bank-pillar instrument, but unlike
-            the treasury venue lane it is always explicit: pre-5a is
-            UNAVAILABLE, never an absent/empty pool. */}
-        <DepositPoolTile pool={health.depositPool} />
+        {/* One frame asserts one treasury subject, never one instrument: venue
+            and pool keep separate tones, absence rules and figures, and no
+            total is allowed to span their unlike windows. */}
+        <section
+          className="ops-bank-group"
+          aria-labelledby="ops-bank-group-title"
+          data-testid="ops-bank-group"
+        >
+          <h2 id="ops-bank-group-title">BANK</h2>
+          {/* The venue renders nothing when it was never wired; the pool stays
+              explicit because its unavailable state is itself a reading. */}
+          <BankLane bank={health.bank} />
+          <DepositPoolTile pool={health.depositPool} />
+        </section>
 
         <PillarStrip probes={health.probes} history={health.history} />
-
-        {/* Only the per-job economics keeps a row of its own. Gas and payout
-            runway now sit under the pools they describe, and the dispute clock
-            in the flow panel — each fact beside its subject rather than in a
-            strip of prose at the bottom that nobody could read. */}
-        {(() => {
-          const e = economicsLine({ payout: health.flow?.payout, gas: health.gas });
-          return e ? (
-            <div className="ops-economics" data-tone={e.tone} title={e.title}>
-              {e.text}
-            </div>
-          ) : null;
-        })()}
 
         {/* ── NEXT ────────────────────────────────────────────────────────
             The board says WHAT is wrong in eleven places and never once said
@@ -180,6 +186,11 @@ export function OpsBoard({
             </div>
           );
         })()}
+
+        {/* The fault line is structural: demand belongs after everything that
+            can page the operator. Both independent doors remain visible, and
+            moving them refuses to recast a business outcome as a money fault. */}
+        <ArrivalsPanel arrivals={health.arrivals} />
 
         <div className="ops-foot">
           <span>INCIDENTS — {incidentSummary(health, nowMs)}</span>

--- a/packages/monitor-ui/src/styles/hermes4-mobile.css
+++ b/packages/monitor-ui/src/styles/hermes4-mobile.css
@@ -538,8 +538,34 @@
   display: grid;
   gap: 7px;
 }
-.hm-ph-bank[data-tone="red"] { border-color: var(--h4-act); }
-.hm-ph-bank[data-tone="degraded"] { border-color: var(--h4-warn); }
+
+/* One frame says BANK; each nested instrument keeps its own tone. A coloured
+   venue rule must not paint the deposit pool as the same instrument. */
+.hm-ph-bank-instrument {
+  display: grid;
+  gap: 5px;
+  min-width: 0;
+}
+.hm-ph-bank-instrument + .hm-ph-bank-instrument {
+  padding-top: 8px;
+  border-top: 1px solid var(--ph-hair);
+}
+.hm-ph-bank-instrument[data-tone="red"] {
+  padding-left: 10px;
+  border-left: 2px solid var(--h4-act);
+}
+.hm-ph-bank-instrument[data-tone="degraded"] {
+  padding-left: 10px;
+  border-left: 2px solid var(--h4-warn);
+}
+.hm-ph-bank-instrument-title {
+  margin: 0;
+  font-family: var(--h4-font-display);
+  font-weight: 600;
+  font-size: 12px;
+  letter-spacing: 0.1em;
+  color: var(--h4-ink);
+}
 
 /* The alarm rides in the section header's right slot, so it is legible before
    any row is read — the same placement the desktop lane uses. */
@@ -568,7 +594,7 @@
 .hm-ph-bank-requests[data-tone="degraded"] { color: var(--h4-warn); }
 .hm-ph-bank-subject[data-tone="red"],
 .hm-ph-bank-requests[data-tone="red"] { color: var(--h4-act); }
-.hm-ph-bank-absent { padding: 0 16px; }
+.hm-ph-bank-absent { padding: 0; }
 
 /* One-line lanes (deposit pool, arrivals).
 
@@ -579,12 +605,16 @@
    whole board is built on — money first, demand and pool second. */
 .hm-ph-lane {
   margin: 0;
-  padding: 0 16px;
   font-family: var(--h4-font-mono);
   font-size: 11.5px;
   line-height: 1.45;
   overflow-wrap: anywhere;
   color: var(--h4-muted);
+}
+.hm-ph-lane--bank { padding: 0; }
+.hm-ph-lane--below {
+  padding: 8px 12px;
+  border: 1px solid var(--ph-hair);
 }
 .hm-ph-lane[data-tone="degraded"] { color: var(--h4-warn); }
 .hm-ph-lane[data-tone="red"] { color: var(--h4-act); }

--- a/packages/monitor-ui/src/styles/hermes4-ops.css
+++ b/packages/monitor-ui/src/styles/hermes4-ops.css
@@ -265,6 +265,7 @@ body,
 .ops-money {
   flex: 1 0 auto;
   display: flex;
+  flex-wrap: wrap;
   border: 1px solid var(--ops-rule);
 }
 .ops-solvency {
@@ -929,8 +930,8 @@ body,
 .ops-arrivals {
   display: grid;
   grid-template-columns: minmax(0, 1fr);
-  gap: calc(8 * var(--ops-u)) calc(18 * var(--ops-u));
-  padding: calc(9 * var(--ops-u)) calc(14 * var(--ops-u));
+  gap: calc(5 * var(--ops-u)) calc(18 * var(--ops-u));
+  padding: calc(7 * var(--ops-u)) calc(14 * var(--ops-u));
   border: 1px solid var(--ops-rule);
 }
 .ops-arrivals > .ops-panel-head,
@@ -946,7 +947,7 @@ body,
 .ops-arrivals-door {
   display: grid;
   align-content: start;
-  gap: calc(8 * var(--ops-u));
+  gap: calc(4 * var(--ops-u));
   min-width: 0;
 }
 .ops-arrivals-door + .ops-arrivals-door {
@@ -955,7 +956,7 @@ body,
 }
 .ops-arrivals-door-title {
   margin: 0;
-  padding-bottom: calc(6 * var(--ops-u));
+  padding-bottom: calc(3 * var(--ops-u));
   border-bottom: 1px solid var(--ops-hair);
   font-family: var(--h4-font-display);
   font-size: calc(16 * var(--ops-u));
@@ -965,7 +966,7 @@ body,
 }
 .ops-arrivals-funnel {
   display: grid;
-  gap: calc(4 * var(--ops-u));
+  gap: calc(2 * var(--ops-u));
   margin: 0;
   padding: 0;
   list-style: none;
@@ -1023,8 +1024,8 @@ body,
 .ops-arrivals-summary {
   display: grid;
   align-content: stretch;
-  gap: calc(8 * var(--ops-u));
-  padding-top: calc(8 * var(--ops-u));
+  gap: calc(4 * var(--ops-u));
+  padding-top: calc(4 * var(--ops-u));
   border-top: 1px solid var(--ops-hair);
 }
 .ops-arrivals-distinct {
@@ -1115,8 +1116,8 @@ body,
 }
 .ops-arrivals-http-summary {
   display: grid;
-  gap: calc(8 * var(--ops-u));
-  padding-top: calc(8 * var(--ops-u));
+  gap: calc(4 * var(--ops-u));
+  padding-top: calc(4 * var(--ops-u));
   border-top: 1px solid var(--ops-hair);
 }
 .ops-arrivals-http-measured {
@@ -1137,7 +1138,7 @@ body,
   color: var(--h4-ok);
 }
 .ops-arrivals-http-cutover {
-  padding-top: calc(8 * var(--ops-u));
+  padding-top: calc(4 * var(--ops-u));
   border-top: 1px solid var(--ops-hair);
   font-family: var(--h4-font-mono);
   font-size: calc(9 * var(--ops-u));
@@ -1146,9 +1147,39 @@ body,
 }
 .ops-arrivals-http-cutover p { margin: 0; }
 .ops-arrivals-http-cutover p + p {
-  margin-top: calc(5 * var(--ops-u));
+  margin-top: calc(2 * var(--ops-u));
   color: var(--h4-tel);
 }
+
+/* ---- BANK group ------------------------------------------------
+   One frame asserts one treasury subject, not one instrument. The venue and
+   depositor pool therefore keep separate cells, tones and absence rules, with
+   no shared total or status allowed to span the columns. */
+.ops-bank-group {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  border: 1px solid var(--ops-rule);
+}
+.ops-bank-group > h2 {
+  grid-column: 1 / -1;
+  margin: 0;
+  padding: calc(8 * var(--ops-u)) calc(14 * var(--ops-u));
+  border-bottom: 1px solid var(--ops-rule);
+  font-family: var(--h4-font-display);
+  font-weight: 600;
+  font-size: calc(15 * var(--ops-u));
+  letter-spacing: 0.1em;
+  color: var(--h4-ink);
+}
+.ops-bank-group > .ops-bank,
+.ops-bank-group > .ops-bank-absent {
+  grid-column: 1;
+  border-right: 1px solid var(--ops-rule);
+}
+.ops-bank-group > .ops-bank-absent {
+  padding: calc(10 * var(--ops-u)) calc(14 * var(--ops-u));
+}
+.ops-bank-group > .ops-deposit-pool { grid-column: 2; }
 
 /* ---- BANK lane -------------------------------------------------
    A second money path beside the funnel's. Compact by design: four
@@ -1163,9 +1194,8 @@ body,
   flex-direction: column;
   gap: calc(4 * var(--ops-u));
   padding: calc(8 * var(--ops-u)) calc(14 * var(--ops-u));
-  border: 1px solid var(--ops-rule);
+  border: 0;
 }
-.ops-bank[data-tone="red"] { border-color: var(--h4-act); }
 .ops-bank-head {
   display: flex;
   align-items: baseline;
@@ -1247,10 +1277,8 @@ body,
   flex-direction: column;
   gap: calc(8 * var(--ops-u));
   padding: calc(10 * var(--ops-u)) calc(14 * var(--ops-u));
-  border: 1px solid var(--ops-rule);
+  border: 0;
 }
-.ops-deposit-pool[data-tone="red"] { border-color: var(--h4-act); }
-.ops-deposit-pool[data-tone="awaiting"] { border-color: var(--h4-tel); }
 .ops-deposit-pool-head,
 .ops-deposit-pool-flow-head {
   display: flex;
@@ -1258,7 +1286,7 @@ body,
   justify-content: space-between;
   gap: calc(12 * var(--ops-u));
 }
-.ops-deposit-pool-head h2 {
+.ops-deposit-pool-head h3 {
   margin: 0;
   font-family: var(--h4-font-display);
   font-size: calc(12.5 * var(--ops-u));
@@ -1286,7 +1314,7 @@ body,
 }
 .ops-deposit-pool-grid {
   display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
+  grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: calc(12 * var(--ops-u));
   margin: 0;
 }
@@ -1338,11 +1366,13 @@ body,
 }
 
 /* ---- per-job economics -------------------------------------------
-   What one job costs and earns, on one line between the probes and
-   the footer. Also shipped unstyled; also monospace now, because it
-   is three numbers and numbers on this board are monospace.        */
+   What one job costs and earns closes the worker-money frame. It keeps its
+   own row and tone rather than being folded into either instrument above. */
 .ops-economics {
-  padding: calc(4 * var(--ops-u)) 0;
+  flex: 0 0 100%;
+  box-sizing: border-box;
+  padding: calc(7 * var(--ops-u)) calc(16 * var(--ops-u));
+  border-top: 1px dashed var(--ops-rule);
   font-family: var(--h4-font-mono);
   font-size: calc(12 * var(--ops-u));
   letter-spacing: 0.02em;
@@ -1406,6 +1436,7 @@ body,
   .ops-verdict-row { flex-direction: column; }
   .ops-trust { width: auto; }
   .ops-money { flex-direction: column; }
+  .ops-money > .ops-economics { flex-basis: auto; }
   .ops-solvency {
     width: auto;
     border-right: 0;


### PR DESCRIPTION
Implements [docs/OPS_BOARD_COMPOSITION_PACKET.md](../blob/main/docs/OPS_BOARD_COMPOSITION_PACKET.md). Built by Codex, gated by Claude.

## What changes

**Desk** — per-job economics moves inside the band it describes; `BankLane` + `DepositPoolTile` become one two-column `ops-bank-group` under a single `BANK` heading; arrivals move out of the money run to below `NEXT`.

**Phone** — the lead slot generalises from *breach or nothing* to *breach → overdue bank → nothing*, ranked by cost of inaction. The pool line is adopted under the `BANK` heading; the arrivals line moves below the fold.

## Gate results

I ran every check myself rather than accepting the handback's report.

| Check | Result |
|---|---|
| Scope | exactly the 7 §4 files + 2 test files |
| Base | `fd38e81` — current `origin/main`, not a stale copy |
| Literals | no figure changed; only the authorised `BANK` / `HYDRATION USDC` / `DEPOSIT POOL` re-split |
| Mockup figures (`3.10 USDC`, `0.05 USDC`) | **no matches** — the design bundle's sample money did not travel |
| Tests / tsc | 473 passed / clean |

**Both new guards were verified by mutation, not by passing.** A green test that cannot go red is not a guard:

- Painted an arrivals element `data-tone="red"` → the fault-line test failed **alone**, 32 others untouched.
- Made the promoted phone render re-caption the verdict → the byte-identical test failed with exactly that diff.

The second is the guard on the decision closest to becoming a second verdict system, so it mattered that it genuinely holds.

## One change beyond the packet's letter, flagged deliberately

A breach previously *replaced* the solvency meters; now both render. Codex added a test naming the intent ("the breach owns the lead slot without hiding the solvency check-in"), and I think it is right — a breached floor is exactly when you want to see the pools — but it changes what sits above the fold and was not in §4, so it should be a decision rather than a discovery.

## Not in scope

**Q5 — the bank lane still does not feed `deriveOpsVerdict`,** so an overdue request cannot move the headline on either surface. That is the unfixed half of the 2026-08-04 incident and gets its own packet next, as decided. The phone lead slot is honest compensation, not the cure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
