### PR TITLE
feat(board): make arrivals verdict legible

### DIFF
--- a/packages/monitor-ui/src/components/ops/ArrivalsPanel.test.tsx
+++ b/packages/monitor-ui/src/components/ops/ArrivalsPanel.test.tsx
@@ -1,338 +1,184 @@
 // @vitest-environment jsdom
-import { afterEach, describe, expect, test } from "vitest";
-import { cleanup, render } from "@testing-library/react";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
 
-import { ARRIVAL_STAGES, type ArrivalsSnapshot } from "../../lib/monitor/product-health.js";
+import { cleanup, render } from "@testing-library/react";
+import { afterEach, describe, expect, test } from "vitest";
+
+import {
+  ARRIVAL_STAGES,
+  type ArrivalOperatorDoorRow,
+  type ArrivalsSnapshot,
+} from "../../lib/monitor/product-health.js";
 import { ArrivalsPanel } from "./ArrivalsPanel.js";
 
 afterEach(cleanup);
 
-// Deliberately a funnel where the total and the external count disagree at
-// every stage, including one our own probes walked to the end and no outsider
-// ever entered. Any assertion below that passes on the total is a bug.
-const arrivals: ArrivalsSnapshot = {
-  schemaVersion: "averray.arrivals.v1",
-  generatedAtMs: 1_786_100_000_000,
-  observingSinceMs: 1_786_000_000_000,
-  funnel: {
-    reached: 28,
-    browsed: 16,
-    evaluated: 9,
-    identified: 4,
-    authenticated: 3,
-    claimed: 1,
-    submitted: 1,
-  },
-  funnelExternal: {
-    reached: 20,
-    browsed: 10,
-    evaluated: 5,
-    identified: 2,
-    authenticated: 1,
-    claimed: 0,
-    submitted: 0,
-  },
-  funnelSelf: {
-    reached: 8,
-    browsed: 6,
-    evaluated: 4,
-    identified: 2,
-    authenticated: 2,
-    claimed: 1,
-    submitted: 1,
-  },
-  distinct: {
-    declared: 4,
-    anonymous: 9,
-    self: 2,
-    furthest: "submitted",
-    furthestExternal: "authenticated",
-  },
-  clients: [],
-};
+const GENERATED_AT = Date.parse("2026-08-16T12:00:00.000Z");
+const HISTORICAL_AT = Date.parse("2026-08-11T08:00:00.000Z");
+const CUTOVER_NOTE = "HTTP arrivals are measured from this cut-over only; earlier HTTP traffic was not backfilled.";
 
-const arrivalsWithHttp: ArrivalsSnapshot = {
-  ...arrivals,
-  funnelHttp: {
-    reached: 13, browsed: 8, evaluated: 5, identified: 3, authenticated: 2, claimed: 1, submitted: 1,
-  },
-  funnelHttpExternal: {
-    reached: 7, browsed: 4, evaluated: 2, identified: 1, authenticated: 1, claimed: 1, submitted: 1,
-  },
-  funnelHttpSelf: {
-    reached: 2, browsed: 2, evaluated: 1, identified: 1, authenticated: 1, claimed: 0, submitted: 0,
-  },
-  funnelHttpAmbiguous: {
-    reached: 1, browsed: 1, evaluated: 1, identified: 0, authenticated: 0, claimed: 0, submitted: 0,
-  },
-  attributionSourceTotals: {
-    mcp: { siwe_wallet: 3, client_name: 4, ip_only: 9 },
-    http: { siwe_wallet: 17, client_name: 6, ip_only: 41 },
-  },
-  httpCutover: {
-    atMs: 1_786_200_000_000,
-    at: "2026-08-09T01:20:00.000Z",
-    backfilled: false,
-    note: "HTTP arrivals are measured from this cut-over only; earlier HTTP traffic was not backfilled.",
-  },
-};
+function rows(values: Partial<Record<string, Partial<Record<"outsider" | "ours" | "unknown", number>>>> = {}) {
+  return ARRIVAL_STAGES.map((stage, index): ArrivalOperatorDoorRow => ({
+    stage,
+    unit: index < 3 ? "calls" : "agents",
+    instrumentation: index < 3
+      ? `${stage} route/tool calls`
+      : "distinct SIWE wallets reaching at least this stage",
+    outsider: values[stage]?.outsider ?? 0,
+    ours: values[stage]?.ours ?? 0,
+    unknown: values[stage]?.unknown ?? 0,
+  }));
+}
 
-describe("ArrivalsPanel", () => {
-  // The headline is what an outsider did. Our own probes reach the same door
-  // and were once added to these bars, which is how this panel came to say
-  // BROWSED 2 on a day exactly one outsider had browsed.
-  test("every funnel figure is the external count, never the total", () => {
-    const { getByTestId, queryByTestId } = render(<ArrivalsPanel arrivals={arrivals} />);
-    const rows = ARRIVAL_STAGES.map((stage) => getByTestId(`ops-arrival-stage-${stage}`));
-
-    // Every call here is attributed, so there is nothing to disclaim.
-    expect(queryByTestId("ops-arrivals-unattributed")).toBeNull();
-
-    expect(rows.map((row) => row.querySelector(".ops-arrivals-stage")?.textContent)).toEqual(ARRIVAL_STAGES);
-    expect(rows.map((row) => row.querySelector("strong")?.textContent)).toEqual(
-      ["20", "10", "5", "2", "1", "0", "0"],
-    );
-    // Bars scale on the external peak of 20, not the total peak of 28, so one
-    // busy canary cannot flatten a real outsider's bar.
-    expect(rows.map((row) => (row.querySelector("i") as HTMLElement).style.width)).toEqual([
-      "100%",
-      "50%",
-      "25%",
-      "10%",
-      "5%",
-      "0%",
-      "0%",
-    ]);
-  });
-
-  // Kept visible, not dropped: a probe that silently stopped running is its
-  // own kind of blindness. It is simply never part of the headline.
-  test("our own traffic is shown apart from the external figure", () => {
-    const { getByTestId } = render(<ArrivalsPanel arrivals={arrivals} />);
-
-    expect(ARRIVAL_STAGES.map((stage) => getByTestId(`ops-arrival-self-${stage}`).textContent)).toEqual(
-      ["+8", "+6", "+4", "+2", "+2", "+1", "+1"],
-    );
-    // A stage no outsider entered reads 0, with our own run still legible.
-    expect(getByTestId("ops-arrival-stage-submitted").textContent).toContain("0");
-    expect(getByTestId("ops-arrival-self-submitted").textContent).toBe("+1");
-  });
-
-  test("shows declared, anonymous and ours, and the furthest an OUTSIDER reached", () => {
-    const { getByTestId, getByLabelText } = render(<ArrivalsPanel arrivals={arrivals} />);
-
-    expect(getByLabelText("Distinct arrival clients").textContent).toContain("DECLARED 4");
-    expect(getByLabelText("Distinct arrival clients").textContent).toContain("ANONYMOUS 9");
-    expect(getByLabelText("Distinct arrival clients").textContent).toContain("OURS 2");
-    // Our own probes submitted. The headline must not borrow their progress.
-    expect(getByTestId("ops-arrivals-furthest").textContent).toContain("authenticated");
-    expect(getByTestId("ops-arrivals-furthest").textContent).not.toContain("submitted");
-    expect(getByTestId("ops-arrivals-furthest").getAttribute("data-advanced")).toBe("yes");
-  });
-
-  // The board went green on our own traffic before the split existed. With no
-  // outsider past the door, nothing here may look like progress.
-  test("a funnel only our own probes walked reads as no outside interest", () => {
-    const { getByTestId } = render(
-      <ArrivalsPanel
-        arrivals={{
-          ...arrivals,
-          funnel: {
-            reached: 9, browsed: 6, evaluated: 4, identified: 2, authenticated: 2, claimed: 1, submitted: 1,
-          },
-          funnelExternal: {
-            reached: 1, browsed: 0, evaluated: 0, identified: 0, authenticated: 0, claimed: 0, submitted: 0,
-          },
-          distinct: { declared: 2, anonymous: 0, self: 1, furthest: "submitted", furthestExternal: "reached" },
-        }}
-      />,
-    );
-
-    expect(getByTestId("ops-arrival-stage-browsed").querySelector("strong")?.textContent).toBe("0");
-    expect(getByTestId("ops-arrivals-furthest").textContent).toContain("reached");
-    expect(getByTestId("ops-arrivals-furthest").getAttribute("data-advanced")).toBe("no");
-  });
-
-  // What the platform serves for a while after the split ships: the totals
-  // survived the upgrade, their actor attribution did not, and the client
-  // table still remembers that an outsider browsed. Unexplained, the panel
-  // would show BROWSED 0 directly beside "furthest an outsider reached:
-  // browsed" and leave an operator to guess which one is lying.
-  test("pre-split history is named, not folded into either column", () => {
-    const zeroed = Object.fromEntries(ARRIVAL_STAGES.map((stage) => [stage, 0])) as typeof arrivals.funnel;
-    const { getByTestId } = render(
-      <ArrivalsPanel
-        arrivals={{
-          ...arrivals,
-          funnel: { ...zeroed, reached: 22, browsed: 2 },
-          funnelExternal: zeroed,
-          funnelSelf: zeroed,
-          distinct: { declared: 2, anonymous: 1, self: 1, furthest: "browsed", furthestExternal: "browsed" },
-        }}
-      />,
-    );
-
-    expect(getByTestId("ops-arrivals-unattributed").textContent).toContain("24 calls");
-    expect(getByTestId("ops-arrivals-unattributed").textContent).toContain("predate the");
-    expect(getByTestId("ops-arrival-stage-browsed").querySelector("strong")?.textContent).toBe("0");
-    expect(getByTestId("ops-arrivals-furthest").textContent).toContain("browsed");
-  });
-
-  test("an unreadable feed says unreachable and renders no zero funnel", () => {
-    const { getByTestId, queryAllByTestId } = render(
-      <ArrivalsPanel arrivals={{ unavailable: "arrivals feed unreachable — platform returned HTTP 521" }} />,
-    );
-
-    expect(getByTestId("ops-arrivals-unreachable").textContent).toContain("UNREACHABLE");
-    expect(getByTestId("ops-arrivals-unreachable").textContent).toContain("HTTP 521");
-    expect(queryAllByTestId(/^ops-arrival-stage-/)).toHaveLength(0);
-  });
-
-  test("an older product-health payload is also a named non-reading", () => {
-    const { getByTestId } = render(<ArrivalsPanel arrivals={undefined} />);
-    expect(getByTestId("ops-arrivals-unreachable").textContent).toContain("feed not present");
-  });
-
-  test("a pre-cut-over snapshot renders MCP normally and makes no HTTP zero claim", () => {
-    const { getByTestId, queryByTestId, queryAllByTestId } = render(<ArrivalsPanel arrivals={arrivals} />);
-
-    expect(getByTestId("ops-arrival-stage-browsed").querySelector("strong")?.textContent).toBe("10");
-    expect(queryByTestId("ops-arrivals-unreachable")).toBeNull();
-    expect(queryByTestId("ops-arrivals-door-http")).toBeNull();
-    expect(queryAllByTestId(/^ops-arrival-http-stage-/)).toHaveLength(0);
-  });
-});
-
-describe("ArrivalsPanel — independent HTTP front door", () => {
-  test("shows the measured HTTP series beside MCP without a combined headline", () => {
-    const { getByTestId, queryByText } = render(<ArrivalsPanel arrivals={arrivalsWithHttp} />);
-
-    expect(getByTestId("ops-arrivals-door-mcp")).toBeTruthy();
-    expect(getByTestId("ops-arrivals-door-http")).toBeTruthy();
-    expect(getByTestId("ops-arrival-stage-reached").querySelector("strong")?.textContent).toBe("20");
-    expect(getByTestId("ops-arrival-http-stage-reached").querySelector("strong")?.textContent).toBe("7");
-    expect(getByTestId("ops-arrival-http-self-browsed").textContent).toBe("+2");
-    expect(getByTestId("ops-arrival-http-ambiguous-browsed").textContent).toBe("?1");
-    expect(queryByText(/combined/i)).toBeNull();
-    expect(getByTestId("ops-arrivals").textContent).not.toContain("27");
-  });
-
-  test("promotes SIWE wallet attribution rather than the inferred IP count", () => {
-    const { getByTestId } = render(<ArrivalsPanel arrivals={arrivalsWithHttp} />);
-    const measured = getByTestId("ops-arrivals-http-measured");
-
-    expect(measured.textContent).toContain("MEASURED (SIWE WALLET)");
-    expect(measured.querySelector("strong")?.textContent).toBe("17");
-    expect(measured.textContent).not.toContain("41");
-  });
-
-  test("renders the producer's cut-over note verbatim and names recovered blindness", () => {
-    const { getByTestId } = render(<ArrivalsPanel arrivals={arrivalsWithHttp} />);
-    const cutover = getByTestId("ops-arrivals-http-cutover");
-
-    expect(cutover.querySelectorAll("p")[0]?.textContent).toBe(arrivalsWithHttp.httpCutover?.note);
-    expect(cutover.textContent).toContain("a larger number here is recovered blindness, not growth.");
-  });
-
-  test("keeps the existing furthest-stage reading on the MCP distinct shape", () => {
-    const { getByTestId } = render(<ArrivalsPanel arrivals={arrivalsWithHttp} />);
-
-    expect(getByTestId("ops-arrivals-furthest").textContent).toContain("authenticated");
-    expect(getByTestId("ops-arrivals-furthest").textContent).not.toContain("submitted");
-  });
-});
-
-// UNCLAIMABLE — traffic under a client name we use ourselves. Our own Claude
-// session and a stranger's both declare `Anthropic/ClaudeAI`, so no rule over
-// that name can separate them. Observed live on 2026-08-10, when the operator
-// inspecting the front door through Claude was counted as outside interest.
-describe("ArrivalsPanel — traffic that can be claimed by neither side", () => {
-  const withAmbiguous: ArrivalsSnapshot = {
-    ...arrivals,
-    funnelAmbiguous: {
-      reached: 0, browsed: 3, evaluated: 0, identified: 0, authenticated: 0, claimed: 0, submitted: 0,
+function snapshot(overrides: Partial<ArrivalsSnapshot> = {}): ArrivalsSnapshot {
+  const zeroes = Object.fromEntries(ARRIVAL_STAGES.map((stage) => [stage, 0])) as Record<(typeof ARRIVAL_STAGES)[number], number>;
+  return {
+    schemaVersion: "averray.arrivals.v1",
+    generatedAtMs: GENERATED_AT,
+    observingSinceMs: Date.parse("2026-08-08T00:00:00.000Z"),
+    funnel: zeroes,
+    funnelExternal: zeroes,
+    funnelSelf: zeroes,
+    distinct: { declared: 0, anonymous: 0, self: 0, furthest: "reached", furthestExternal: "reached" },
+    clients: [],
+    httpCutover: {
+      atMs: Date.parse("2026-08-11T00:00:00.000Z"),
+      at: "2026-08-11T00:00:00.000Z",
+      backfilled: false,
+      note: CUTOVER_NOTE,
     },
-    funnel: { ...arrivals.funnel, browsed: 19 },
-    distinct: { ...arrivals.distinct, ambiguous: 1, furthestAmbiguous: "browsed" },
+    operatorView: {
+      version: "averray.arrivals.operator.v1",
+      generatedAtMs: GENERATED_AT,
+      outsiders: {
+        furthestEver: {
+          window: "all-time",
+          stage: "settled",
+          atMs: HISTORICAL_AT,
+          door: "http",
+          agents: 1,
+          payouts: 42,
+          payoutWindow: "12h",
+          payoutSpanMs: 7 * 60 * 60 * 1000,
+        },
+        lastActivity: { window: "all-time", atMs: HISTORICAL_AT, stage: "settled", door: "http" },
+        week: { window: "7d", identified: 3, worked: 0 },
+        postedWork: { window: "all-time", status: "never", count: 0, firstAtMs: null },
+      },
+      ours: {
+        day: {
+          window: "24h",
+          agents: 6,
+          canaryRuns: 5,
+          acceptanceRuns: 1,
+          adminConsoleAgents: 1,
+          operatorAgents: 0,
+        },
+      },
+      unknown: { window: "all-time", sharedClientNames: 1, preSplitCalls: 455 },
+      doors: {
+        mcp: {
+          window: "all-time",
+          sinceMs: Date.parse("2026-08-08T00:00:00.000Z"),
+          rows: rows({ reached: { outsider: 9 }, browsed: { outsider: 2 } }),
+        },
+        http: {
+          window: "all-time",
+          sinceMs: Date.parse("2026-08-11T00:00:00.000Z"),
+          rows: rows({
+            reached: { outsider: 40, ours: 20, unknown: 3 },
+            browsed: { outsider: 382, ours: 4 },
+            evaluated: { outsider: 1730, ours: 8 },
+            identified: { outsider: 3, ours: 6 },
+            authenticated: { outsider: 2, ours: 6 },
+            claimed: { outsider: 1, ours: 6 },
+            submitted: { outsider: 1, ours: 6 },
+          }),
+        },
+      },
+    },
+    ...overrides,
   };
+}
 
-  test("is shown beside the external figure, never inside it", () => {
-    const { getByTestId } = render(<ArrivalsPanel arrivals={withAmbiguous} />);
+describe("ArrivalsPanel — verdict first", () => {
+  test("renders the historical furthest-ever payout burst from feed data", () => {
+    const { getByTestId } = render(<ArrivalsPanel arrivals={snapshot()} />);
+    const furthest = getByTestId("ops-arrivals-furthest-ever");
 
-    // The headline is unmoved by traffic we cannot attribute.
-    expect(getByTestId("ops-arrival-stage-browsed").querySelector("strong")?.textContent).toBe("10");
-    expect(getByTestId("ops-arrival-ambiguous-browsed").textContent).toBe("?3");
-    expect(getByTestId("ops-arrivals-distinct-ambiguous").textContent).toContain("UNCLAIMABLE 1");
+    expect(furthest.textContent).toContain("SETTLED · 42 payouts in 12h · 2026-08-11 (HTTP)");
+    expect(furthest.textContent).toContain("ALL-TIME");
+    expect(getByTestId("ops-arrivals-last-activity").textContent).toContain("5d ago");
   });
 
-  // The defect this change closes. `unattributed` is computed by subtraction,
-  // so before the third bucket was subtracted too, every unclaimable call was
-  // rendered under a line stating it predated the external/self split. The
-  // number was real and the explanation printed beside it was false.
-  test("is not mislabelled as history that predates the split", () => {
-    const { queryByTestId } = render(<ArrivalsPanel arrivals={withAmbiguous} />);
+  test("posted work flips from NEVER when the producer reports the first external job", () => {
+    const first = snapshot();
+    const { getByTestId, rerender } = render(<ArrivalsPanel arrivals={first} />);
+    expect(getByTestId("ops-arrivals-posted-work").textContent).toContain("NEVER");
 
-    expect(queryByTestId("ops-arrivals-unattributed")).toBeNull();
+    const changed = snapshot();
+    if (changed.operatorView && !("unavailable" in changed.operatorView)) {
+      changed.operatorView.outsiders.postedWork = {
+        window: "all-time",
+        status: "observed",
+        count: 1,
+        firstAtMs: GENERATED_AT,
+      };
+    }
+    rerender(<ArrivalsPanel arrivals={changed} />);
+    expect(getByTestId("ops-arrivals-posted-work").textContent).toContain("1 POSTED");
+    expect(getByTestId("ops-arrivals-posted-work").textContent).not.toContain("NEVER");
   });
 
-  // Both kinds at once: genuinely pre-split calls still have to be named, and
-  // the unclaimable ones must not be counted into that explanation.
-  test("real pre-split history is still named, and counts only itself", () => {
-    const { getByTestId } = render(
-      <ArrivalsPanel arrivals={{ ...withAmbiguous, funnel: { ...withAmbiguous.funnel, reached: 33 } }} />,
-    );
+  test("pure canary and acceptance traffic never becomes outsider work", () => {
+    const pureSelf = snapshot();
+    if (pureSelf.operatorView && !("unavailable" in pureSelf.operatorView)) {
+      pureSelf.operatorView.outsiders.week = { window: "7d", identified: 0, worked: 0 };
+      pureSelf.operatorView.ours.day.canaryRuns = 5;
+      pureSelf.operatorView.ours.day.acceptanceRuns = 1;
+    }
+    const { getByTestId } = render(<ArrivalsPanel arrivals={pureSelf} />);
 
-    // 33 reached − 20 external − 8 ours − 0 unclaimable = 5, and nothing more.
-    expect(getByTestId("ops-arrivals-unattributed").textContent).toContain("5 calls");
-    expect(getByTestId("ops-arrivals-unattributed").textContent).toContain("predate the");
+    expect(getByTestId("ops-arrivals-this-week").textContent).toContain("0 worked");
+    expect(getByTestId("ops-arrivals-ours").textContent).toContain("5 canary runs");
+    expect(getByTestId("ops-arrivals-ours").textContent).toContain("1 acceptance run");
   });
 
-  test("the furthest an outsider reached is not borrowed from an unclaimable client", () => {
-    const { getByTestId } = render(
-      <ArrivalsPanel
-        arrivals={{
-          ...withAmbiguous,
-          distinct: { ...withAmbiguous.distinct, furthestExternal: "reached", furthestAmbiguous: "claimed" },
-        }}
-      />,
-    );
+  test("labels non-monotonic call rows and puts a window badge on every figure", () => {
+    const { getByTestId, getAllByTestId } = render(<ArrivalsPanel arrivals={snapshot()} />);
+    const browsed = getByTestId("ops-arrivals-row-http-browsed");
+    const evaluated = getByTestId("ops-arrivals-row-http-evaluated");
 
-    expect(getByTestId("ops-arrivals-furthest").getAttribute("data-advanced")).toBe("no");
-    // Reported alongside, because it may well have been an outsider.
-    expect(getByTestId("ops-arrivals-furthest-ambiguous").textContent).toContain("claimed");
+    expect(browsed.textContent).toContain("calls · browsed route/tool calls");
+    expect(evaluated.textContent).toContain("calls · evaluated route/tool calls");
+    expect(getByTestId("ops-arrivals-row-http-identified").textContent).toContain("agents · distinct SIWE wallets");
+    for (const figure of getAllByTestId(/^ops-arrivals-figure-/)) {
+      expect(figure.querySelector(".ops-window-badge")).not.toBeNull();
+    }
   });
 
-  test("the panel explains why the external figure is narrower than it was", () => {
-    const { getByTestId } = render(<ArrivalsPanel arrivals={withAmbiguous} />);
+  test("keeps unknown apart and renders the producer cut-over note verbatim", () => {
+    const { getByTestId } = render(<ArrivalsPanel arrivals={snapshot()} />);
 
-    expect(getByTestId("ops-arrivals-ambiguous-note").textContent).toContain("client name we use ourselves");
+    expect(getByTestId("ops-arrivals-unknown").textContent).toContain("shared client names 1");
+    expect(getByTestId("ops-arrivals-unknown").textContent).toContain("pre-split calls 455");
+    expect(getByTestId("ops-arrivals-http-cutover").textContent).toBe(CUTOVER_NOTE);
   });
 
-  // A platform deployed before the bucket existed reports nothing here. That
-  // is not a measurement of zero, so the panel makes no claim at all — and
-  // renders exactly as it did before, rather than blanking on a deploy skew.
-  test("a platform that does not report the bucket renders as it always did", () => {
-    const { queryByTestId, getByTestId } = render(<ArrivalsPanel arrivals={arrivals} />);
+  test("an older producer is a named missing verdict, never a reconstructed zero", () => {
+    const older = snapshot({ operatorView: undefined });
+    const { getByTestId, queryByTestId } = render(<ArrivalsPanel arrivals={older} />);
 
-    expect(queryByTestId("ops-arrival-ambiguous-browsed")).toBeNull();
-    expect(queryByTestId("ops-arrivals-distinct-ambiguous")).toBeNull();
-    expect(queryByTestId("ops-arrivals-furthest-ambiguous")).toBeNull();
-    expect(queryByTestId("ops-arrivals-ambiguous-note")).toBeNull();
-    expect(getByTestId("ops-arrival-stage-browsed").querySelector("strong")?.textContent).toBe("10");
+    expect(getByTestId("ops-arrivals-unreachable").textContent).toContain("VERDICT VIEW UNAVAILABLE");
+    expect(queryByTestId("ops-arrivals-outsiders")).toBeNull();
   });
 
-  // Reported-and-zero is a real finding: nobody arrived under a shared name.
-  // It keeps the column, unlike absent, which keeps nothing.
-  test("a reported zero still counts as a reading", () => {
-    const zeroed = Object.fromEntries(ARRIVAL_STAGES.map((stage) => [stage, 0])) as typeof arrivals.funnel;
-    const { getByTestId } = render(
-      <ArrivalsPanel
-        arrivals={{ ...arrivals, funnelAmbiguous: zeroed, distinct: { ...arrivals.distinct, ambiguous: 0 } }}
-      />,
-    );
-
-    expect(getByTestId("ops-arrival-ambiguous-browsed").textContent).toBe("");
-    expect(getByTestId("ops-arrivals-distinct-ambiguous").textContent).toContain("UNCLAIMABLE 0");
-    expect(getByTestId("ops-arrivals-ambiguous-note")).toBeTruthy();
+  test("render code contains no historical design-handback literals", () => {
+    const source = readFileSync(resolve(
+      process.cwd(),
+      "packages/monitor-ui/src/components/ops/ArrivalsPanel.tsx",
+    ), "utf8");
+    expect(source).not.toMatch(/42 payouts|2026-08-11|pre-split calls 455|outreach #1/iu);
   });
 });

--- a/packages/monitor-ui/src/components/ops/ArrivalsPanel.tsx
+++ b/packages/monitor-ui/src/components/ops/ArrivalsPanel.tsx
@@ -1,35 +1,14 @@
-// ARRIVALS — who has actually crossed either public front door, and how far.
+// ARRIVALS — the operator verdict first, raw transport counters second.
 //
-// The platform owns these counts. This component only renders its versioned
-// snapshot; it never infers a later stage from calls or client names. Most
-// importantly, an absent/unreachable feed is a named instrument failure, not a
-// seven-zero funnel that would read as "nobody arrived".
-//
-// Every headline here is the EXTERNAL count. Our own canaries, smokes and
-// adversarial probes reach the same door, and for a while this panel added
-// them to the same bars — it once read BROWSED 2 when one of the two was our
-// own roadmap probe. Ours are still shown, deliberately: knowing a probe ran
-// is useful. They are just never part of the number that reads as demand.
-//
-// A third column is neither. A declared client name identifies the client
-// SOFTWARE, not the operator: our own Claude session and a stranger's both
-// announce `Anthropic/ClaudeAI`, so no rule over that name can separate them.
-// Counted as outsiders they manufacture demand every time we inspect our own
-// front door; counted as ours they erase the real users who arrive the same
-// way. So they are shown apart, and the panel says why — an operator watching
-// the external figure drop is owed the reason it was wrong before.
-//
-// The column is absent, not zero, against a platform deployed before the
-// bucket existed. Zero is a measurement; absent is not.
-//
-// This panel sits below NEXT at compact weight. Only row density changes there:
-// both doors, every series and every caveat remain because condensing a subject
-// must never become combining unlike windows or dropping attribution.
+// The backend owns identity joins, historical payout evidence, and windows.
+// This component never recovers a verdict from the legacy call funnels: doing
+// so would make canaries look like demand and compare unlike instrumentation.
 
-import { OPS_GLOSS } from "../../lib/monitor/ops-gloss.js";
-import {
-  ARRIVAL_STAGES,
-  type ArrivalsBlock,
+import { formatAgo } from "../../lib/monitor/ops-model.js";
+import type {
+  ArrivalOperatorDoorRow,
+  ArrivalOperatorView,
+  ArrivalsBlock,
 } from "../../lib/monitor/product-health.js";
 
 export interface ArrivalsPanelProps {
@@ -38,221 +17,217 @@ export interface ArrivalsPanelProps {
 
 export function ArrivalsPanel({ arrivals }: ArrivalsPanelProps) {
   if (!arrivals || "unavailable" in arrivals) {
+    return <Unavailable reason={arrivals?.unavailable ?? "feed not present in this product-health snapshot"} />;
+  }
+  const operatorView = arrivals.operatorView;
+  if (!operatorView || "unavailable" in operatorView) {
     return (
-      <section className="ops-arrivals" aria-label="Arrivals — public front doors" data-testid="ops-arrivals">
-        <header className="ops-panel-head">
-          <h2 className="ops-panel-title">ARRIVALS — PUBLIC FRONT DOORS</h2>
-        </header>
-        <p className="ops-arrivals-unreachable" data-tone="awaiting" role="status" data-testid="ops-arrivals-unreachable">
-          <strong>UNREACHABLE</strong> — {arrivals?.unavailable ?? "feed not present in this product-health snapshot"}
-        </p>
-      </section>
+      <Unavailable
+        label="VERDICT VIEW UNAVAILABLE"
+        reason={operatorView?.unavailable ?? "shared identity registry projection not present in this snapshot"}
+      />
     );
   }
 
-  // Scaled on the external peak so the bars are a picture of outside interest.
-  // Scaling on the total would let one busy canary flatten every real bar.
-  const peak = Math.max(1, ...ARRIVAL_STAGES.map((stage) => arrivals.funnelExternal[stage]));
-  const advanced = arrivals.distinct.furthestExternal !== "reached";
-  // Absent means a platform deployed before the bucket existed, which is a
-  // different thing from a platform reporting none — so the column appears
-  // only when there is actually a reading behind it.
-  const ambiguousCounts = arrivals.funnelAmbiguous;
-  const hasHttpReading =
-    arrivals.funnelHttp !== undefined ||
-    arrivals.funnelHttpExternal !== undefined ||
-    arrivals.funnelHttpSelf !== undefined ||
-    arrivals.funnelHttpAmbiguous !== undefined ||
-    arrivals.attributionSourceTotals !== undefined ||
-    arrivals.httpCutover !== undefined;
-  const httpPeak = arrivals.funnelHttpExternal
-    ? Math.max(1, ...ARRIVAL_STAGES.map((stage) => arrivals.funnelHttpExternal?.[stage] ?? 0))
-    : 1;
-  // Calls the platform counted before it split the funnel. Their actor was
-  // never recorded and cannot be recovered, so they sit in none of the
-  // columns. They have to be named: the furthest-stage figures come from the
-  // client table, which DOES remember that history, so an operator can
-  // otherwise face a funnel reading 0 outsiders beside "an outsider reached
-  // browsed" with nothing on screen to reconcile them.
-  //
-  // Ambiguous calls are subtracted here too. They are unattributed in the
-  // ordinary sense, but they do NOT predate the split — saying so on screen
-  // would be a false explanation of a real number.
-  // `funnel` is MCP-only. Keep this subtraction pinned to that door: folding
-  // HTTP into it would relabel newly recovered HTTP visibility as old,
-  // unattributed MCP history.
-  const unattributed = ARRIVAL_STAGES.reduce(
-    (total, stage) =>
-      total +
-      (arrivals.funnel[stage] -
-        arrivals.funnelExternal[stage] -
-        arrivals.funnelSelf[stage] -
-        (ambiguousCounts?.[stage] ?? 0)),
-    0,
-  );
-
+  const { outsiders, ours, unknown, generatedAtMs } = operatorView;
   return (
-    <section className="ops-arrivals" aria-label="Arrivals — public front doors" data-testid="ops-arrivals">
+    <section className="ops-arrivals" aria-label="Arrivals — who is actually showing up" data-testid="ops-arrivals">
       <header className="ops-panel-head">
-        <h2 className="ops-panel-title">ARRIVALS — PUBLIC FRONT DOORS</h2>
-        <span className="ops-panel-note">
-          reached → submitted · two independent series · outsiders, ours and the unclaimable kept apart
-        </span>
+        <h2 className="ops-panel-title">ARRIVALS — WHO IS ACTUALLY SHOWING UP?</h2>
+        <span className="ops-panel-note">identities after SIWE · self and unknown never count as demand</span>
       </header>
 
-      <div className="ops-arrivals-doors">
-        <section className="ops-arrivals-door" aria-label="MCP arrivals" data-testid="ops-arrivals-door-mcp">
-          <h3 className="ops-arrivals-door-title" title={OPS_GLOSS.doorMcp}>MCP</h3>
-          <ol className="ops-arrivals-funnel" aria-label="MCP arrival funnel, reached through submitted">
-            {ARRIVAL_STAGES.map((stage) => {
-              const value = arrivals.funnelExternal[stage];
-              const ours = arrivals.funnelSelf[stage];
-              const unclear = ambiguousCounts?.[stage];
-              return (
-                <li
-                  key={stage}
-                  data-testid={`ops-arrival-stage-${stage}`}
-                  aria-label={
-                    `${stage}: ${value} external, ${ours} ours` +
-                    (unclear === undefined ? "" : `, ${unclear} unattributable`)
-                  }
-                >
-                  <span className="ops-arrivals-stage">{stage}</span>
-                  <span className="ops-arrivals-track" aria-hidden>
-                    <i style={{ width: `${(value / peak) * 100}%` }} />
-                  </span>
-                  <strong>{value}</strong>
-                  <span className="ops-arrivals-self" data-testid={`ops-arrival-self-${stage}`} aria-hidden>
-                    {ours > 0 ? `+${ours}` : ""}
-                  </span>
-                  {/* Beside the headline, never inside it. Rendered only when
-                      the platform actually reports the bucket. */}
-                  {unclear !== undefined ? (
-                    <span
-                      className="ops-arrivals-ambiguous"
-                      data-testid={`ops-arrival-ambiguous-${stage}`}
-                      aria-hidden
-                    >
-                      {unclear > 0 ? `?${unclear}` : ""}
-                    </span>
-                  ) : null}
-                </li>
-              );
-            })}
-          </ol>
+      <section className="ops-arrivals-verdict" data-testid="ops-arrivals-outsiders">
+        <div className="ops-arrivals-block-head">
+          <h3>OUTSIDERS</h3>
+          <span>the only demand signal</span>
+        </div>
+        <dl className="ops-arrivals-verdict-lines">
+          <VerdictLine label="furthest ever" testId="ops-arrivals-furthest-ever">
+            <Figure window={outsiders.furthestEver?.window ?? "all-time"} testId="ops-arrivals-figure-furthest">
+              {formatFurthest(outsiders.furthestEver)}
+            </Figure>
+          </VerdictLine>
+          <VerdictLine label="last activity" testId="ops-arrivals-last-activity">
+            <Figure window={outsiders.lastActivity?.window ?? "all-time"} testId="ops-arrivals-figure-last">
+              {formatLastActivity(outsiders.lastActivity, generatedAtMs)}
+            </Figure>
+          </VerdictLine>
+          <VerdictLine label="this week" testId="ops-arrivals-this-week">
+            <span className="ops-arrivals-pair">
+              <Figure window={outsiders.week.window} testId="ops-arrivals-figure-week-identified">
+                {outsiders.week.identified} identified
+              </Figure>
+              <span aria-hidden>·</span>
+              <Figure window={outsiders.week.window} testId="ops-arrivals-figure-week-worked">
+                {outsiders.week.worked} worked
+              </Figure>
+            </span>
+          </VerdictLine>
+          <VerdictLine label="posted work" testId="ops-arrivals-posted-work">
+            <Figure window={outsiders.postedWork.window} testId="ops-arrivals-figure-posted">
+              {formatPostedWork(outsiders.postedWork)}
+            </Figure>
+          </VerdictLine>
+        </dl>
+      </section>
 
-          <div className="ops-arrivals-summary">
-            <div className="ops-arrivals-distinct" aria-label="Distinct arrival clients">
-              <span>DECLARED <strong>{arrivals.distinct.declared}</strong></span>
-              <span>ANONYMOUS <strong>{arrivals.distinct.anonymous}</strong></span>
-              <span>OURS <strong>{arrivals.distinct.self}</strong></span>
-              {arrivals.distinct.ambiguous === undefined ? null : (
-                <span data-testid="ops-arrivals-distinct-ambiguous">
-                  UNCLAIMABLE <strong>{arrivals.distinct.ambiguous}</strong>
-                </span>
-              )}
-            </div>
-            <div
-              className="ops-arrivals-furthest"
-              data-advanced={advanced ? "yes" : "no"}
-              data-testid="ops-arrivals-furthest"
-            >
-              {/* `distinct`, including furthestExternal, is the established
-                  MCP client view. Do not repoint this to distinctAgents: that
-                  is a different producer shape with different semantics. */}
-              <span>FURTHEST MCP STAGE AN OUTSIDER REACHED</span>
-              <strong>{arrivals.distinct.furthestExternal}</strong>
-              {arrivals.distinct.furthestAmbiguous === undefined ? null : (
-                <span className="ops-arrivals-furthest-ambiguous" data-testid="ops-arrivals-furthest-ambiguous">
-                  possibly, unclaimable client <strong>{arrivals.distinct.furthestAmbiguous}</strong>
-                </span>
-              )}
-            </div>
+      <div className="ops-arrivals-secondary">
+        <section className="ops-arrivals-owned" data-testid="ops-arrivals-ours">
+          <div className="ops-arrivals-block-head">
+            <h3>OURS</h3>
+            <span>operational traffic, kept apart</span>
           </div>
-
-          {ambiguousCounts ? (
-            <p className="ops-arrivals-ambiguous-note" data-testid="ops-arrivals-ambiguous-note">
-              <strong>UNCLAIMABLE</strong> — calls under a client name we use ourselves. A declared name
-              identifies the client software, not the operator, so our own session and a stranger's are
-              indistinguishable. Counted as outsiders they would manufacture demand; counted as ours they
-              would erase real users. They are neither, and are shown apart.
-            </p>
-          ) : null}
-
-          {unattributed > 0 ? (
-            <p
-              className="ops-arrivals-unattributed"
-              data-tone="awaiting"
-              data-testid="ops-arrivals-unattributed"
-            >
-              <strong>UNATTRIBUTED</strong> — {unattributed} call{unattributed === 1 ? "" : "s"} predate the
-              external/self split and belong to neither MCP column. The MCP stage counts above begin at the
-              split; the furthest MCP stage does not, and may run ahead of them.
-            </p>
-          ) : null}
+          <div className="ops-arrivals-figures">
+            <Figure window={ours.day.window} testId="ops-arrivals-figure-canary">
+              {countLabel(ours.day.canaryRuns, "canary run")}
+            </Figure>
+            <Figure window={ours.day.window} testId="ops-arrivals-figure-acceptance">
+              {countLabel(ours.day.acceptanceRuns, "acceptance run")}
+            </Figure>
+            <Figure window={ours.day.window} testId="ops-arrivals-figure-admin">
+              {countLabel(ours.day.adminConsoleAgents, "admin console agent")}
+            </Figure>
+            <Figure window={ours.day.window} testId="ops-arrivals-figure-operator">
+              {countLabel(ours.day.operatorAgents, "operator agent")}
+            </Figure>
+          </div>
         </section>
 
-        {hasHttpReading ? (
-          <section className="ops-arrivals-door" aria-label="HTTP API arrivals" data-testid="ops-arrivals-door-http">
-            <h3 className="ops-arrivals-door-title" title={OPS_GLOSS.doorHttp}>HTTP API</h3>
-            {arrivals.funnelHttpExternal ? (
-              <ol className="ops-arrivals-funnel" aria-label="HTTP API arrival funnel, reached through submitted">
-                {ARRIVAL_STAGES.map((stage) => {
-                  const value = arrivals.funnelHttpExternal?.[stage] ?? 0;
-                  const ours = arrivals.funnelHttpSelf?.[stage];
-                  const unclear = arrivals.funnelHttpAmbiguous?.[stage];
-                  return (
-                    <li
-                      key={stage}
-                      data-testid={`ops-arrival-http-stage-${stage}`}
-                      aria-label={
-                        `${stage}: ${value} external` +
-                        (ours === undefined ? "" : `, ${ours} ours`) +
-                        (unclear === undefined ? "" : `, ${unclear} unattributable`)
-                      }
-                    >
-                      <span className="ops-arrivals-stage">{stage}</span>
-                      <span className="ops-arrivals-track" aria-hidden>
-                        <i style={{ width: `${(value / httpPeak) * 100}%` }} />
-                      </span>
-                      <strong>{value}</strong>
-                      {ours === undefined ? null : (
-                        <span className="ops-arrivals-self" data-testid={`ops-arrival-http-self-${stage}`} aria-hidden>
-                          {ours > 0 ? `+${ours}` : ""}
-                        </span>
-                      )}
-                      {unclear === undefined ? null : (
-                        <span
-                          className="ops-arrivals-ambiguous"
-                          data-testid={`ops-arrival-http-ambiguous-${stage}`}
-                          aria-hidden
-                        >
-                          {unclear > 0 ? `?${unclear}` : ""}
-                        </span>
-                      )}
-                    </li>
-                  );
-                })}
-              </ol>
-            ) : null}
+        <section className="ops-arrivals-unknown" data-testid="ops-arrivals-unknown">
+          <div className="ops-arrivals-block-head">
+            <h3>UNKNOWN / UNCLAIMABLE</h3>
+            <span>counted apart</span>
+          </div>
+          <div className="ops-arrivals-figures">
+            <Figure window={unknown.window} testId="ops-arrivals-figure-shared-clients">
+              shared client names {unknown.sharedClientNames}
+            </Figure>
+            <Figure window={unknown.window} testId="ops-arrivals-figure-presplit">
+              pre-split calls {unknown.preSplitCalls}
+            </Figure>
+          </div>
+        </section>
+      </div>
 
-            <div className="ops-arrivals-http-summary">
-              {arrivals.attributionSourceTotals ? (
-                <p className="ops-arrivals-http-measured" data-testid="ops-arrivals-http-measured">
-                  <span>MEASURED (SIWE WALLET)</span>
-                  <strong>{arrivals.attributionSourceTotals.http.siwe_wallet}</strong>
-                </p>
-              ) : null}
-              {arrivals.httpCutover ? (
-                <div className="ops-arrivals-http-cutover" data-testid="ops-arrivals-http-cutover">
-                  <p>{arrivals.httpCutover.note}</p>
-                  <p>a larger number here is recovered blindness, not growth.</p>
-                </div>
-              ) : null}
-            </div>
-          </section>
+      <details className="ops-arrivals-evidence" data-testid="ops-arrivals-evidence">
+        <summary>DOORS — RAW INSTRUMENTATION</summary>
+        <p>
+          Reached, browsed and evaluated are independently instrumented calls, not a monotonic agent funnel.
+          From identified onward, rows are distinct SIWE wallets reaching at least that stage.
+        </p>
+        <div className="ops-arrivals-door-tables">
+          <DoorTable name="MCP" door="mcp" view={operatorView} />
+          <DoorTable name="HTTP API" door="http" view={operatorView} />
+        </div>
+        {arrivals.httpCutover ? (
+          <p className="ops-arrivals-cutover" data-testid="ops-arrivals-http-cutover">
+            {arrivals.httpCutover.note}
+          </p>
         ) : null}
+      </details>
+    </section>
+  );
+}
+
+function Unavailable({ reason, label = "UNREACHABLE" }: { reason: string; label?: string }) {
+  return (
+    <section className="ops-arrivals" aria-label="Arrivals — who is actually showing up" data-testid="ops-arrivals">
+      <header className="ops-panel-head">
+        <h2 className="ops-panel-title">ARRIVALS — WHO IS ACTUALLY SHOWING UP?</h2>
+      </header>
+      <p className="ops-arrivals-unreachable" data-tone="awaiting" role="status" data-testid="ops-arrivals-unreachable">
+        <strong>{label}</strong> — {reason}
+      </p>
+    </section>
+  );
+}
+
+function VerdictLine({ label, testId, children }: { label: string; testId: string; children: React.ReactNode }) {
+  return (
+    <div data-testid={testId}>
+      <dt>{label}</dt>
+      <dd>{children}</dd>
+    </div>
+  );
+}
+
+function Figure({ window, testId, children }: { window: string; testId: string; children: React.ReactNode }) {
+  return (
+    <span className="ops-arrivals-figure" data-testid={testId}>
+      <span>{children}</span>
+      <WindowBadge window={window} />
+    </span>
+  );
+}
+
+function WindowBadge({ window }: { window: string }) {
+  return <small className="ops-window-badge">{window.toUpperCase()}</small>;
+}
+
+function DoorTable({ name, door, view }: { name: string; door: "mcp" | "http"; view: ArrivalOperatorView }) {
+  const evidence = view.doors[door];
+  return (
+    <section className="ops-arrivals-door" data-testid={`ops-arrivals-door-${door}`}>
+      <h3>{name}</h3>
+      <p className="ops-arrivals-door-since">
+        observed since {formatDate(evidence.sinceMs)} <WindowBadge window={evidence.window} />
+      </p>
+      <div className="ops-arrivals-table" role="table" aria-label={`${name} raw arrivals`}>
+        <div className="ops-arrivals-table-head" role="row">
+          <span role="columnheader">stage / instrument</span>
+          <span role="columnheader">outsider</span>
+          <span role="columnheader">ours</span>
+          <span role="columnheader">unknown</span>
+        </div>
+        {evidence.rows.map((row) => <DoorRow key={row.stage} door={door} row={row} window={evidence.window} />)}
       </div>
     </section>
   );
+}
+
+function DoorRow({ door, row, window }: { door: "mcp" | "http"; row: ArrivalOperatorDoorRow; window: string }) {
+  return (
+    <div className="ops-arrivals-table-row" role="row" data-testid={`ops-arrivals-row-${door}-${row.stage}`}>
+      <span role="cell">
+        <strong>{row.stage}</strong>
+        <small>{row.unit} · {row.instrumentation}</small>
+      </span>
+      {(["outsider", "ours", "unknown"] as const).map((actor) => (
+        <Figure key={actor} window={window} testId={`ops-arrivals-figure-${door}-${row.stage}-${actor}`}>
+          {row[actor]}
+        </Figure>
+      ))}
+    </div>
+  );
+}
+
+function formatFurthest(reading: ArrivalOperatorView["outsiders"]["furthestEver"]): string {
+  if (!reading) return "NO IDENTIFIED OUTSIDER YET";
+  const payout = reading.payouts === undefined
+    ? ""
+    : ` · ${reading.payouts} payouts in ${reading.payoutWindow ?? "the measured burst"}`;
+  return `${reading.stage.toUpperCase()}${payout} · ${formatDate(reading.atMs)} (${reading.door.toUpperCase()})`;
+}
+
+function formatLastActivity(
+  reading: ArrivalOperatorView["outsiders"]["lastActivity"],
+  generatedAtMs: number,
+): string {
+  if (!reading) return "NO IDENTIFIED OUTSIDER ACTIVITY YET";
+  return `${formatAgo(reading.atMs, generatedAtMs)} · ${reading.stage} (${reading.door.toUpperCase()})`;
+}
+
+function formatPostedWork(reading: ArrivalOperatorView["outsiders"]["postedWork"]): string {
+  if (reading.status === "never") return "NEVER — THE OPEN GATE";
+  if (reading.status === "unknown") return "UNKNOWN — JOB CATALOGUE UNREADABLE";
+  return `${reading.count ?? 0} POSTED · FIRST ${formatDate(reading.firstAtMs)}`;
+}
+
+function formatDate(atMs: number | null): string {
+  return atMs === null || !Number.isFinite(atMs) ? "date unknown" : new Date(atMs).toISOString().slice(0, 10);
+}
+
+function countLabel(count: number, singular: string): string {
+  return `${count} ${singular}${count === 1 ? "" : "s"}`;
 }

--- a/packages/monitor-ui/src/lib/monitor/phone-spec.test.ts
+++ b/packages/monitor-ui/src/lib/monitor/phone-spec.test.ts
@@ -65,6 +65,42 @@ describe("phoneArrivals — did anyone come, what did they do, how far", () => {
     expect(lane?.line).not.toMatch(/MCP|HTTP/);
   });
 
+  it("prefers the registry-backed settled history over shallower legacy call counters", () => {
+    const lane = phoneArrivals(arrivals({
+      funnelExternal: stages({ reached: 9 }),
+      funnelHttpExternal: stages({ reached: 40 }),
+      operatorView: {
+        version: "averray.arrivals.operator.v1",
+        generatedAtMs: Date.parse("2026-08-16T12:00:00.000Z"),
+        outsiders: {
+          furthestEver: {
+            window: "all-time", stage: "settled", atMs: Date.parse("2026-08-11T08:00:00.000Z"),
+            door: "http", agents: 1, payouts: 42, payoutWindow: "12h",
+          },
+          lastActivity: {
+            window: "all-time", atMs: Date.parse("2026-08-11T08:00:00.000Z"), stage: "settled", door: "http",
+          },
+          week: { window: "7d", identified: 0, worked: 0 },
+          postedWork: { window: "all-time", status: "never", count: 0, firstAtMs: null },
+        },
+        ours: {
+          day: {
+            window: "24h", agents: 0, canaryRuns: 0, acceptanceRuns: 0,
+            adminConsoleAgents: 0, operatorAgents: 0,
+          },
+        },
+        unknown: { window: "all-time", sharedClientNames: 0, preSplitCalls: 0 },
+        doors: {
+          mcp: { window: "all-time", sinceMs: null, rows: [] },
+          http: { window: "all-time", sinceMs: null, rows: [] },
+        },
+      },
+    }));
+
+    expect(lane?.line).toBe("OUTSIDERS — someone settled work · last activity 5d ago");
+    expect(lane?.line).not.toMatch(/MCP|HTTP/);
+  });
+
   it("takes the FURTHEST across doors, never the sum", () => {
     // The doors cover different spans — HTTP is counted only from a cutover —
     // so adding them would be arithmetic across unlike windows. Furthest-stage

--- a/packages/monitor-ui/src/lib/monitor/phone-spec.ts
+++ b/packages/monitor-ui/src/lib/monitor/phone-spec.ts
@@ -481,6 +481,19 @@ export function phoneArrivals(arrivals: ProductHealth["arrivals"]): PhoneLane | 
     return { line: `OUTSIDERS — ${arrivals.unavailable}`, tone: "awaiting", unreadable: true };
   }
 
+  // Prefer the registry-backed cross-door journey. The legacy call funnels
+  // remain below only for deploy skew; they cannot express settlement history
+  // or separate per-run canaries from outsiders as completely as this view.
+  if (arrivals.operatorView && !("unavailable" in arrivals.operatorView)) {
+    const { furthestEver, lastActivity } = arrivals.operatorView.outsiders;
+    if (!furthestEver) return { line: "OUTSIDERS — no identified outsider yet", tone: "ok" };
+    const did = furthestEver.stage === "settled" ? "settled work" : STAGE_DID[furthestEver.stage];
+    const recency = lastActivity
+      ? ` · last activity ${formatAgo(lastActivity.atMs, arrivals.operatorView.generatedAtMs)}`
+      : "";
+    return { line: `OUTSIDERS — someone ${did}${recency}`, tone: "ok" };
+  }
+
   // The AMBIGUOUS bucket is in neither door's series on purpose: traffic under
   // a client name we also use ourselves cannot be called outside demand
   // without manufacturing it, nor ours without erasing a real stranger.

--- a/packages/monitor-ui/src/lib/monitor/product-health.ts
+++ b/packages/monitor-ui/src/lib/monitor/product-health.ts
@@ -361,6 +361,59 @@ export const ARRIVAL_STAGES = [
 ] as const;
 
 export type ArrivalStage = (typeof ARRIVAL_STAGES)[number];
+export type ArrivalJourneyStage = ArrivalStage | "settled";
+
+export interface ArrivalOperatorStageReading {
+  window: "all-time";
+  stage: ArrivalJourneyStage;
+  atMs: number | null;
+  door: string;
+  agents: number;
+  payouts?: number;
+  payoutWindow?: "12h";
+  payoutSpanMs?: number;
+}
+
+export interface ArrivalOperatorDoorRow {
+  stage: ArrivalStage;
+  unit: "calls" | "agents";
+  instrumentation: string;
+  outsider: number;
+  ours: number;
+  unknown: number;
+}
+
+export interface ArrivalOperatorView {
+  version: "averray.arrivals.operator.v1";
+  generatedAtMs: number;
+  outsiders: {
+    furthestEver: ArrivalOperatorStageReading | null;
+    lastActivity: { window: "all-time"; atMs: number; stage: ArrivalJourneyStage; door: string } | null;
+    week: { window: "7d"; identified: number; worked: number };
+    postedWork: {
+      window: "all-time";
+      status: "never" | "observed" | "unknown";
+      count: number | null;
+      firstAtMs: number | null;
+    };
+  };
+  ours: {
+    day: {
+      window: "24h";
+      agents: number;
+      canaryRuns: number;
+      acceptanceRuns: number;
+      adminConsoleAgents: number;
+      operatorAgents: number;
+    };
+  };
+  unknown: { window: "all-time"; sharedClientNames: number; preSplitCalls: number };
+  doors: Record<"mcp" | "http", {
+    window: "all-time";
+    sinceMs: number | null;
+    rows: ArrivalOperatorDoorRow[];
+  }>;
+}
 
 export interface ArrivalAttributionCounts {
   siwe_wallet: number;
@@ -382,6 +435,7 @@ export interface HttpArrivalCutover {
 
 export interface ArrivalClient {
   key: string;
+  wallet?: string | null;
   name: string | null;
   version: string | null;
   era: string | null;
@@ -433,6 +487,8 @@ export interface ArrivalsSnapshot {
     furthestAmbiguous?: ArrivalStage;
   };
   clients: ArrivalClient[];
+  /** Verdict-first projection derived by the shared self-identity registry. */
+  operatorView?: ArrivalOperatorView | { unavailable: string };
 }
 
 /** A reading and a failure are mutually exclusive; neither becomes zero. */

--- a/packages/monitor-ui/src/styles/hermes4-ops.css
+++ b/packages/monitor-ui/src/styles/hermes4-ops.css
@@ -1151,6 +1151,188 @@ body,
   color: var(--h4-tel);
 }
 
+/* Verdict-first arrivals projection. The older selectors above remain for
+   deploy-skew snapshots, but the shared-registry view deliberately has no bar
+   chart: its pre-identity counters sample different instrumentation points. */
+.ops-arrivals-verdict,
+.ops-arrivals-secondary,
+.ops-arrivals-evidence {
+  grid-column: 1 / -1;
+}
+.ops-arrivals-verdict {
+  padding: calc(9 * var(--ops-u)) calc(12 * var(--ops-u));
+  border: 1px solid var(--ops-rule);
+  border-left: 3px solid var(--h4-ok);
+  background: var(--h4-paper-sunken);
+}
+.ops-arrivals-block-head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: calc(12 * var(--ops-u));
+  padding-bottom: calc(5 * var(--ops-u));
+  border-bottom: 1px solid var(--ops-hair);
+}
+.ops-arrivals-block-head h3,
+.ops-arrivals-evidence summary,
+.ops-arrivals-door h3 {
+  margin: 0;
+  font-family: var(--h4-font-display);
+  font-size: calc(14 * var(--ops-u));
+  font-weight: 650;
+  letter-spacing: 0.08em;
+  color: var(--h4-ink);
+}
+.ops-arrivals-block-head span {
+  font-family: var(--h4-font-mono);
+  font-size: calc(9 * var(--ops-u));
+  color: var(--h4-muted);
+}
+.ops-arrivals-verdict-lines {
+  display: grid;
+  gap: calc(3 * var(--ops-u));
+  margin: calc(6 * var(--ops-u)) 0 0;
+}
+.ops-arrivals-verdict-lines > div {
+  display: grid;
+  grid-template-columns: calc(106 * var(--ops-u)) minmax(0, 1fr);
+  align-items: baseline;
+  gap: calc(12 * var(--ops-u));
+}
+.ops-arrivals-verdict-lines dt,
+.ops-arrivals-verdict-lines dd { margin: 0; }
+.ops-arrivals-verdict-lines dt {
+  font-family: var(--h4-font-mono);
+  font-size: calc(9 * var(--ops-u));
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--h4-muted);
+}
+.ops-arrivals-verdict-lines dd {
+  font-family: var(--h4-font-mono);
+  font-size: calc(12 * var(--ops-u));
+  color: var(--h4-ink);
+}
+.ops-arrivals-verdict-lines > div:first-child dd {
+  font-family: var(--h4-font-display);
+  font-size: calc(18 * var(--ops-u));
+  font-weight: 650;
+  letter-spacing: 0.025em;
+}
+.ops-arrivals-pair,
+.ops-arrivals-figure {
+  display: inline-flex;
+  align-items: baseline;
+  flex-wrap: wrap;
+  gap: calc(5 * var(--ops-u));
+}
+.ops-window-badge {
+  display: inline-block;
+  padding: calc(1 * var(--ops-u)) calc(4 * var(--ops-u));
+  border: 1px solid var(--ops-hair);
+  font-family: var(--h4-font-mono);
+  font-size: calc(7.5 * var(--ops-u));
+  font-weight: 500;
+  line-height: 1.25;
+  letter-spacing: 0.06em;
+  color: var(--h4-muted);
+  background: var(--h4-paper);
+}
+.ops-arrivals-secondary {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: calc(10 * var(--ops-u));
+}
+.ops-arrivals-owned,
+.ops-arrivals-unknown {
+  padding: calc(8 * var(--ops-u)) calc(10 * var(--ops-u));
+  border: 1px solid var(--ops-hair);
+}
+.ops-arrivals-figures {
+  display: flex;
+  flex-wrap: wrap;
+  gap: calc(6 * var(--ops-u)) calc(14 * var(--ops-u));
+  padding-top: calc(7 * var(--ops-u));
+  font-family: var(--h4-font-mono);
+  font-size: calc(10 * var(--ops-u));
+  color: var(--h4-ink-2);
+}
+.ops-arrivals-unknown .ops-arrivals-figures { color: var(--h4-tel); }
+.ops-arrivals-evidence {
+  padding-top: calc(5 * var(--ops-u));
+  border-top: 1px solid var(--ops-hair);
+}
+.ops-arrivals-evidence summary {
+  cursor: pointer;
+  font-size: calc(11 * var(--ops-u));
+  color: var(--h4-muted);
+}
+.ops-arrivals-evidence > p {
+  margin: calc(6 * var(--ops-u)) 0;
+  font-family: var(--h4-font-mono);
+  font-size: calc(9 * var(--ops-u));
+  line-height: 1.45;
+  color: var(--h4-muted);
+}
+.ops-arrivals-door-tables {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: calc(14 * var(--ops-u));
+}
+.ops-arrivals-door,
+.ops-arrivals-door + .ops-arrivals-door {
+  display: block;
+  padding: calc(8 * var(--ops-u));
+  border: 1px solid var(--ops-hair);
+}
+.ops-arrivals-door-since {
+  margin: calc(3 * var(--ops-u)) 0 calc(6 * var(--ops-u));
+  font-family: var(--h4-font-mono);
+  font-size: calc(8 * var(--ops-u));
+  color: var(--h4-muted);
+}
+.ops-arrivals-table {
+  display: grid;
+  font-family: var(--h4-font-mono);
+  font-size: calc(8.5 * var(--ops-u));
+}
+.ops-arrivals-table-head,
+.ops-arrivals-table-row {
+  display: grid;
+  grid-template-columns: minmax(calc(150 * var(--ops-u)), 1fr) repeat(3, minmax(calc(64 * var(--ops-u)), auto));
+  gap: calc(7 * var(--ops-u));
+  align-items: center;
+  padding: calc(4 * var(--ops-u)) 0;
+  border-bottom: 1px solid var(--ops-hair);
+}
+.ops-arrivals-table-head {
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--h4-muted);
+}
+.ops-arrivals-table-head span:not(:first-child) { text-align: right; }
+.ops-arrivals-table-row > span:first-child {
+  display: grid;
+  gap: calc(1 * var(--ops-u));
+}
+.ops-arrivals-table-row > span:first-child strong {
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--h4-ink);
+}
+.ops-arrivals-table-row > span:first-child small {
+  color: var(--h4-muted);
+}
+.ops-arrivals-table-row > .ops-arrivals-figure {
+  justify-content: flex-end;
+  color: var(--h4-ink-2);
+}
+.ops-arrivals-cutover {
+  padding-top: calc(5 * var(--ops-u));
+  border-top: 1px solid var(--ops-hair);
+  color: var(--h4-tel) !important;
+}
+
 /* ---- BANK group ------------------------------------------------
    One frame asserts one treasury subject, not one instrument. The venue and
    depositor pool therefore keep separate cells, tones and absence rules, with
@@ -1363,6 +1545,12 @@ body,
 @media (max-width: 760px) {
   .ops-deposit-pool-grid { grid-template-columns: 1fr 1fr; }
   .ops-deposit-pool-flows ul { grid-template-columns: 1fr; }
+  .ops-arrivals-verdict-lines > div { grid-template-columns: 1fr; gap: calc(2 * var(--ops-u)); }
+  .ops-arrivals-table-head,
+  .ops-arrivals-table-row {
+    grid-template-columns: minmax(calc(120 * var(--ops-u)), 1fr) repeat(3, minmax(calc(48 * var(--ops-u)), auto));
+    gap: calc(4 * var(--ops-u));
+  }
 }
 
 /* ---- per-job economics -------------------------------------------
@@ -1444,6 +1632,8 @@ body,
   }
   .ops-arrivals { grid-template-columns: 1fr; }
   .ops-arrivals-doors { grid-template-columns: 1fr; }
+  .ops-arrivals-secondary,
+  .ops-arrivals-door-tables { grid-template-columns: 1fr; }
   .ops-arrivals-door + .ops-arrivals-door {
     padding: calc(14 * var(--ops-u)) 0 0;
     border-left: 0;


### PR DESCRIPTION
## What changed

- Replaces the door-first arrivals display with the outsider verdict first: historical furthest stage, last activity, weekly identified and worked wallets, and posted-work state.
- Keeps canary, acceptance, admin, operator, and unknown traffic visibly separate from demand.
- Moves MCP and HTTP instrumentation into an expandable evidence drawer, labels call-versus-agent units, and gives every figure a window badge.
- Makes the compact phone line prefer the registry-backed cross-door journey while retaining a deploy-skew fallback.
- Names the verdict unavailable when the producer projection is absent instead of manufacturing zeroes.

Depends on averray-agent/agent#1147 for the operatorView producer and shared identity registry.

## Packet acceptance evidence

- A historical feed fixture renders SETTLED, 42 payouts in 12h, 2026-08-11, and HTTP from supplied data; the component source contains none of those historical literals.
- Posted work changes from NEVER — THE OPEN GATE when the first external job appears.
- A pure canary and acceptance fixture renders outsider worked as zero and owned run counts separately.
- Every rendered figure has a window badge; non-monotonic pre-identity rows say calls and identify their instrumentation.
- Unknown traffic and the producer cut-over note are preserved verbatim.

## Checks

- npm test — 205 test files passed, 3,011 tests passed, 37 skipped.
- npm run typecheck
- git diff --check

## Scope and operations

Monitor UI only. No backend, contract, indexer, Caddy, deployment, environment, or generated-output changes.