### PR TITLE
Fix board truth for terminal XCM and protocol revenue

### DIFF
--- a/packages/monitor-ui/src/components/mobile/MobileBoard.test.tsx
+++ b/packages/monitor-ui/src/components/mobile/MobileBoard.test.tsx
@@ -67,6 +67,15 @@ describe("phone board — the check-in", () => {
     expect(getByTestId("mobile-unfloored").textContent).toContain("99.00");
   });
 
+  test("protocol revenue discloses gas retention and operator-self-paid fees on the phone board", () => {
+    const { getByTestId } = render(
+      <MobileBoard health={OPS_FIXTURE_NOMINAL} nowMs={fresh(OPS_FIXTURE_NOMINAL)} />,
+    );
+    const text = getByTestId("mobile-unfloored").textContent ?? "";
+    expect(text).toContain("protocol revenue — poster fees + gas retention");
+    expect(text).toContain("of which operator-self-paid: 0.10 USDC");
+  });
+
   test("an unreadable balance is '—', never 0", () => {
     const pools: SolvencyPool[] = [
       { key: "bank", label: "Reward bank", amount: null, unit: "USDC", floor: 2, status: "ok" },

--- a/packages/monitor-ui/src/components/mobile/MobileBoard.tsx
+++ b/packages/monitor-ui/src/components/mobile/MobileBoard.tsx
@@ -316,7 +316,11 @@ function SolvencyPanel({ health }: { health: ProductHealth }) {
         <p className="hm-ph-unfloored" data-testid="mobile-unfloored">
           no floor, no meter —{" "}
           {unfloored
-            .map((v) => `${v.pool.label.toLowerCase()} ${v.amountLabel}${v.pool.note ? " (intentional)" : ""}`)
+            .map((v) => {
+              const base = `${v.pool.label.toLowerCase()} ${v.amountLabel}`;
+              if (v.pool.key === "protocol_revenue" && v.pool.note) return `${base} (${v.pool.note})`;
+              return `${base}${v.pool.note ? " (intentional)" : ""}`;
+            })
             .join(" · ")}
         </p>
       ) : null}

--- a/packages/monitor-ui/src/components/ops/OpsBoard.test.tsx
+++ b/packages/monitor-ui/src/components/ops/OpsBoard.test.tsx
@@ -163,6 +163,16 @@ describe("OpsBoard — solvency meters", () => {
     expect(reserve.textContent).toContain("intentionally unfunded");
   });
 
+  test("protocol revenue names gas retention and discloses operator-self-paid fees", () => {
+    const { getByTestId } = render(
+      <OpsBoard health={OPS_FIXTURE_NOMINAL} nowMs={fresh(OPS_FIXTURE_NOMINAL)} />,
+    );
+    const revenue = getByTestId("ops-pool-protocol_revenue");
+    expect(revenue.textContent).toContain("Protocol revenue — poster fees + gas retention");
+    expect(revenue.textContent).toContain("external poster fees: 0.29 USDC");
+    expect(revenue.textContent).toContain("of which operator-self-paid: 0.10 USDC");
+  });
+
   test("a breached floor is coral and states the absolute shortfall", () => {
     const { getByTestId } = render(<OpsBoard health={OPS_FIXTURE_STRESS} nowMs={FIXTURE_NOW} />);
     const bank = getByTestId("ops-pool-reward_bank");

--- a/packages/monitor-ui/src/lib/monitor/ops-fixtures.ts
+++ b/packages/monitor-ui/src/lib/monitor/ops-fixtures.ts
@@ -264,16 +264,16 @@ const MAINNET_POOLS: SolvencyPool[] = [
     addressLabel: "EscrowCore",
   },
   {
-    key: "revenue",
-    label: "Protocol revenue",
-    amount: 0.01,
+    key: "protocol_revenue",
+    label: "Protocol revenue — poster fees + gas retention",
+    amount: 0.39,
     unit: "USDC",
     status: "ok",
-    note: "5% poster-side fee · held under the 2-of-3 treasury multisig",
-      address: "0x01e6eed856e989201f4ff6346e18eab7e46c874c",
+    note: "external poster fees: 0.29 USDC · of which operator-self-paid: 0.10 USDC",
+    address: "0x01e6eed856e989201f4ff6346e18eab7e46c874c",
     addressSs58: "13VefHVLFhdvis2hA75gVSrAR6psiRqaqBzFPdwxW6GG6aJ",
     addressLabel: "treasury multisig",
-},
+  },
 ];
 
 const MAINNET_PROBES: ProductHealthProbe[] = [

--- a/services/slack-operator/src/bank-feed-fetch.ts
+++ b/services/slack-operator/src/bank-feed-fetch.ts
@@ -199,6 +199,7 @@ function requestsBlock(raw: unknown): { requests: BankRequests } | { reason: str
       return { reason: `bank feed request ${e.id} needs numeric ageSeconds and boolean overdue` };
     }
     const reconciliation = terminalReconciliation(e.reconciliation);
+    const finalization = requestFinalization(e.finalization);
     items.push({
       id: e.id,
       kind: typeof e.kind === "string" ? e.kind : "unknown",
@@ -217,6 +218,8 @@ function requestsBlock(raw: unknown): { requests: BankRequests } | { reason: str
           ? { deadlineAtMs: Date.parse(e.deadlineAt) }
           : {}),
       ...(typeof e.status === "string" ? { status: e.status } : {}),
+      ...(typeof e.reason === "string" && e.reason.trim() ? { reason: e.reason.trim() } : {}),
+      ...(finalization ? { finalization } : {}),
       ...(reconciliation ? { reconciliation } : {}),
     });
   }
@@ -226,6 +229,20 @@ function requestsBlock(raw: unknown): { requests: BankRequests } | { reason: str
       readAtMs: (r.readAtMs as number | null) ?? null,
       ...(typeof r.lastError === "string" ? { lastError: r.lastError } : {}),
     },
+  };
+}
+
+function requestFinalization(raw: unknown): BankRequest["finalization"] | undefined {
+  if (!raw || typeof raw !== "object") return undefined;
+  const r = raw as Record<string, unknown>;
+  if (r.status !== "error" && r.status !== "pending") return undefined;
+  const attemptCount = Number(r.attemptCount);
+  return {
+    status: r.status,
+    attemptCount: Number.isSafeInteger(attemptCount) && attemptCount >= 0 ? attemptCount : 0,
+    lastError: typeof r.lastError === "string" ? r.lastError : null,
+    lastTriedAt: typeof r.lastTriedAt === "string" ? r.lastTriedAt : null,
+    nextAttemptAt: typeof r.nextAttemptAt === "string" ? r.nextAttemptAt : null,
   };
 }
 

--- a/services/slack-operator/src/bank-feed.ts
+++ b/services/slack-operator/src/bank-feed.ts
@@ -59,7 +59,7 @@ export interface BankRequest {
   /**
    * The observer's state machine value, DELIBERATELY not a closed union.
    *
-   * The four known phases are listed in `KNOWN_PHASES`, but the observer owns
+   * The known phases are listed in `KNOWN_PHASES`, but the observer owns
    * this vocabulary and may extend it — `recovery-pending` is plausible given
    * the recovery bucket. A board that hard-failed or silently dropped an
    * unrecognized phase would hide precisely the unusual request, which is the
@@ -82,6 +82,16 @@ export interface BankRequest {
   deadlineAtMs?: number | null;
   /** Producer-owned terminal status; pending for in-flight rows. */
   status?: string;
+  /** Presentation-safe reason for a terminal failure, when the producer has one. */
+  reason?: string;
+  /** Failed finalization detail from the producer's durable retry record. */
+  finalization?: {
+    status: "error" | "pending";
+    attemptCount: number;
+    lastError: string | null;
+    lastTriedAt: string | null;
+    nextAttemptAt: string | null;
+  };
   /**
    * Presentation-safe terminal accounting. The producer deliberately omits
    * raw contract recovery slots that are known accounting artifacts.
@@ -127,6 +137,7 @@ export const KNOWN_PHASES = [
   "leg2-dispatched",
   // shared tail
   "pending-finalize",
+  "finalize-error",
   "scope-unknown",
   "terminal",
   // synthesized by the feed itself, never by the observer

--- a/services/slack-operator/src/bank-lane.ts
+++ b/services/slack-operator/src/bank-lane.ts
@@ -362,14 +362,10 @@ function requestLine(requests: BankRequests, nowMs: number, staleAfterMs: number
     return { text: `request table is ${mins}m old — in-flight state not current`, tone: "degraded" };
   }
 
-  // An unrecognized phase is NOT dropped and NOT treated as terminal. The
-  // observer owns this vocabulary and may extend it; a request in a phase this
-  // board has never heard of is the most unusual one in the table, which makes
-  // hiding it exactly backwards.
-  const unknown = requests.items.filter((r) => !isKnownPhase(r.phase));
-  const live = requests.items.filter((r) => r.phase !== "terminal");
+  const unknown = requests.items.filter((r) => requestDisposition(r) === "unrecognised");
+  const live = requests.items.filter((r) => requestDisposition(r) !== "terminal");
   if (live.length === 0) {
-    const terminal = requests.items.find((request) => request.phase === "terminal" && request.reconciliation);
+    const terminal = requests.items.find((request) => requestDisposition(request) === "terminal" && request.reconciliation);
     if (terminal?.reconciliation) {
       const r = terminal.reconciliation;
       const final = r.actualTreasuryReturnRaw !== undefined &&
@@ -386,6 +382,16 @@ function requestLine(requests: BankRequests, nowMs: number, staleAfterMs: number
             `${r.stagedRaw} staged − ${r.leg1TransferFeeRaw} leg-1 fee − ` +
             `${r.trappedWriteOff3Raw} trapped write-off #3 = ${r.remoteRecoverableRaw} recoverable · ` +
             `${r.unexplainedRaw} unexplained · ${r.artifactLabel}`,
+        tone: "degraded",
+      };
+    }
+    const failures = requests.items.filter((request) => terminalFailureReason(request) !== null);
+    if (failures.length > 0) {
+      const lead = failures[0]!;
+      return {
+        text:
+          `${failures.length} CLOSED ${String(lead.status ?? lead.phase).toUpperCase()} · ${lead.id} · ` +
+          `${terminalFailureReason(lead)}`,
         tone: "degraded",
       };
     }
@@ -406,9 +412,28 @@ function requestLine(requests: BankRequests, nowMs: number, staleAfterMs: number
   if (unknown.length > 0) {
     // Verbatim, so the value is searchable against the observer's own source.
     const u = unknown[0]!;
-    return { text: `${base} · UNRECOGNISED PHASE "${u.phase}" on ${u.id}`, tone: "degraded" };
+    return { text: `${base} · unrecognised — investigate: phase "${u.phase}" on ${u.id}`, tone: "degraded" };
   }
   return { text: base, tone: "ok" };
+}
+
+export function requestDisposition(request: BankRequest): "pending" | "terminal" | "unrecognised" {
+  const phase = request.phase.trim().toLowerCase();
+  const status = String(request.status ?? "pending").trim().toLowerCase();
+  if (phase === "terminal" || phase === "finalize-error") return "terminal";
+  if (!isKnownPhase(phase)) return "unrecognised";
+  if (["failed", "error", "cancelled", "rejected"].includes(status)) return "terminal";
+  return "pending";
+}
+
+function terminalFailureReason(request: BankRequest): string | null {
+  const phase = request.phase.trim().toLowerCase();
+  const status = String(request.status ?? "").trim().toLowerCase();
+  const failed = phase === "finalize-error" || ["failed", "error", "cancelled", "rejected"].includes(status);
+  if (!failed) return null;
+  return request.reason?.trim()
+    || request.finalization?.lastError?.trim()
+    || `terminal ${status || phase} without a supplied reason`;
 }
 
 /**

--- a/services/slack-operator/src/product-health.ts
+++ b/services/slack-operator/src/product-health.ts
@@ -2285,6 +2285,66 @@ export async function probeSignerLiquidity(input: {
   }
 }
 
+export interface PosterFeeAttribution {
+  external: number;
+  operatorSelfPaid: number;
+  total: number;
+  status: string;
+}
+
+export function posterFeeAttributionFromTransparency(snapshot: unknown): PosterFeeAttribution | undefined {
+  if (!snapshot || typeof snapshot !== "object") return undefined;
+  const root = snapshot as Record<string, unknown>;
+  if (root.schemaVersion !== "averray.transparency.v1") return undefined;
+  const flow = root.flow && typeof root.flow === "object" ? root.flow as Record<string, unknown> : {};
+  const fees = flow.posterFeesAllTime && typeof flow.posterFeesAllTime === "object"
+    ? flow.posterFeesAllTime as Record<string, unknown>
+    : {};
+  const read = (key: string): { value: number; status: string } | undefined => {
+    const raw = fees[key];
+    if (!raw || typeof raw !== "object") return undefined;
+    const field = raw as Record<string, unknown>;
+    if (field.value === null || field.value === undefined) return undefined;
+    const value = Number(field.value);
+    const status = typeof field.status === "string" ? field.status : "unknown";
+    return Number.isFinite(value) && status !== "unknown" ? { value, status } : undefined;
+  };
+  const external = read("external");
+  const operatorSelfPaid = read("operatorSelfPaid");
+  const total = read("total");
+  if (!external || !operatorSelfPaid || !total) return undefined;
+  return {
+    external: external.value,
+    operatorSelfPaid: operatorSelfPaid.value,
+    total: total.value,
+    status: [external.status, operatorSelfPaid.status, total.status].every((status) => status === "fresh")
+      ? "fresh"
+      : "stale",
+  };
+}
+
+export async function readPosterFeeAttribution(input: {
+  baseUrl?: string;
+  fetchImpl: typeof fetch;
+  timeoutMs?: number;
+}): Promise<PosterFeeAttribution | undefined> {
+  if (!input.baseUrl) return undefined;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), input.timeoutMs ?? 5_000);
+  try {
+    const response = await input.fetchImpl(`${input.baseUrl.replace(/\/+$/u, "")}/transparency`, {
+      headers: { accept: "application/json" },
+      signal: controller.signal,
+    });
+    if (!response.ok) return undefined;
+    return posterFeeAttributionFromTransparency(await response.json());
+  } catch {
+    return undefined;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
 /** Treasury / reward-pool headroom: USDC balanceOf(AAC / escrow / reserve) via direct
  *  RPC + the reward bank (rewardBank.liquid the product computes on /health). Floors
  *  page (red); escrow is informational (in-flight, fluctuates). Addresses absent (the
@@ -2299,6 +2359,7 @@ export async function probeTreasuryLiquidity(input: {
   minAac: number;
   rpcUrl?: string;
   fetchImpl: typeof fetch;
+  posterFeeAttribution?: PosterFeeAttribution;
 }): Promise<ProbeResult & { pools?: SolvencyPoolData[] }> {
   const name = "treasury_liquidity";
   const a = input.addresses;
@@ -2403,10 +2464,9 @@ export async function probeTreasuryLiquidity(input: {
       });
     }
 
-    // Protocol revenue — the 5% poster-side fee accrued in the treasury
-    // multisig's position. Internal ops metric (Hermes-only); informational, no
-    // floor. Omitted entirely if unreadable — never shown as a fake zero, since
-    // a zero here is a real "no fees yet" statement.
+    // Protocol revenue is the treasury AAC's liquid position: poster fees PLUS
+    // retained gas. The public transparency read supplies the independently
+    // classified poster-fee breakout; it never replaces this on-chain total.
     const protocolRevenue = await readProtocolRevenueUsdc({
       rpcUrl: input.rpcUrl,
       escrowCore: a.escrowCore,
@@ -2418,12 +2478,16 @@ export async function probeTreasuryLiquidity(input: {
     if (protocolRevenue !== undefined) {
       pools.push({
         key: "protocol_revenue",
-        label: "Protocol revenue (fees)",
+        label: "Protocol revenue — poster fees + gas retention",
         amount: protocolRevenue.usdc,
         unit: "USDC",
         status: "ok",
         informational: true,
-        note: "5% poster-side fee, held under the 2-of-3 treasury",
+        note: input.posterFeeAttribution
+          ? `external poster fees: ${input.posterFeeAttribution.external.toFixed(2)} USDC · ` +
+            `of which operator-self-paid: ${input.posterFeeAttribution.operatorSelfPaid.toFixed(2)} USDC` +
+            `${input.posterFeeAttribution.status === "fresh" ? "" : ` (${input.posterFeeAttribution.status})`}`
+          : "of which operator-self-paid: attribution unavailable — total still includes poster fees + gas retention",
         address: protocolRevenue.treasuryAccount,
         addressLabel: "treasury multisig",
       });
@@ -2809,16 +2873,19 @@ export async function collectProductHealthProbes(
     haltStatus: chainHaltStatus(chainId, config.haltSeverity),
     blockAgeSec,
   };
-  const signer = await probeSignerLiquidity({
-    rpcUrl: config.rpcUrl,
-    signerAddress: config.signerAddress,
-    rewardBankLiquid,
-    minGasNative: config.minGasNative,
-    minRewardBank: config.minRewardBank,
-    // Balances are only trusted from an RPC on the product's own chain.
-    expectedChainId: chainId,
-    fetchImpl,
-  });
+  const [signer, posterFeeAttribution] = await Promise.all([
+    probeSignerLiquidity({
+      rpcUrl: config.rpcUrl,
+      signerAddress: config.signerAddress,
+      rewardBankLiquid,
+      minGasNative: config.minGasNative,
+      minRewardBank: config.minRewardBank,
+      // Balances are only trusted from an RPC on the product's own chain.
+      expectedChainId: chainId,
+      fetchImpl,
+    }),
+    readPosterFeeAttribution({ baseUrl: config.apiBaseUrl, fetchImpl }),
+  ]);
   const treasury = await probeTreasuryLiquidity({
     addresses: h.body?.addresses,
     rewardBankLiquid,
@@ -2829,6 +2896,7 @@ export async function collectProductHealthProbes(
     minAac: config.minAac,
     rpcUrl: config.rpcUrl,
     fetchImpl,
+    ...(posterFeeAttribution ? { posterFeeAttribution } : {}),
   });
   // signer_liquidity and treasury_liquidity intentionally share the same
   // /health reward-bank position. Keep one board row while retaining both

--- a/services/slack-operator/test/unit/bank-feed-fetch.test.ts
+++ b/services/slack-operator/test/unit/bank-feed-fetch.test.ts
@@ -121,6 +121,38 @@ describe("nothing that crossed the network is trusted", () => {
     });
     expect(r.feed!.requests.items[0]!.reconciliation).not.toHaveProperty("rawRecoveryAssetsOutstandingRaw");
   });
+
+  test("finalize-error reason crosses the boundary for the closed row", () => {
+    const r = normalizeBankFeed({
+      ...good,
+      requests: {
+        items: [{
+          id: "req-failed",
+          kind: "withdraw",
+          phase: "finalize-error",
+          status: "error",
+          ageSeconds: 100,
+          overdue: false,
+          finalization: {
+            status: "error",
+            attemptCount: 2,
+            lastError: "FAILED: remote execution rejected",
+            lastTriedAt: "2026-08-14T10:00:00.000Z",
+            nextAttemptAt: null,
+          },
+        }],
+        readAtMs: 1,
+      },
+    });
+
+    expect(r.feed!.requests.items[0]!.finalization).toEqual({
+      status: "error",
+      attemptCount: 2,
+      lastError: "FAILED: remote execution rejected",
+      lastTriedAt: "2026-08-14T10:00:00.000Z",
+      nextAttemptAt: null,
+    });
+  });
 });
 
 describe("a malformed calibration is dropped, never repaired", () => {

--- a/services/slack-operator/test/unit/bank-lane.test.ts
+++ b/services/slack-operator/test/unit/bank-lane.test.ts
@@ -161,7 +161,7 @@ describe("an unrecognised phase is surfaced, never dropped", () => {
       nowMs: NOW,
     })!;
     expect(v.requests.text).toContain("1 in flight");
-    expect(v.requests.text).toContain('UNRECOGNISED PHASE "phase-from-the-future"');
+    expect(v.requests.text).toContain('unrecognised — investigate: phase "phase-from-the-future"');
     expect(v.requests.text).toContain("req-77");
     expect(v.requests.tone).toBe("degraded");
   });
@@ -202,6 +202,42 @@ describe("an overdue request is the stuck-pending alarm, named", () => {
   test("terminal requests are not in flight", () => {
     const v = bankLaneView({ feed: feed({ requests: { items: [req({ phase: "terminal" })], readAtMs: NOW } }), nowMs: NOW })!;
     expect(v.requests.text).toBe("no requests in flight");
+  });
+
+  test("the five 2026-08-14 finalize-error recalls render closed with their failure reason", () => {
+    const items = Array.from({ length: 5 }, (_, index) => req({
+      id: `recall-2026-08-14-${index + 1}`,
+      phase: "finalize-error",
+      status: "error",
+      finalization: {
+        status: "error",
+        attemptCount: 1,
+        lastError: "FAILED: XCM destination rejected the recall",
+        lastTriedAt: null,
+        nextAttemptAt: null,
+      },
+    }));
+    const v = bankLaneView({ feed: feed({ requests: { items, readAtMs: NOW } }), nowMs: NOW })!;
+
+    expect(v.requests.text).toContain("5 CLOSED ERROR");
+    expect(v.requests.text).toContain("XCM destination rejected the recall");
+    expect(v.requests.text).not.toContain("in flight");
+    expect(v.requests.text).not.toContain("pending");
+  });
+
+  test("FAILED is terminal while a genuinely pending request remains pending", () => {
+    const failed = bankLaneView({
+      feed: feed({ requests: { items: [req({ phase: "pending-finalize", status: "FAILED", reason: "remote failed" })], readAtMs: NOW } }),
+      nowMs: NOW,
+    })!;
+    const pending = bankLaneView({
+      feed: feed({ requests: { items: [req({ phase: "pending-finalize", status: "pending" })], readAtMs: NOW } }),
+      nowMs: NOW,
+    })!;
+
+    expect(failed.requests.text).toContain("1 CLOSED FAILED");
+    expect(failed.requests.text).toContain("remote failed");
+    expect(pending.requests.text).toContain("1 in flight");
   });
 
   test("terminal failure renders the five-line reconciliation and artifact label", () => {
@@ -262,7 +298,7 @@ describe("the documented v2.2 vocabulary is recognised", () => {
       feed: feed({ requests: { items: [req({ phase: "staged-on-chain-backfill" })], readAtMs: NOW } }),
       nowMs: NOW,
     })!;
-    expect(v.requests.text).not.toContain("UNRECOGNISED");
+    expect(v.requests.text).not.toContain("unrecognised");
   });
 
   test("the first v2.2 dispatch phase will not cry wolf either", () => {
@@ -274,7 +310,7 @@ describe("the documented v2.2 vocabulary is recognised", () => {
         feed: feed({ requests: { items: [req({ phase })], readAtMs: NOW } }),
         nowMs: NOW,
       })!;
-      expect(v.requests.text, phase).not.toContain("UNRECOGNISED");
+      expect(v.requests.text, phase).not.toContain("unrecognised");
     }
   });
 });

--- a/test/unit/product-health.test.ts
+++ b/test/unit/product-health.test.ts
@@ -10,6 +10,7 @@ import {
   deriveLatencyProbe,
   deriveMoneyPathProbe,
   probeTreasuryLiquidity,
+  posterFeeAttributionFromTransparency,
   trackChainAdvance,
   chainHaltStatus,
   probeSignerLiquidity,
@@ -889,6 +890,7 @@ describe("probeTreasuryLiquidity (direct RPC + /health rewardBank)", () => {
     const r = await probeTreasuryLiquidity({
       ...base,
       rewardBankLiquid: 100,
+      posterFeeAttribution: { external: 0.29, operatorSelfPaid: 0.1, total: 0.39, status: "fresh" },
       fetchImpl: revenueFetch({
         usdcHex: "0x989680",
         treasury: "0x01E6eed856e989201F4FF6346E18EAb7e46C874C",
@@ -900,6 +902,41 @@ describe("probeTreasuryLiquidity (direct RPC + /health rewardBank)", () => {
     expect(revenue?.amount).toBe(0.005);
     expect(revenue?.informational).toBe(true);
     expect(revenue?.status).toBe("ok"); // informational, never pages
+    expect(revenue?.label).toBe("Protocol revenue — poster fees + gas retention");
+    expect(revenue?.note).toContain("external poster fees: 0.29 USDC");
+    expect(revenue?.note).toContain("of which operator-self-paid: 0.10 USDC");
+  });
+
+  it("keeps operator-self-paid fixed when an external poster settlement moves the external line", () => {
+    const snapshot = (external: string) => ({
+      schemaVersion: "averray.transparency.v1",
+      flow: {
+        posterFeesAllTime: {
+          external: { value: external, status: "fresh" },
+          operatorSelfPaid: { value: "0.10", status: "fresh" },
+          total: { value: String(Number(external) + 0.1), status: "fresh" },
+        },
+      },
+    });
+    const before = posterFeeAttributionFromTransparency(snapshot("0.29"));
+    const after = posterFeeAttributionFromTransparency(snapshot("0.34"));
+
+    expect(before?.operatorSelfPaid).toBe(0.1);
+    expect(after?.operatorSelfPaid).toBe(before?.operatorSelfPaid);
+    expect(after?.external).toBe(0.34);
+  });
+
+  it("never turns an absent self-paid attribution into zero", () => {
+    expect(posterFeeAttributionFromTransparency({
+      schemaVersion: "averray.transparency.v1",
+      flow: {
+        posterFeesAllTime: {
+          external: { value: "0.29", status: "fresh" },
+          operatorSelfPaid: { value: null, status: "fresh" },
+          total: { value: "0.39", status: "fresh" },
+        },
+      },
+    })).toBeUndefined();
   });
 
   it("omits protocol_revenue rather than faking a zero when the treasury read fails", async () => {


### PR DESCRIPTION
## What changed
- Treat FAILED and finalize-error XCM request rows as closed with their reason while keeping real pending work in flight and future phases visibly unrecognised.
- Preserve finalization reasons through the bank feed boundary.
- Keep protocol revenue sourced from the treasury AAC and relabel it as poster fees plus gas retention.
- Read external and operator-self-paid poster-fee attribution from the platform transparency endpoint, with explicit unknown and stale behavior, on desktop and phone boards.

## Acceptance evidence
- Five 2026-08-14 failure fixtures render 5 CLOSED, no pending or in flight, and include the failure reason.
- A genuinely pending request remains pending.
- A future phase renders unrecognised — investigate.
- External poster-fee movement changes only the external line; operator-self-paid remains fixed.
- Null attribution is unavailable, never zero.

## Checks
- npm run build
- npm run typecheck
- npm test — 3,020 passed and 37 skipped across 210 files
- Focused acceptance suite — 302 passed

## Impact
Monitor service and desktop/phone board UI. No backend mutation, contract, deployment, or environment changes.