### PR TITLE
fix(arrivals): operatorView survives feed normalization

### DIFF
--- a/services/slack-operator/src/arrivals-feed.ts
+++ b/services/slack-operator/src/arrivals-feed.ts
@@ -91,6 +91,13 @@ export interface ArrivalsSnapshot {
   funnelHttpAmbiguous?: Record<ArrivalStage, number>;
   attributionSourceTotals?: ArrivalAttributionSourceTotals;
   httpCutover?: HttpArrivalCutover;
+  /**
+   * The producer's verdict-first operator view (outsiders/ours/unknown with
+   * furthest-ever and posted-work). Carried through opaquely: the panel owns
+   * its shape, including the {unavailable} form. Absent from producers that
+   * predate it — absent, never fabricated.
+   */
+  operatorView?: Record<string, unknown>;
   distinct: {
     declared: number;
     anonymous: number;
@@ -282,6 +289,12 @@ export function normalizeArrivalsFeed(body: unknown): ArrivalsBlock {
       ? { attributionSourceTotals: attributionSourceTotals.value }
       : {}),
     ...(httpCutover && "value" in httpCutover ? { httpCutover: httpCutover.value } : {}),
+    // Pass the producer's operator view through untouched; the panel owns its
+    // shape. Dropping it here is what turned the live verdict band into
+    // "projection not present" while the backend was emitting it all along.
+    ...(value.operatorView && typeof value.operatorView === "object" && !Array.isArray(value.operatorView)
+      ? { operatorView: value.operatorView as Record<string, unknown> }
+      : {}),
     distinct: {
       declared,
       anonymous,

--- a/services/slack-operator/test/unit/arrivals-feed.test.ts
+++ b/services/slack-operator/test/unit/arrivals-feed.test.ts
@@ -133,6 +133,23 @@ describe("normalizeArrivalsFeed", () => {
     expect("clients" in result && result.clients).toEqual(good.clients);
   });
 
+  // The seam this file guards: the producer's operator view must survive
+  // normalization byte-for-byte, or the live verdict band renders "projection
+  // not present" while the backend emits it — the 2026-08-17 defect.
+  test("passes the producer's operatorView through untouched", () => {
+    const operatorView = {
+      generatedAtMs: 1755400000000,
+      outsiders: { furthestEver: { stage: "settled" }, postedWork: { status: "never" } },
+    };
+    const result = normalizeArrivalsFeed({ ...good, operatorView });
+    expect("operatorView" in result && result.operatorView).toEqual(operatorView);
+  });
+
+  test("a producer without an operator view stays absent, never fabricated", () => {
+    const result = normalizeArrivalsFeed(good);
+    expect("operatorView" in result).toBe(false);
+  });
+
   // A producer too old to split the funnel cannot answer "did an OUTSIDER
   // browse?". Reading `funnel` in its place would answer a different question
   // with the same confident number, which is the defect this contract exists


### PR DESCRIPTION
The #813 seam miss: normalizeArrivalsFeed's field-by-field rebuild dropped operatorView, so the deployed verdict band showed 'shared identity registry projection not present' while the post-#1147 backend emitted the view all along. Panel tests never caught it because they feed fixtures directly. Adds the opaque passthrough (panel owns the shape; absent stays absent, never fabricated) plus the two seam tests that were missing. Focused suite 23/23.

🤖 Generated with [Claude Code](https://claude.com/claude-code)