### PR TITLE
feat(board): visual overhaul — draw the data the payload already carries

### DIFF
--- a/packages/monitor-ui/src/components/ops/DepositPoolTile.test.tsx
+++ b/packages/monitor-ui/src/components/ops/DepositPoolTile.test.tsx
@@ -48,6 +48,47 @@ describe("DepositPoolTile truth states", () => {
     expect(getByTestId("ops-deposit-pool-flow-window").textContent).toContain("blocks 100–101");
   });
 
+  test("the cap meter draws only against the configured cap, and zero draws no fill", () => {
+    const snapshot = {
+      schemaVersion: 1 as const,
+      available: true as const,
+      totalAssets: amount("20446982"),
+      caps: { totalAssetCap: amount("1000000000"), headroom: amount("979553018"), utilizationBps: 204 },
+    };
+    const { getByTestId, rerender, queryByTestId } = render(<DepositPoolTile pool={{ snapshot }} />);
+    const meter = getByTestId("ops-deposit-pool-cap-meter");
+    expect(meter.querySelector("i")).not.toBeNull();
+    expect(meter.querySelector("i")!.style.width).toBe("2.04%");
+
+    // Zero utilisation keeps the track and drops the fill — the CSS floor that
+    // keeps a real 0.1% visible must never fabricate a sliver at exactly 0.
+    rerender(
+      <DepositPoolTile
+        pool={{ snapshot: { ...snapshot, caps: { ...snapshot.caps, utilizationBps: 0 } } }}
+      />,
+    );
+    expect(getByTestId("ops-deposit-pool-cap-meter").querySelector("i")).toBeNull();
+
+    // No configured cap → no bar at all: a meter needs a real fixed scale.
+    rerender(
+      <DepositPoolTile
+        pool={{ snapshot: { ...snapshot, caps: { utilizationBps: 204 } } }}
+      />,
+    );
+    expect(queryByTestId("ops-deposit-pool-cap-meter")).toBeNull();
+
+    // Over the cap the pegged bar carries the over marker — "at cap" and
+    // "over cap" must not render alike.
+    rerender(
+      <DepositPoolTile
+        pool={{ snapshot: { ...snapshot, caps: { ...snapshot.caps, utilizationBps: 12_000 } } }}
+      />,
+    );
+    const pegged = getByTestId("ops-deposit-pool-cap-meter");
+    expect(pegged.getAttribute("data-over")).toBe("yes");
+    expect(pegged.querySelector("b")).not.toBeNull();
+  });
+
   test("a missing pre-5a endpoint renders UNAVAILABLE, visually distinct from zero", () => {
     const { getByTestId, queryByTestId } = render(
       <DepositPoolTile pool={{ unavailable: "deposit pool unreachable — platform returned HTTP 404" }} />,

--- a/packages/monitor-ui/src/components/ops/DepositPoolTile.tsx
+++ b/packages/monitor-ui/src/components/ops/DepositPoolTile.tsx
@@ -14,7 +14,7 @@ import type {
   DepositPoolFlow,
 } from "../../lib/monitor/product-health.js";
 
-import { formatPoolAmount } from "../../lib/monitor/ops-spec.js";
+import { capMeterView, formatPoolAmount } from "../../lib/monitor/ops-spec.js";
 
 export function DepositPoolTile({ pool }: { pool: DepositPoolBlock | undefined }) {
   if (!pool || "unavailable" in pool) {
@@ -68,6 +68,33 @@ export function DepositPoolTile({ pool }: { pool: DepositPoolBlock | undefined }
         </Fact>
         <Fact label="CAP" testId="ops-deposit-pool-cap">
           {formatBps(snapshot.caps?.utilizationBps)} utilized
+          {/* The one bounded scale on this side of the board: fill = utilisation
+              against the CONFIGURED cap, which is fixed the way a floor is.
+              No cap or no utilisation figure → no bar (never an auto-fit). */}
+          {(() => {
+            const meter = capMeterView(snapshot.caps);
+            return meter ? (
+              <span
+                className="ops-cap-meter"
+                role="meter"
+                aria-valuenow={meter.fillPct}
+                aria-valuemin={0}
+                aria-valuemax={100}
+                aria-label="Deposit pool utilisation against its configured cap"
+                title={meter.title}
+                data-over={meter.over ? "yes" : "no"}
+                data-testid="ops-deposit-pool-cap-meter"
+              >
+                {/* No fill element at exactly zero — the CSS keeps a tiny
+                    fill visible for any real utilisation, and that floor
+                    must never fabricate one where the reading is 0. */}
+                {meter.fillPct > 0 ? <i style={{ width: `${meter.fillPct}%` }} /> : null}
+                {/* Utilisation past the cap: the bar is pegged and marks it,
+                    so "at cap" and "over cap" cannot render alike. */}
+                {meter.over ? <b aria-hidden /> : null}
+              </span>
+            ) : null;
+          })()}
           <small>
             {formatPoolAmount(snapshot.caps?.headroom, "USDC")} headroom
             {snapshot.caps?.totalAssetCap ? ` of ${formatPoolAmount(snapshot.caps.totalAssetCap, "USDC")}` : ""}

--- a/packages/monitor-ui/src/components/ops/FlowPanel.tsx
+++ b/packages/monitor-ui/src/components/ops/FlowPanel.tsx
@@ -27,6 +27,7 @@ import {
   volumeMixNote,
 } from "../../lib/monitor/ops-spec.js";
 import type { ExternalFunnelView, LifecycleView } from "../../lib/monitor/product-health.js";
+import { worstOpsTone, type OpsTone } from "../../lib/monitor/ops-model.js";
 
 export interface FlowPanelProps {
   flow: MoneyPathSnapshot | undefined;
@@ -55,9 +56,18 @@ export function FlowPanel({ flow, externalFunnel, lifecycle, nowMs }: FlowPanelP
   const evidence = payoutView(flow?.payout);
   const provenance = payoutProvenanceLine(flow?.payout);
   const cross = crossCheckLine(flow?.payout, nowMs ?? Date.now());
+  // Edge rail: the worst of the panel's own conclusions. `awaiting` evidence
+  // keeps the rail grey on purpose — an unverified instrument is a fact about
+  // this panel, and a sage edge over it would out-claim the evidence block.
+  const rail = worstOpsTone([funnel.tone, evidence.tone, ...(clock ? [clock.tone] : [])] as OpsTone[]);
 
   return (
-    <section className="ops-flow" aria-label="Flow — money path over 24 hours" data-testid="ops-flow">
+    <section
+      className="ops-flow"
+      aria-label="Flow — money path over 24 hours"
+      data-testid="ops-flow"
+      data-rail={rail}
+    >
       <header className="ops-panel-head">
         <h2 className="ops-panel-title">FLOW — MONEY PATH · 24 H</h2>
         <span className="ops-chip" data-tone={funnel.stuck !== "0" && funnel.stuck !== "—" ? "degraded" : "awaiting"}>

--- a/packages/monitor-ui/src/components/ops/OpsBoard.test.tsx
+++ b/packages/monitor-ui/src/components/ops/OpsBoard.test.tsx
@@ -264,6 +264,16 @@ describe("OpsBoard — pillars and footer", () => {
     expect(container.querySelector(".ops-foot")?.textContent).toContain("none recorded");
   });
 
+  test("an ABSENT incident log is 'not reported', never a clean record", () => {
+    // The footer used to collapse absent and empty into "none recorded" — a
+    // clean-record claim over a log the build never reported.
+    const health = { ...OPS_FIXTURE_NOMINAL, history: undefined };
+    const { container } = render(<OpsBoard health={health} nowMs={fresh(health)} />);
+    const foot = container.querySelector(".ops-foot")?.textContent ?? "";
+    expect(foot).toContain("durable log not reported");
+    expect(foot).not.toContain("none recorded");
+  });
+
   // Demoted from the tallest column on the board to one footer line.
   test("LLM spend is a single footer line, and admits what it excludes", () => {
     const { container } = render(
@@ -350,6 +360,62 @@ describe("OpsBoard — pillars and footer", () => {
       <OpsBoard health={OPS_FIXTURE_NOMINAL} nowMs={fresh(OPS_FIXTURE_NOMINAL)} />,
     );
     expect(getAllByTestId(/^ops-pool-[a-z_]+$/).length).toBe(6);
+  });
+});
+
+describe("OpsBoard — the census as marks", () => {
+  test("one mark per probe, tone carried, under the verdict", () => {
+    const { getByTestId } = render(
+      <OpsBoard health={OPS_FIXTURE_NOMINAL} nowMs={fresh(OPS_FIXTURE_NOMINAL)} />,
+    );
+    const census = getByTestId("ops-census");
+    const cells = census.querySelectorAll("i");
+    expect(cells.length).toBe(OPS_FIXTURE_NOMINAL.probes.length);
+    // The degraded capability probe reaches its cell as a degraded mark.
+    const tones = [...cells].map((c) => c.getAttribute("data-tone"));
+    expect(tones).toContain("degraded");
+    expect(tones.filter((t) => t === "ok").length).toBeGreaterThan(0);
+  });
+
+  test("no probes → no strip: an empty census would read as 'none are red'", () => {
+    const { queryByTestId } = render(
+      <OpsBoard health={{ ...OPS_FIXTURE_NOMINAL, probes: [] }} nowMs={fresh(OPS_FIXTURE_NOMINAL)} />,
+    );
+    expect(queryByTestId("ops-census")).toBeNull();
+  });
+});
+
+describe("OpsBoard — per-check strips and the durable log", () => {
+  test("every probe row carries its own check strip", () => {
+    const { getByTestId } = render(
+      <OpsBoard health={OPS_FIXTURE_NOMINAL} nowMs={fresh(OPS_FIXTURE_NOMINAL)} />,
+    );
+    const strips = getByTestId("ops-pillars").querySelectorAll(".ops-spark");
+    expect(strips.length).toBe(OPS_FIXTURE_NOMINAL.probes.length);
+  });
+
+  test("an empty durable log says so — watched, nothing recorded", () => {
+    // NOMINAL carries `incidents: []`, which is a measurement, not a gap.
+    const { getByTestId } = render(
+      <OpsBoard health={OPS_FIXTURE_NOMINAL} nowMs={fresh(OPS_FIXTURE_NOMINAL)} />,
+    );
+    expect(getByTestId("ops-incidents-empty").textContent).toContain("no episodes");
+  });
+
+  test("an absent log reads 'not reported', never as a clean record", () => {
+    const health = { ...OPS_FIXTURE_NOMINAL, history: undefined };
+    const { getByTestId } = render(<OpsBoard health={health} nowMs={fresh(health)} />);
+    expect(getByTestId("ops-incidents-absent").textContent).toContain("not reported");
+  });
+
+  test("an ongoing episode is named, with its probe and a running duration", () => {
+    const { getByTestId } = render(
+      <OpsBoard health={OPS_FIXTURE_STRESS} nowMs={OPS_FIXTURE_STRESS.at! + 2_000} />,
+    );
+    const row = getByTestId("ops-incident-reward-bank-floor");
+    expect(row.textContent).toContain("signer_liquidity");
+    expect(row.textContent).toContain("ONGOING");
+    expect(row.getAttribute("data-tone")).toBe("red");
   });
 });
 

--- a/packages/monitor-ui/src/components/ops/OpsBoard.tsx
+++ b/packages/monitor-ui/src/components/ops/OpsBoard.tsx
@@ -21,7 +21,7 @@
 import { opsSuggestions } from "../../lib/monitor/ops-suggestions.js";
 import type { MonitorBoard } from "../../lib/monitor/board-cache.js";
 import type { ProductHealth } from "../../lib/monitor/product-health.js";
-import { formatAgo, incidentRows } from "../../lib/monitor/ops-model.js";
+import { formatAgo, incidentRows, probeOpsTone } from "../../lib/monitor/ops-model.js";
 import { economicsLine } from "../../lib/monitor/ops-spec.js";
 import { opsVerdict, staleAfterMs, trustRows } from "../../lib/monitor/ops-spec.js";
 import { FlowPanel } from "./FlowPanel.js";
@@ -105,6 +105,28 @@ export function OpsBoard({
             <p className="ops-verdict-sub" data-tone={verdict.subTone}>
               {verdict.sub}
             </p>
+            {/* The census, as marks: one cell per probe, severity carried by
+                BOTH colour and height (amber and coral are near-identical to
+                deutan vision, so colour alone must never be the split). The
+                words above stay the record; this row is the same fact made
+                legible from across a room. Absent probes draw nothing —
+                an empty strip would read as "no probes are red". */}
+            {health.probes.length > 0 ? (
+              <div
+                className="ops-census"
+                data-testid="ops-census"
+                role="img"
+                aria-label={`probe census: ${verdict.sub}`}
+              >
+                {health.probes.map((p) => (
+                  <i
+                    key={p.name}
+                    data-tone={probeOpsTone(p)}
+                    title={`${p.name} — ${p.status}`}
+                  />
+                ))}
+              </div>
+            ) : null}
           </div>
 
           <div className="ops-trust" data-testid="ops-trust">
@@ -152,7 +174,7 @@ export function OpsBoard({
           <DepositPoolTile pool={health.depositPool} />
         </section>
 
-        <PillarStrip probes={health.probes} history={health.history} />
+        <PillarStrip probes={health.probes} history={health.history} nowMs={nowMs} />
 
         {/* ── NEXT ────────────────────────────────────────────────────────
             The board says WHAT is wrong in eleven places and never once said
@@ -236,6 +258,9 @@ function metaLine(health: ProductHealth): string {
 
 /** Ongoing incidents lead; an empty durable log says so rather than "all clear". */
 function incidentSummary(health: ProductHealth, nowMs: number): string {
+  // Absent is not empty: a build that reports no log at all must not read as a
+  // clean record. The INCIDENTS column makes the same distinction.
+  if (!health.history?.incidents) return "durable log not reported by this build";
   const rows = incidentRows(health.history, nowMs);
   if (rows.length === 0) return "none recorded in this window";
   const ongoing = rows.filter((r) => r.ongoing);

--- a/packages/monitor-ui/src/components/ops/PillarStrip.tsx
+++ b/packages/monitor-ui/src/components/ops/PillarStrip.tsx
@@ -1,26 +1,42 @@
-// The four pillars — the "why is it wrong, specifically" band.
+// The four pillars — the "why is it wrong, specifically" band — plus the
+// durable incident log beside them.
 //
 // Every probe the monitor runs, grouped by the operational domain it belongs
-// to, each with its one-line detail verbatim from the probe. This is the third
-// question the board answers, so it sits below the verdict and the money and
-// gets one compact row rather than the wide sparse table it used to be.
+// to, each with its one-line detail verbatim from the probe AND its last few
+// checks as a strip — the server has always sent the per-check history, and
+// until now the desktop drew none of it. "Flapping for an hour" and "went
+// amber one check ago" are different situations that used to render the same.
 //
 // Awaiting-data probes draw warm grey and are counted separately in the
 // roll-up. They are a telemetry gap, not a degradation — folding them into the
 // amber count is how a board acquires a permanently-lit warning.
+//
+// The INCIDENTS column is the same priority answered in time: which probe
+// broke, when, for how long. It renders the durable log's newest episodes and
+// distinguishes an absent log (older build — says "not reported") from an
+// empty one (watched, nothing recorded) — absent is never a clean record.
 
 import type { ProductHealthProbe, HealthHistory } from "../../lib/monitor/product-health.js";
-import { formatDuration, groupProbesByPillar, probeOpsTone, type OpsTone } from "../../lib/monitor/ops-model.js";
-import { LineSpark } from "./OpsSparks.js";
+import {
+  formatAgo,
+  formatDuration,
+  groupProbesByPillar,
+  probeOpsTone,
+  recentIncidents,
+  trendSpanLabel,
+  worstOpsTone,
+  type OpsTone,
+} from "../../lib/monitor/ops-model.js";
+import { LineSpark, OpsSpark } from "./OpsSparks.js";
 
 export interface PillarStripProps {
   probes: ProductHealthProbe[];
   history: HealthHistory | undefined;
+  /** Injected clock — incident ages and durations must be deterministic to test. */
+  nowMs?: number;
 }
 
-const TONE_RANK: Record<OpsTone, number> = { red: 3, degraded: 2, awaiting: 1, ok: 0 };
-
-export function PillarStrip({ probes, history }: PillarStripProps) {
+export function PillarStrip({ probes, history, nowMs = Date.now() }: PillarStripProps) {
   const groups = groupProbesByPillar(probes);
   if (groups.length === 0) {
     return (
@@ -34,7 +50,7 @@ export function PillarStrip({ probes, history }: PillarStripProps) {
     <section className="ops-pillars" aria-label="Probes by pillar" data-testid="ops-pillars">
       {groups.map((group) => {
         const tones = group.probes.map(probeOpsTone);
-        const worst = tones.reduce<OpsTone>((acc, t) => (TONE_RANK[t] > TONE_RANK[acc] ? t : acc), "ok");
+        const worst = worstOpsTone(tones);
         return (
           <div className="ops-pillar" key={group.pillar} data-testid={`ops-pillar-${group.pillar}`}>
             <div className="ops-pillar-head">
@@ -50,6 +66,10 @@ export function PillarStrip({ probes, history }: PillarStripProps) {
                   <span className="ops-probe-detail" data-tone={probeOpsTone(probe)}>
                     {probe.detail}
                   </span>
+                  {/* The probe's own recent checks, oldest → newest. Severity is
+                      encoded twice — tone AND cell height — because amber vs
+                      coral is exactly the pair colour-blind vision loses. */}
+                  {probe.sparkline?.length ? <OpsSpark series={probe.sparkline} bins={8} /> : null}
                 </div>
               ))}
             </div>
@@ -57,6 +77,7 @@ export function PillarStrip({ probes, history }: PillarStripProps) {
           </div>
         );
       })}
+      <IncidentsColumn history={history} nowMs={nowMs} />
     </section>
   );
 }
@@ -112,29 +133,99 @@ function uptimeText(history: HealthHistory | undefined): string {
 }
 
 /**
- * The one trend that earns space on this board: 24h latency + uptime. Both stay
+ * The one trend that earns space on this board: latency + uptime. Both stay
  * honestly absent until the ring buffer has enough samples — a line drawn
  * through two points is a fabricated trend, so it reads "awaiting history"
  * instead of drawing a flat zero.
+ *
+ * The caption carries the MEASURED span (`trendSpanLabel`), not a hard-coded
+ * "24h": the same buffer that makes the uptime figure state its span makes
+ * this label state its own.
  */
 function AvailabilityTrend({ history }: { history: HealthHistory | undefined }) {
   const series = history?.latencySeriesMs ?? [];
   const samples = series.filter((n): n is number => typeof n === "number");
   const uptimeLabel = uptimeText(history);
+  const spanLabel = trendSpanLabel(history);
 
   if (samples.length < 2) {
     return (
       <p className="ops-pillar-trend" data-tone="awaiting" data-testid="ops-trend-awaiting">
-        ◔ latency 24h — awaiting history · {uptimeLabel}
+        ◔ latency — awaiting history · {uptimeLabel}
       </p>
     );
   }
   return (
     <p className="ops-pillar-trend" data-testid="ops-trend">
-      <LineSpark values={series} tone="ok" width={96} height={20} ariaLabel="API latency, last 24 hours" />
+      <LineSpark values={series} tone="ok" width={96} height={20} ariaLabel={`API latency, ${spanLabel}`} />
       <span>
-        latency 24h · {Math.round(samples[samples.length - 1]!)} ms now · {uptimeLabel}
+        latency {spanLabel} · {Math.round(samples[samples.length - 1]!)} ms now · {uptimeLabel}
       </span>
     </p>
+  );
+}
+
+/**
+ * The durable log, beside the probes it explains.
+ *
+ * The board carried up to 200 incident records and rendered ONE line of them —
+ * a count in the footer. Which probe, when, how long: that is the diagnosis
+ * data an operator scans for after the verdict, and it was fetched, stored and
+ * never drawn. A LIST, deliberately not a timeline: a timeline's empty stretches
+ * would claim "observed and healthy" over hours the monitor may not have been
+ * watching, and no field in the payload backs that claim.
+ */
+function IncidentsColumn({ history, nowMs }: { history: HealthHistory | undefined; nowMs: number }) {
+  const view = recentIncidents(history, nowMs, 3);
+  // Head dot: worst severity among ONGOING episodes only. Ended episodes are
+  // history — a column glowing amber for last week teaches the eye to skip it.
+  const headTone: OpsTone =
+    view == null ? "awaiting" : worstOpsTone(view.rows.filter((r) => r.ongoing).map((r) => r.severity));
+
+  return (
+    <div className="ops-pillar ops-pillar--incidents" data-testid="ops-incidents">
+      <div className="ops-pillar-head">
+        <i className="ops-dot" data-tone={headTone} aria-hidden />
+        <span className="ops-pillar-name">INCIDENTS</span>
+        <span className="ops-pillar-rollup">durable log</span>
+      </div>
+      {view == null ? (
+        <p className="ops-incident-absent" data-testid="ops-incidents-absent">
+          incident log not reported by this build
+        </p>
+      ) : view.rows.length === 0 ? (
+        <p className="ops-incident-absent" data-testid="ops-incidents-empty">
+          no episodes in this window
+        </p>
+      ) : (
+        <>
+          <div className="ops-incident-rows">
+            {view.rows.map((r) => (
+              <div
+                className="ops-incident"
+                key={r.id}
+                data-tone={r.severity}
+                data-ongoing={r.ongoing ? "yes" : "no"}
+                data-testid={`ops-incident-${r.id}`}
+                title={r.note}
+              >
+                <i className="ops-dot ops-dot--sm" data-tone={r.severity} aria-hidden />
+                <span className="ops-incident-probe">{r.probe}</span>
+                <span className="ops-incident-when" data-tone={r.ongoing ? r.severity : "awaiting"}>
+                  {r.ongoing
+                    ? `ONGOING · ${r.durationLabel}`
+                    : `${r.durationLabel} · ended ${formatAgo(r.endedAt ?? r.startedAt, nowMs)}`}
+                </span>
+              </div>
+            ))}
+          </div>
+          {view.more > 0 ? (
+            <p className="ops-incident-more" data-testid="ops-incidents-more">
+              +{view.more} more in the window
+            </p>
+          ) : null}
+        </>
+      )}
+    </div>
   );
 }

--- a/packages/monitor-ui/src/components/ops/SolvencyPanel.tsx
+++ b/packages/monitor-ui/src/components/ops/SolvencyPanel.tsx
@@ -17,7 +17,7 @@ import { OPS_GLOSS } from "../../lib/monitor/ops-gloss.js";
 import type { GasSpendView, PayoutEvidence, SolvencySnapshot } from "../../lib/monitor/product-health.js";
 import { splitPools, type PoolView } from "../../lib/monitor/ops-spec.js";
 import { gasPoolNote, gasUnreadableNote, payoutRunwayNote } from "../../lib/monitor/ops-spec.js";
-import type { OpsTone } from "../../lib/monitor/ops-model.js";
+import { worstOpsTone, type OpsTone } from "../../lib/monitor/ops-model.js";
 
 export interface SolvencyPanelProps {
   solvency: SolvencySnapshot | undefined;
@@ -57,9 +57,17 @@ const POOL_NOTE_KEY: Readonly<Record<string, string>> = {
 export function SolvencyPanel({ solvency, gas, payout }: SolvencyPanelProps) {
   const pools = solvency?.pools ?? [];
   const { floored, unfloored } = splitPools(pools);
+  // The panel's edge rail — the worst tone among its own rows, the same
+  // roll-up rule as a pillar's head dot. Peripheral state, no new claim.
+  const rail = worstOpsTone([...floored, ...unfloored].map((v) => v.tone));
 
   return (
-    <section className="ops-solvency" aria-label="Solvency — pools versus floors" data-testid="ops-solvency">
+    <section
+      className="ops-solvency"
+      aria-label="Solvency — pools versus floors"
+      data-testid="ops-solvency"
+      data-rail={pools.length === 0 ? "awaiting" : rail}
+    >
       <header className="ops-panel-head">
         <h2 className="ops-panel-title">SOLVENCY — POOLS VS FLOORS</h2>
         <span className="ops-panel-note">absolute balances · fixed scales · floor = tick</span>

--- a/packages/monitor-ui/src/lib/monitor/ops-fixtures.ts
+++ b/packages/monitor-ui/src/lib/monitor/ops-fixtures.ts
@@ -350,6 +350,37 @@ export const OPS_FIXTURE_NOMINAL: ProductHealth = {
   // Configured and delivering — the state after the first real narration lands.
   buzz: { status: "ok", detail: "delivered 4m ago" },
   solvency: { pools: MAINNET_POOLS },
+  // The live pool as of 2026-08-17: funded by the operator, no outside
+  // depositors yet, 2% of the cap used. Gives the preview the populated tile
+  // (and its cap meter) instead of a permanent UNAVAILABLE.
+  depositPool: {
+    snapshot: {
+      schemaVersion: 1,
+      available: true,
+      pricingModel: "principal-cost-basis",
+      totalAssets: { raw: "20446982", decimals: 6 },
+      totalShares: { raw: "20501328", decimals: 6 },
+      sharePrice: { raw: "997349", decimals: 6 },
+      buffer: { raw: "15446982", decimals: 6 },
+      deployed: { raw: "5000000", decimals: 6 },
+      reconciled: true,
+      caps: {
+        totalAssetCap: { raw: "1000000000", decimals: 6 },
+        headroom: { raw: "979553018", decimals: 6 },
+        utilizationBps: 204,
+      },
+      yieldStatus: "earning",
+      yieldStatusText:
+        "Pool capital is deployed to the configured venue; yield is recognized only when returned to pool accounting.",
+      flows: {
+        status: "ok",
+        depositorCount: 0,
+        pendingUnfulfilledRedemptionAssets: { raw: "0", decimals: 6 },
+        recent: [],
+        window: { fromBlock: 19_573_403, toBlock: 19_575_402, maxBlocks: 2_000, recentLimit: 8 },
+      },
+    },
+  },
   flow: {
     claimed24h: 9,
     submitted24h: 9,

--- a/packages/monitor-ui/src/lib/monitor/ops-model.test.ts
+++ b/packages/monitor-ui/src/lib/monitor/ops-model.test.ts
@@ -8,6 +8,9 @@ import {
   hasFlowData,
   solvencyRows,
   incidentRows,
+  recentIncidents,
+  trendSpanLabel,
+  worstOpsTone,
   formatAmount,
   formatDuration,
 } from "./ops-model.js";
@@ -160,6 +163,90 @@ describe("incidentRows", () => {
 
   test("undefined history yields no rows", () => {
     expect(incidentRows(undefined, FIXTURE_NOW)).toEqual([]);
+  });
+});
+
+describe("worstOpsTone — one severity order for every roll-up", () => {
+  test("red outranks everything", () => {
+    expect(worstOpsTone(["ok", "awaiting", "degraded", "red"])).toBe("red");
+  });
+  test("awaiting outranks ok — a telemetry gap is not a pass", () => {
+    expect(worstOpsTone(["ok", "awaiting", "ok"])).toBe("awaiting");
+  });
+  test("an empty list is ok — nothing observed wrong", () => {
+    expect(worstOpsTone([])).toBe("ok");
+  });
+});
+
+describe("recentIncidents — absent is not empty", () => {
+  test("no incident log at all returns null, never an empty view", () => {
+    // An older build that reports no log must render "not reported" — a clean
+    // record would be a claim the payload never made.
+    expect(recentIncidents(undefined, FIXTURE_NOW)).toBeNull();
+    expect(recentIncidents({}, FIXTURE_NOW)).toBeNull();
+  });
+
+  test("an empty log is a view with no rows — watched, nothing recorded", () => {
+    expect(recentIncidents({ incidents: [] }, FIXTURE_NOW)).toEqual({ rows: [], more: 0 });
+  });
+
+  test("caps the rows and counts the remainder instead of hiding it", () => {
+    const view = recentIncidents(
+      {
+        incidents: Array.from({ length: 5 }, (_, i) => ({
+          id: `inc-${i}`,
+          probe: "capabilities",
+          severity: "degraded" as const,
+          startedAt: FIXTURE_NOW - (i + 1) * 3_600_000,
+          endedAt: FIXTURE_NOW - (i + 1) * 3_600_000 + 600_000,
+        })),
+      },
+      FIXTURE_NOW,
+      3,
+    )!;
+    expect(view.rows).toHaveLength(3);
+    expect(view.more).toBe(2);
+    // Newest first — the top row is the most recent episode.
+    expect(view.rows[0]!.id).toBe("inc-0");
+  });
+
+  test("an ongoing episode keeps running against the injected clock", () => {
+    const view = recentIncidents(
+      {
+        incidents: [
+          { id: "live", probe: "money_path", severity: "red", startedAt: FIXTURE_NOW - 14 * 60_000, endedAt: null },
+        ],
+      },
+      FIXTURE_NOW,
+    )!;
+    expect(view.rows[0]!.ongoing).toBe(true);
+    expect(view.rows[0]!.durationLabel).toBe("14m");
+  });
+});
+
+describe("trendSpanLabel — the caption states what was measured", () => {
+  const HOUR = 3_600_000;
+  test("a covered 24h window is labelled 24h", () => {
+    expect(trendSpanLabel({ uptimeSpanMs: 24 * HOUR, uptimeWindowMs: 24 * HOUR })).toBe("24h");
+  });
+
+  test("check jitter within 5% still counts as the window", () => {
+    expect(trendSpanLabel({ uptimeSpanMs: 23.2 * HOUR, uptimeWindowMs: 24 * HOUR })).toBe("24h");
+  });
+
+  test("a short buffer names its measured span, not the window", () => {
+    // The post-deploy case: the in-memory ring buffer spans minutes while the
+    // caption used to claim a day.
+    expect(trendSpanLabel({ uptimeSpanMs: 34 * 60_000, uptimeWindowMs: 24 * HOUR })).toBe("over 34m");
+  });
+
+  test("a known span with no reported window is still stated as a span", () => {
+    expect(trendSpanLabel({ uptimeSpanMs: 90 * 60_000 })).toBe("over 1h 30m");
+  });
+
+  test("nothing known says so instead of implying coverage", () => {
+    expect(trendSpanLabel(undefined)).toBe("span unknown");
+    expect(trendSpanLabel({ uptimeSpanMs: 0 })).toBe("span unknown");
   });
 });
 

--- a/packages/monitor-ui/src/lib/monitor/ops-model.ts
+++ b/packages/monitor-ui/src/lib/monitor/ops-model.ts
@@ -138,6 +138,61 @@ export function incidentRows(history: HealthHistory | undefined, nowMs: number):
     });
 }
 
+/** Severity order for roll-ups. Shared so every "worst of" on the board ranks
+ *  the same way — a pillar head and a panel rail must never disagree. */
+export const OPS_TONE_RANK: Record<OpsTone, number> = { red: 3, degraded: 2, awaiting: 1, ok: 0 };
+
+/** The worst tone in a list; an empty list is `ok` (nothing observed wrong). */
+export function worstOpsTone(tones: readonly OpsTone[]): OpsTone {
+  return tones.reduce<OpsTone>((acc, t) => (OPS_TONE_RANK[t] > OPS_TONE_RANK[acc] ? t : acc), "ok");
+}
+
+export interface RecentIncidentsView {
+  /** Newest first, capped for a narrow column. */
+  rows: IncidentRow[];
+  /** Episodes beyond the cap, still inside the durable window. Never hidden silently. */
+  more: number;
+}
+
+/**
+ * The durable log's newest episodes, sized for the INCIDENTS column.
+ *
+ * `null` means the build reports no incident log AT ALL — absent is not empty,
+ * and the column must say "not reported" rather than implying a clean record.
+ * An empty array is the opposite fact: the log exists and holds nothing.
+ */
+export function recentIncidents(
+  history: HealthHistory | undefined,
+  nowMs: number,
+  max = 3,
+): RecentIncidentsView | null {
+  if (!history?.incidents) return null;
+  const rows = incidentRows(history, nowMs);
+  return { rows: rows.slice(0, max), more: Math.max(0, rows.length - max) };
+}
+
+/**
+ * The span qualifier for a history sparkline ("24h" · "over 34m" · "span unknown").
+ *
+ * The latency trend was captioned "latency 24h" unconditionally, while the ring
+ * buffer behind it lives in memory: right after a deploy those samples span
+ * minutes, and the caption claimed a day. Uptime already states its measured
+ * span (same buffer, same lesson) — this applies the identical ≥95%-of-window
+ * rule to the series caption, so both labels degrade together.
+ */
+export function trendSpanLabel(history: HealthHistory | undefined): string {
+  const span = history?.uptimeSpanMs;
+  if (typeof span !== "number" || span <= 0) return "span unknown";
+  const window = history?.uptimeWindowMs;
+  if (typeof window === "number" && window > 0 && span >= window * 0.95) {
+    // Covered: label the window itself. Whole hours read as hours ("24h"),
+    // anything else falls back to the coarse duration label.
+    const hours = window / 3_600_000;
+    return hours < 48 && Number.isInteger(hours) ? `${hours}h` : formatDuration(window);
+  }
+  return `over ${formatDuration(span)}`;
+}
+
 /** Compact money/amount label: 4.99k, 1.20M, 2.00. */
 export function formatAmount(n: number): string {
   const abs = Math.abs(n);

--- a/packages/monitor-ui/src/lib/monitor/ops-spec.test.ts
+++ b/packages/monitor-ui/src/lib/monitor/ops-spec.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, test } from "vitest";
 import {
   DATA_STALE_FALLBACK_MS,
   EVIDENCE_KEY,
+  capMeterView,
   crossCheckLine,
   payoutProvenanceLine,
   METER_RUNGS,
@@ -865,5 +866,35 @@ describe("trustRows", () => {
       nowMs: health.at! + 3 * 60_000,
     });
     expect(rows.find((r) => r.key === "DATA AGE")!.tone).toBe("ok");
+  });
+});
+
+describe("capMeterView — a bar only against a real fixed scale", () => {
+  const CAP = { raw: "1000000000", decimals: 6 };
+
+  test("cap + utilisation draw a bounded fill", () => {
+    const view = capMeterView({ totalAssetCap: CAP, utilizationBps: 204 })!;
+    expect(view.fillPct).toBeCloseTo(2.04);
+    expect(view.title).toContain("2.04%");
+    expect(view.title).toContain("1,000 USDC");
+  });
+
+  test("no cap → no bar, however precise the utilisation", () => {
+    // A meter against a guessed scale is the auto-fitted two-thirds-full
+    // failure the solvency panel already removed.
+    expect(capMeterView({ utilizationBps: 204 })).toBeNull();
+  });
+
+  test("no utilisation reading → no bar", () => {
+    expect(capMeterView({ totalAssetCap: CAP })).toBeNull();
+    expect(capMeterView(undefined)).toBeNull();
+  });
+
+  test("fill clamps to the scale — a breached cap pegs at 100 AND says over", () => {
+    const view = capMeterView({ totalAssetCap: CAP, utilizationBps: 12_000 })!;
+    expect(view.fillPct).toBe(100);
+    // "At cap" and "over cap" are different facts; the peg alone conflates them.
+    expect(view.over).toBe(true);
+    expect(capMeterView({ totalAssetCap: CAP, utilizationBps: 10_000 })!.over).toBe(false);
   });
 });

--- a/packages/monitor-ui/src/lib/monitor/ops-spec.ts
+++ b/packages/monitor-ui/src/lib/monitor/ops-spec.ts
@@ -1159,6 +1159,30 @@ export function formatSeconds(seconds: number | null): string {
  * `decimals` absent ⇒ the raw base-unit string, labelled `raw`. Scaling by a
  * guessed exponent would silently move a decimal point on a money value.
  */
+/**
+ * The deposit pool's cap meter — the one bounded scale on the BANK side.
+ *
+ * Same rule as the solvency meters: a bar is only honest against a scale that
+ * does not move with the value. The configured cap IS such a scale, so
+ * utilisation can be drawn against it. Either half missing → no bar at all —
+ * a meter against a guessed cap would be the auto-fitted two-thirds-full
+ * failure this board removed from the pools.
+ */
+export function capMeterView(
+  caps: { totalAssetCap?: { raw: string; decimals?: number }; utilizationBps?: number } | undefined,
+): { fillPct: number; over: boolean; title: string } | null {
+  if (!caps || typeof caps.utilizationBps !== "number" || !caps.totalAssetCap) return null;
+  const pct = caps.utilizationBps / 100;
+  return {
+    fillPct: Math.max(0, Math.min(100, pct)),
+    // Past the cap (it can be lowered under the current assets) the bar pegs —
+    // and says so, exactly like a pool meter past its top rung. A pegged bar
+    // that looks merely full conflates "at cap" with "over cap".
+    over: pct > 100,
+    title: `${pct.toFixed(2)}% of the ${formatPoolAmount(caps.totalAssetCap, "USDC")} cap — scale is the cap, fixed`,
+  };
+}
+
 export function formatPoolAmount(
   amount: { raw: string; decimals?: number } | undefined,
   unit: string,

--- a/packages/monitor-ui/src/styles/hermes4-ops.css
+++ b/packages/monitor-ui/src/styles/hermes4-ops.css
@@ -106,6 +106,31 @@ body,
 .ops-board [data-tone="paused"],
 .ops-board [data-tone="neutral"]  { --tone: var(--h4-muted); }
 
+/* ---- panel edge rails ------------------------------------------
+   Each money panel wears its own worst-of-contents tone on its left
+   edge — the roll-up a pillar's head dot already does, made legible
+   from across the room. A SEPARATE attribute (data-rail) so a rail
+   never recolours the text inside its panel the way --tone would.
+
+   Healthy is the quiet soft-line sage: an edge that shouts green all
+   day is decoration, and decoration teaches the eye to skip the edge
+   on the day it turns coral. Rails are box-shadows, not borders, so
+   they move no layout and stay real pixels at every viewport. */
+.ops-board [data-rail="ok"]       { --rail: var(--h4-ok-line); }
+.ops-board [data-rail="degraded"] { --rail: var(--h4-warn); }
+.ops-board [data-rail="red"]      { --rail: var(--h4-act); }
+.ops-board [data-rail="awaiting"] { --rail: var(--h4-tel-soft); }
+.ops-solvency,
+.ops-flow { box-shadow: inset 3px 0 0 var(--rail, transparent); }
+/* The BANK tiles already carry an honest section tone — the rail keys off it. */
+:is(.ops-bank, .ops-deposit-pool)[data-tone="ok"]       { --rail: var(--h4-ok-line); }
+:is(.ops-bank, .ops-deposit-pool)[data-tone="degraded"] { --rail: var(--h4-warn); }
+:is(.ops-bank, .ops-deposit-pool)[data-tone="red"]      { --rail: var(--h4-act); }
+:is(.ops-bank, .ops-deposit-pool)[data-tone="awaiting"],
+:is(.ops-bank, .ops-deposit-pool)[data-tone="paused"]   { --rail: var(--h4-tel-soft); }
+.ops-bank,
+.ops-deposit-pool { box-shadow: inset 3px 0 0 var(--rail, transparent); }
+
 /* ---- meta line ------------------------------------------------ */
 .ops-meta {
   display: flex;
@@ -206,6 +231,34 @@ body,
   font-size: calc(13 * var(--ops-u));
   line-height: 1.45;
   color: var(--tone, var(--h4-muted));
+}
+
+/* ---- the census, as marks --------------------------------------
+   One cell per probe under the verdict — the same "10 ok / 0 red"
+   the subline says in words, readable at wall distance. Severity is
+   encoded TWICE, tone and height, because amber vs coral is exactly
+   the pair deutan vision loses; a hollow cell is a probe with no
+   reading (never a small green). Baseline-anchored so ok cells sit
+   low and a red one towers. */
+.ops-census {
+  display: flex;
+  align-items: flex-end;
+  gap: calc(4 * var(--ops-u));
+  height: calc(15 * var(--ops-u));
+  margin-top: calc(9 * var(--ops-u));
+}
+.ops-census i {
+  width: calc(19 * var(--ops-u));
+  height: 42%;
+  background: var(--tone, var(--h4-tel));
+}
+.ops-census i[data-tone="degraded"] { height: 72%; }
+.ops-census i[data-tone="red"]      { height: 100%; }
+.ops-census i[data-tone="awaiting"] {
+  height: 42%;
+  background: transparent;
+  border: 1px solid var(--h4-tel);
+  box-sizing: border-box;
 }
 
 .ops-trust {
@@ -612,6 +665,20 @@ body,
   white-space: nowrap;
   color: var(--tone, var(--h4-muted));
 }
+/* "Gaps between stages are the signal" — the panel says so, then draws the
+   gaps as the smallest thing on it. When a gap chip carries a real tone the
+   connector it annotates takes the same colour and the chip firms up, so a
+   backlog is visible at the distance the stage numerals are. A quiet gap
+   stays quiet: the emphasis exists only when the signal does. */
+.ops-funnel-gap:has(> .ops-funnel-gap-label[data-tone="degraded"]) .ops-funnel-arrow { color: var(--h4-warn); }
+.ops-funnel-gap:has(> .ops-funnel-gap-label[data-tone="degraded"]) .ops-funnel-arrow i { background: var(--h4-warn-line); }
+.ops-funnel-gap:has(> .ops-funnel-gap-label[data-tone="red"]) .ops-funnel-arrow { color: var(--h4-act); }
+.ops-funnel-gap:has(> .ops-funnel-gap-label[data-tone="red"]) .ops-funnel-arrow i { background: var(--h4-act-line); }
+.ops-funnel-gap-label[data-tone="degraded"],
+.ops-funnel-gap-label[data-tone="red"] {
+  border-color: var(--tone);
+  font-weight: 600;
+}
 
 /* ---- the two lines under the panel head -------------------------
    Shipped in #686/#687 with no rules of their own, so they inherited
@@ -843,9 +910,12 @@ body,
 }
 
 /* ---- pillars ---------------------------------------------------- */
+/* Four probe domains plus the durable incident log — the "why" and the
+   "when" of the same question, one band. The log column is narrower:
+   it holds three compact episodes, not a fifth probe family. */
 .ops-pillars {
   display: grid;
-  grid-template-columns: repeat(4, 1fr);
+  grid-template-columns: repeat(4, minmax(0, 1fr)) minmax(0, 0.78fr);
   padding: calc(10 * var(--ops-u)) calc(16 * var(--ops-u));
   border: 1px solid var(--ops-rule);
 }
@@ -901,6 +971,81 @@ body,
 .ops-probe-detail[data-tone="red"]      { color: var(--h4-act); }
 .ops-probe-detail[data-tone="degraded"] { color: var(--h4-warn); }
 .ops-probe-detail[data-tone="awaiting"] { color: var(--h4-tel); }
+
+/* ---- per-check status strips (OpsSpark) -------------------------
+   Each probe's last checks, oldest → newest, riding the row's right
+   edge. Severity is tone AND height — the same double encoding as
+   the census, for the same deutan reason. A pad cell (fewer checks
+   than bins) is hollow: an unmade check must never draw as a pass. */
+.ops-spark {
+  display: inline-flex;
+  align-items: flex-end;
+  gap: calc(2 * var(--ops-u));
+  height: calc(11 * var(--ops-u));
+  flex: none;
+  margin-left: auto;
+  align-self: center;
+  padding-left: calc(8 * var(--ops-u));
+}
+.ops-spark-cell {
+  width: calc(5 * var(--ops-u));
+  height: 42%;
+  background: var(--h4-ok);
+}
+.ops-spark-cell--degraded { height: 72%; background: var(--h4-warn); }
+.ops-spark-cell--red      { height: 100%; background: var(--h4-act); }
+.ops-spark-cell--empty {
+  height: 100%;
+  background: transparent;
+  border: 1px solid var(--h4-line-2);
+  box-sizing: border-box;
+}
+
+/* ---- the durable incident log ----------------------------------
+   A LIST, deliberately not a timeline: a timeline's empty stretches
+   would claim "watched and healthy" over hours the monitor may not
+   have been running, and nothing in the payload backs that. Rows are
+   facts with their own clocks — probe, severity, duration, ended. */
+.ops-incident-rows {
+  display: grid;
+  gap: calc(7 * var(--ops-u));
+  margin-top: calc(9 * var(--ops-u));
+}
+.ops-incident {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  column-gap: calc(8 * var(--ops-u));
+  row-gap: calc(1 * var(--ops-u));
+  align-items: baseline;
+}
+.ops-incident .ops-dot { position: relative; top: calc(-1 * var(--ops-u)); }
+.ops-incident-probe {
+  font-family: var(--h4-font-mono);
+  font-size: calc(11 * var(--ops-u));
+  color: var(--h4-ink);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.ops-incident-when {
+  grid-column: 2;
+  font-family: var(--h4-font-mono);
+  font-size: calc(9.5 * var(--ops-u));
+  color: var(--tone, var(--h4-muted));
+}
+.ops-incident-absent {
+  margin: calc(9 * var(--ops-u)) 0 0;
+  font-family: var(--h4-font-mono);
+  font-size: calc(10 * var(--ops-u));
+  line-height: 1.45;
+  color: var(--h4-tel);
+}
+.ops-incident-more {
+  margin: calc(7 * var(--ops-u)) 0 0;
+  font-family: var(--h4-font-mono);
+  font-size: calc(9 * var(--ops-u));
+  color: var(--h4-muted);
+}
 .ops-pillar-trend {
   display: flex;
   align-items: center;
@@ -1159,10 +1304,14 @@ body,
 .ops-arrivals-evidence {
   grid-column: 1 / -1;
 }
+/* The OUTSIDERS edge was a permanent 3px sage rail — a health colour on a
+   panel that reports demand, lit regardless of what the panel said. Green
+   that cannot go out is decoration wearing a status colour; the edge is now
+   neutral and tone stays with the readings themselves. */
 .ops-arrivals-verdict {
   padding: calc(9 * var(--ops-u)) calc(12 * var(--ops-u));
   border: 1px solid var(--ops-rule);
-  border-left: 3px solid var(--h4-ok);
+  border-left: 3px solid var(--h4-line-strong);
   background: var(--h4-paper-sunken);
 }
 .ops-arrivals-block-head {
@@ -1178,9 +1327,9 @@ body,
 .ops-arrivals-door h3 {
   margin: 0;
   font-family: var(--h4-font-display);
-  font-size: calc(14 * var(--ops-u));
-  font-weight: 650;
-  letter-spacing: 0.08em;
+  font-size: calc(13.5 * var(--ops-u));
+  font-weight: 600;
+  letter-spacing: 0.09em;
   color: var(--h4-ink);
 }
 .ops-arrivals-block-head span {
@@ -1327,6 +1476,16 @@ body,
   justify-content: flex-end;
   color: var(--h4-ink-2);
 }
+/* Inside the door tables every cell shares the table's own window, already
+   stated once beside "observed since". The per-cell badge stays (it is the
+   claim, and tests pin it) but drops to a whisper so forty repetitions of
+   ALL-TIME stop competing with the counts they qualify. */
+.ops-arrivals-table-row .ops-window-badge {
+  padding-inline: 0;
+  border-color: transparent;
+  background: none;
+  opacity: 0.55;
+}
 .ops-arrivals-cutover {
   padding-top: calc(5 * var(--ops-u));
   border-top: 1px solid var(--ops-hair);
@@ -1383,12 +1542,16 @@ body,
   align-items: baseline;
   gap: calc(12 * var(--ops-u));
 }
+/* One sub-head scale across the board: the BANK tiles and the ARRIVALS
+   blocks are the same rank of heading and used to be three slightly
+   different sizes — enough to read as three different designs, not
+   enough to mean anything. */
 .ops-bank-title {
   margin: 0;
   font-family: var(--h4-font-display);
   font-weight: 600;
-  font-size: calc(12.5 * var(--ops-u));
-  letter-spacing: 0.1em;
+  font-size: calc(13.5 * var(--ops-u));
+  letter-spacing: 0.09em;
   color: var(--h4-ink);
 }
 /* Hoisted so the one state that costs money while ignored is legible
@@ -1471,9 +1634,9 @@ body,
 .ops-deposit-pool-head h3 {
   margin: 0;
   font-family: var(--h4-font-display);
-  font-size: calc(12.5 * var(--ops-u));
+  font-size: calc(13.5 * var(--ops-u));
   font-weight: 600;
-  letter-spacing: 0.1em;
+  letter-spacing: 0.09em;
   color: var(--h4-ink);
 }
 .ops-deposit-pool-head > span,
@@ -1525,6 +1688,32 @@ body,
   font-size: calc(9.5 * var(--ops-u));
   color: var(--h4-tel);
 }
+/* The pool's one bounded meter — the same grammar as the solvency bars:
+   a fixed scale (the configured cap) and a fill that drains or grows
+   against it. Rendered only when both halves are real; a near-empty bar
+   over a 2% utilisation is the truth, not a rendering problem. */
+.ops-cap-meter {
+  display: block;
+  position: relative;
+  height: calc(7 * var(--ops-u));
+  margin-top: calc(4 * var(--ops-u));
+  border: 1px solid var(--ops-hair);
+  background: var(--h4-paper-sunken);
+}
+.ops-cap-meter i {
+  position: absolute;
+  inset: 0 auto 0 0;
+  min-width: 2px;
+  background: var(--h4-ok);
+}
+/* Past the cap the bar pegs and says so — the same warm end-cap the pool
+   meters use past their top rung. "At cap" and "over cap" must not look alike. */
+.ops-cap-meter b {
+  position: absolute;
+  inset: 0 0 0 auto;
+  width: calc(5 * var(--ops-u));
+  background: var(--h4-warn);
+}
 .ops-deposit-pool-flows {
   padding-top: calc(7 * var(--ops-u));
   border-top: 1px solid var(--ops-hair);
@@ -1561,10 +1750,11 @@ body,
   box-sizing: border-box;
   padding: calc(7 * var(--ops-u)) calc(16 * var(--ops-u));
   border-top: 1px dashed var(--ops-rule);
+  background: var(--h4-paper-veil);
   font-family: var(--h4-font-mono);
-  font-size: calc(12 * var(--ops-u));
+  font-size: calc(12.5 * var(--ops-u));
   letter-spacing: 0.02em;
-  color: var(--tone, var(--h4-ink-2));
+  color: var(--tone, var(--h4-ink));
 }
 
 /* ---- footer ------------------------------------------------------
@@ -1644,6 +1834,15 @@ body,
   .ops-arrivals-unreachable { grid-column: auto; }
   .ops-pillars { grid-template-columns: repeat(2, 1fr); }
   .ops-pillar:nth-child(3) { border-left: 0; }
+  /* Fifth column: on the two-column layout the incident log takes a full row
+     under the pillars rather than squeezing one column thin. */
+  .ops-pillar--incidents {
+    grid-column: 1 / -1;
+    margin-top: calc(8 * var(--ops-u));
+    padding-top: calc(8 * var(--ops-u));
+    border-left: 0;
+    border-top: 1px dashed var(--ops-hair);
+  }
   .ops-foot { flex-wrap: wrap; }
 }
 


### PR DESCRIPTION
## What

A visual overhaul of the ops board that renders data the payload already carries but the desktop never drew, under the board's existing truth rules. No section is reordered, no verdict logic changes, no new derivation of money — every addition is an honest encoding of an existing field.

**New encodings**
- **Census marks** under the verdict — one cell per probe; severity is tone **and** height (amber↔coral is ΔE 4.0 to deutan vision — color alone must never carry that split); no-reading probes are hollow; no probes → no strip.
- **Per-check strips** on every probe row — `OpsSpark` existed, was tested, and was rendered by nothing. Pad cells are hollow: an unmade check never draws as a pass.
- **INCIDENTS column** beside the pillars — the durable log carried up to 200 episodes and rendered as one footer count. Now a list (deliberately not a timeline: empty stretches would claim observation nobody made) with probe, severity, duration, ONGOING/ended, `+N more`. Absent log reads *"not reported by this build"*; empty log reads *"no episodes"* — and the footer now makes the same absent≠empty distinction instead of calling both "none recorded".
- **Deposit-pool cap meter** — fill against the *configured* cap (a fixed scale, same rule as floors). No cap or no reading → no bar. Past the cap the pegged bar carries an over-marker so at-cap ≠ over-cap.
- **Panel tone rails** — each money panel wears its worst-of-contents tone on its edge (the same roll-up a pillar head dot already does). The arrivals panel's permanent sage edge — green that could not go out — is now neutral.
- **Span-honest trend caption** — "latency 24h" was hard-coded over an in-memory ring buffer that spans minutes after a deploy; the caption now states the measured span (same ≥95%-of-window rule as the uptime label).

**Polish**
- Funnel gap connectors take the gap's tone only when it is nonzero ("gaps between stages are the signal" — now visible at stage-numeral distance).
- One sub-head scale across BANK / ARRIVALS; DOORS window badges quieted (claim kept — tests still pin them).
- NOMINAL fixture gains the live deposit-pool snapshot (dated) so the preview exercises the populated tile.

## Contracts held

- All sizes in `--ops-u`; no border in the scaled unit; floor tick stays 2px; `.ops-money` keeps `flex: 1 0 auto` (ops-scaling + ops-overflow suites).
- All `MONEY_LINE_RENDERERS` still wired; all panels mounted; phone board untouched.
- 488 tests green (33 files), `tsc -b` clean.

## Truth-boundary review

Run per `truth-boundary-review`; two conflations found and fixed in this diff: cap meter at-cap vs over-cap (over-marker), footer absent-log vs empty-log ("durable log not reported by this build"). Failure paths walked: no probes, missing sparklines, absent vs empty history, partial caps, zero utilization, stale/dim inheritance, UNVERIFIED vs SHORTFALL distinctness.

Verified in the ops-preview harness (Chrome) across **NOMINAL / STRESS / UNVERIFIED / LIVE**: hatched unread hours, BELOW-FLOOR coral meter, ONGOING incident row, hollow awaiting census cells all render as designed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
