### PR TITLE
feat(board): arrivals in the operator-kit grammar

### DIFF
--- a/packages/monitor-ui/src/components/ops/ArrivalsPanel.test.tsx
+++ b/packages/monitor-ui/src/components/ops/ArrivalsPanel.test.tsx
@@ -107,7 +107,10 @@ describe("ArrivalsPanel — verdict first", () => {
     const { getByTestId } = render(<ArrivalsPanel arrivals={snapshot()} />);
     const furthest = getByTestId("ops-arrivals-furthest-ever");
 
-    expect(furthest.textContent).toContain("SETTLED · 42 payouts in 12h · 2026-08-11 (HTTP)");
+    // KPI form: the record is the display value, the provenance is the mono
+    // sub-line — every fact from the feed still on the card, plus its window.
+    expect(furthest.textContent).toContain("SETTLED");
+    expect(furthest.textContent).toContain("42 payouts in 12h · 2026-08-11 (HTTP)");
     expect(furthest.textContent).toContain("ALL-TIME");
     expect(getByTestId("ops-arrivals-last-activity").textContent).toContain("5d ago");
   });
@@ -166,49 +169,30 @@ describe("ArrivalsPanel — verdict first", () => {
     expect(getByTestId("ops-arrivals-http-cutover").textContent).toBe(CUTOVER_NOTE);
   });
 
-  test("the wallet-journey ladders draw only the wallet-unit rows, per door", () => {
+  test("the wallet journey draws only the wallet-unit rows, per door", () => {
     const { getByTestId, queryByTestId } = render(<ArrivalsPanel arrivals={snapshot()} />);
 
-    // The HTTP door's wallet rows become bars with their counts…
-    const identified = getByTestId("ops-arrivals-ladder-http-identified");
-    expect(identified.textContent).toContain("identified");
+    // The HTTP door's wallet rows become cells with a fill and their count…
+    const identified = getByTestId("ops-arrivals-journey-http-identified");
     expect(identified.textContent).toContain("3");
-    expect(identified.querySelector(".ops-ladder-track i")).not.toBeNull();
-    // …the 1730-call evaluated counter must NOT have become a ladder row.
-    expect(queryByTestId("ops-arrivals-ladder-http-evaluated")).toBeNull();
-    expect(queryByTestId("ops-arrivals-ladder-http-reached")).toBeNull();
+    expect(identified.querySelector(".ops-journey-fill i")).not.toBeNull();
+    // …the 1730-call evaluated counter must NOT have become a journey row.
+    expect(queryByTestId("ops-arrivals-journey-evaluated")).toBeNull();
+    expect(queryByTestId("ops-arrivals-journey-reached")).toBeNull();
 
-    // A zero-wallet stage keeps its row and its 0, but draws no fill.
-    const mcpIdentified = getByTestId("ops-arrivals-ladder-mcp-identified");
+    // A zero-wallet stage keeps its cell and its 0, but draws no fill.
+    const mcpIdentified = getByTestId("ops-arrivals-journey-mcp-identified");
     expect(mcpIdentified.textContent).toContain("0");
-    expect(mcpIdentified.querySelector(".ops-ladder-track i")).toBeNull();
+    expect(mcpIdentified.querySelector(".ops-journey-fill i")).toBeNull();
   });
 
-  test("the recency strip marks one fixed band from the snapshot clock", () => {
-    const { getByTestId } = render(<ArrivalsPanel arrivals={snapshot()} />);
-    // HISTORICAL_AT is 5 days before GENERATED_AT → the <7d band.
-    const strip = getByTestId("ops-arrivals-recency");
-    expect(strip.getAttribute("data-band")).toBe("7d");
-    expect(strip.querySelectorAll('[data-active="yes"]').length).toBe(1);
-  });
-
-  test("no outsider activity ever → no recency strip at all", () => {
+  test("no outsider activity ever stays a named absence on the KPI card", () => {
     const none = snapshot();
     if (none.operatorView && !("unavailable" in none.operatorView)) {
       none.operatorView.outsiders.lastActivity = null;
     }
-    const { queryByTestId, getByTestId } = render(<ArrivalsPanel arrivals={none} />);
-    expect(queryByTestId("ops-arrivals-recency")).toBeNull();
+    const { getByTestId } = render(<ArrivalsPanel arrivals={none} />);
     expect(getByTestId("ops-arrivals-last-activity").textContent).toContain("NO IDENTIFIED OUTSIDER ACTIVITY YET");
-  });
-
-  test("a zero week draws no bars — the words carry the zero", () => {
-    const quiet = snapshot();
-    if (quiet.operatorView && !("unavailable" in quiet.operatorView)) {
-      quiet.operatorView.outsiders.week = { window: "7d", identified: 0, worked: 0 };
-    }
-    const { queryByTestId } = render(<ArrivalsPanel arrivals={quiet} />);
-    expect(queryByTestId("ops-arrivals-weekpair")).toBeNull();
   });
 
   test("an older producer is a named missing verdict, never a reconstructed zero", () => {

--- a/packages/monitor-ui/src/components/ops/ArrivalsPanel.test.tsx
+++ b/packages/monitor-ui/src/components/ops/ArrivalsPanel.test.tsx
@@ -166,6 +166,51 @@ describe("ArrivalsPanel — verdict first", () => {
     expect(getByTestId("ops-arrivals-http-cutover").textContent).toBe(CUTOVER_NOTE);
   });
 
+  test("the wallet-journey ladders draw only the wallet-unit rows, per door", () => {
+    const { getByTestId, queryByTestId } = render(<ArrivalsPanel arrivals={snapshot()} />);
+
+    // The HTTP door's wallet rows become bars with their counts…
+    const identified = getByTestId("ops-arrivals-ladder-http-identified");
+    expect(identified.textContent).toContain("identified");
+    expect(identified.textContent).toContain("3");
+    expect(identified.querySelector(".ops-ladder-track i")).not.toBeNull();
+    // …the 1730-call evaluated counter must NOT have become a ladder row.
+    expect(queryByTestId("ops-arrivals-ladder-http-evaluated")).toBeNull();
+    expect(queryByTestId("ops-arrivals-ladder-http-reached")).toBeNull();
+
+    // A zero-wallet stage keeps its row and its 0, but draws no fill.
+    const mcpIdentified = getByTestId("ops-arrivals-ladder-mcp-identified");
+    expect(mcpIdentified.textContent).toContain("0");
+    expect(mcpIdentified.querySelector(".ops-ladder-track i")).toBeNull();
+  });
+
+  test("the recency strip marks one fixed band from the snapshot clock", () => {
+    const { getByTestId } = render(<ArrivalsPanel arrivals={snapshot()} />);
+    // HISTORICAL_AT is 5 days before GENERATED_AT → the <7d band.
+    const strip = getByTestId("ops-arrivals-recency");
+    expect(strip.getAttribute("data-band")).toBe("7d");
+    expect(strip.querySelectorAll('[data-active="yes"]').length).toBe(1);
+  });
+
+  test("no outsider activity ever → no recency strip at all", () => {
+    const none = snapshot();
+    if (none.operatorView && !("unavailable" in none.operatorView)) {
+      none.operatorView.outsiders.lastActivity = null;
+    }
+    const { queryByTestId, getByTestId } = render(<ArrivalsPanel arrivals={none} />);
+    expect(queryByTestId("ops-arrivals-recency")).toBeNull();
+    expect(getByTestId("ops-arrivals-last-activity").textContent).toContain("NO IDENTIFIED OUTSIDER ACTIVITY YET");
+  });
+
+  test("a zero week draws no bars — the words carry the zero", () => {
+    const quiet = snapshot();
+    if (quiet.operatorView && !("unavailable" in quiet.operatorView)) {
+      quiet.operatorView.outsiders.week = { window: "7d", identified: 0, worked: 0 };
+    }
+    const { queryByTestId } = render(<ArrivalsPanel arrivals={quiet} />);
+    expect(queryByTestId("ops-arrivals-weekpair")).toBeNull();
+  });
+
   test("an older producer is a named missing verdict, never a reconstructed zero", () => {
     const older = snapshot({ operatorView: undefined });
     const { getByTestId, queryByTestId } = render(<ArrivalsPanel arrivals={older} />);

--- a/packages/monitor-ui/src/components/ops/ArrivalsPanel.tsx
+++ b/packages/monitor-ui/src/components/ops/ArrivalsPanel.tsx
@@ -1,16 +1,18 @@
 // ARRIVALS — the operator verdict first, raw transport counters second.
 //
+// Visual grammar per the Averray design system's operator kit (the design
+// project's SKILL.md): records render as KPI cards — uppercase display
+// eyebrow, one large display value, mono sub-line; instrumentation renders as
+// a table; OURS / UNKNOWN counts are status pills; identifiers stay mono.
+// Translated onto the board's --h4 tokens so every color profile keeps
+// working.
+//
 // The backend owns identity joins, historical payout evidence, and windows.
 // This component never recovers a verdict from the legacy call funnels: doing
 // so would make canaries look like demand and compare unlike instrumentation.
 
 import { formatAgo } from "../../lib/monitor/ops-model.js";
-import {
-  RECENCY_BANDS,
-  doorLadders,
-  recencyBand,
-  weekPair,
-} from "../../lib/monitor/arrivals-view.js";
+import { doorJourneys } from "../../lib/monitor/arrivals-view.js";
 import type {
   ArrivalOperatorView,
   ArrivalOperatorDoorRow,
@@ -36,6 +38,8 @@ export function ArrivalsPanel({ arrivals }: ArrivalsPanelProps) {
   }
 
   const { outsiders, ours, unknown, generatedAtMs } = operatorView;
+  const furthest = outsiders.furthestEver;
+  const last = outsiders.lastActivity;
   return (
     <section className="ops-arrivals" aria-label="Arrivals — who is actually showing up" data-testid="ops-arrivals">
       <header className="ops-panel-head">
@@ -48,44 +52,69 @@ export function ArrivalsPanel({ arrivals }: ArrivalsPanelProps) {
           <h3>OUTSIDERS</h3>
           <span>the only demand signal</span>
         </div>
-        {/* Two halves of one answer: the verdict lines (records and windows,
-            in words) and the wallet-journey ladders (the same instrumentation
-            as marks). The ladders draw ONLY the wallet-unit rows — the
-            pre-identity call counters stay un-charted in the DOORS drawer,
-            where their unlike instruments are labelled. */}
-        <div className="ops-arrivals-verdict-body">
-          <dl className="ops-arrivals-verdict-lines">
-            <VerdictLine label="furthest ever" testId="ops-arrivals-furthest-ever">
-              <Figure window={outsiders.furthestEver?.window ?? "all-time"} testId="ops-arrivals-figure-furthest">
-                {formatFurthest(outsiders.furthestEver)}
-              </Figure>
-            </VerdictLine>
-            <VerdictLine label="last activity" testId="ops-arrivals-last-activity">
-              <Figure window={outsiders.lastActivity?.window ?? "all-time"} testId="ops-arrivals-figure-last">
-                {formatLastActivity(outsiders.lastActivity, generatedAtMs)}
-              </Figure>
-              <RecencyStrip atMs={outsiders.lastActivity?.atMs ?? null} generatedAtMs={generatedAtMs} />
-            </VerdictLine>
-            <VerdictLine label="this week" testId="ops-arrivals-this-week">
-              <span className="ops-arrivals-pair">
-                <Figure window={outsiders.week.window} testId="ops-arrivals-figure-week-identified">
-                  {outsiders.week.identified} identified
+
+        {/* The four records, as KPI cards. The value is the record; the mono
+            sub-line is its provenance (count, date, door); the window badge
+            rides every figure, exactly as before. */}
+        <div className="ops-arrivals-kpis">
+          <Kpi label="FURTHEST EVER" testId="ops-arrivals-furthest-ever">
+            {furthest ? (
+              <>
+                <span className="ops-kpi-val">{furthest.stage.toUpperCase()}</span>
+                <Figure window={furthest.window} testId="ops-arrivals-figure-furthest">
+                  {furthestSub(furthest)}
                 </Figure>
-                <span aria-hidden>·</span>
-                <Figure window={outsiders.week.window} testId="ops-arrivals-figure-week-worked">
-                  {outsiders.week.worked} worked
+              </>
+            ) : (
+              <Figure window="all-time" testId="ops-arrivals-figure-furthest">
+                NO IDENTIFIED OUTSIDER YET
+              </Figure>
+            )}
+          </Kpi>
+
+          <Kpi label="LAST ACTIVITY" testId="ops-arrivals-last-activity">
+            {last ? (
+              <>
+                <span className="ops-kpi-val">{formatAgo(last.atMs, generatedAtMs)}</span>
+                <Figure window={last.window} testId="ops-arrivals-figure-last">
+                  {last.stage} ({last.door.toUpperCase()})
                 </Figure>
-              </span>
-              <WeekBars week={outsiders.week} />
-            </VerdictLine>
-            <VerdictLine label="posted work" testId="ops-arrivals-posted-work">
+              </>
+            ) : (
+              <Figure window="all-time" testId="ops-arrivals-figure-last">
+                NO IDENTIFIED OUTSIDER ACTIVITY YET
+              </Figure>
+            )}
+          </Kpi>
+
+          <Kpi label="THIS WEEK" testId="ops-arrivals-this-week">
+            <Figure window={outsiders.week.window} testId="ops-arrivals-figure-week-identified">
+              <span className="ops-kpi-val">{outsiders.week.identified}</span> identified
+            </Figure>
+            <Figure window={outsiders.week.window} testId="ops-arrivals-figure-week-worked">
+              {outsiders.week.worked} worked
+            </Figure>
+          </Kpi>
+
+          <Kpi label="POSTED WORK" testId="ops-arrivals-posted-work">
+            {outsiders.postedWork.status === "observed" ? (
+              <>
+                <span className="ops-kpi-val">
+                  {outsiders.postedWork.count ?? 0} <span className="ops-kpi-word">POSTED</span>
+                </span>
+                <Figure window={outsiders.postedWork.window} testId="ops-arrivals-figure-posted">
+                  FIRST {formatDate(outsiders.postedWork.firstAtMs)}
+                </Figure>
+              </>
+            ) : (
               <Figure window={outsiders.postedWork.window} testId="ops-arrivals-figure-posted">
-                {formatPostedWork(outsiders.postedWork)}
+                {outsiders.postedWork.status === "never" ? "NEVER — THE OPEN GATE" : "UNKNOWN — JOB CATALOGUE UNREADABLE"}
               </Figure>
-            </VerdictLine>
-          </dl>
-          <JourneyLadders view={operatorView} />
+            )}
+          </Kpi>
         </div>
+
+        <JourneyPanel view={operatorView} />
       </section>
 
       <div className="ops-arrivals-secondary">
@@ -159,109 +188,96 @@ function Unavailable({ reason, label = "UNREACHABLE" }: { reason: string; label?
   );
 }
 
-function VerdictLine({ label, testId, children }: { label: string; testId: string; children: React.ReactNode }) {
+/** One record card: uppercase eyebrow, then whatever the record renders. */
+function Kpi({ label, testId, children }: { label: string; testId: string; children: React.ReactNode }) {
   return (
-    <div data-testid={testId}>
-      <dt>{label}</dt>
-      <dd>{children}</dd>
+    <div className="ops-kpi" data-testid={testId}>
+      <span className="ops-kpi-lbl">{label}</span>
+      {children}
     </div>
   );
 }
 
+/** The furthest-ever provenance sub-line: burst, date, door. */
+function furthestSub(reading: NonNullable<ArrivalOperatorView["outsiders"]["furthestEver"]>): string {
+  const burst =
+    reading.payouts === undefined ? "" : `${reading.payouts} payouts in ${reading.payoutWindow ?? "the measured burst"} · `;
+  return `${burst}${formatDate(reading.atMs)} (${reading.door.toUpperCase()})`;
+}
+
 /**
- * The wallet-journey ladders — one per door, never summed, never compared.
+ * The wallet journey, as the kit's table pattern — one row per wallet stage,
+ * one column per door.
  *
  * Only rows the producer declared in the `agents` unit are drawn: distinct
- * SIWE wallets reaching AT LEAST each stage, which is monotonic by
- * construction and therefore honest as bars. Each door fills against its OWN
- * busiest stage, so a 1-wallet MCP door and a 160-wallet HTTP door are both
- * legible without the widths implying a comparison the windows cannot support.
+ * SIWE wallets reaching AT LEAST each stage, monotonic by construction, which
+ * is what makes the fill behind each count honest. Each door fills against
+ * its OWN busiest stage — a 1-wallet MCP door and a 160-wallet HTTP door are
+ * both legible without the widths implying a comparison the windows cannot
+ * support. The pre-identity call counters stay un-charted in the DOORS drawer.
  */
-function JourneyLadders({ view }: { view: ArrivalOperatorView }) {
-  const doors = doorLadders(view);
+function JourneyPanel({ view }: { view: ArrivalOperatorView }) {
+  const doors = doorJourneys(view);
+  // Row spine: every wallet stage any door reported, in producer order.
+  const stageOrder = doors.flatMap((d) => d.stages.map((s) => s.stage)).filter((s, i, all) => all.indexOf(s) === i);
+
   return (
-    <div className="ops-arrivals-journey" data-testid="ops-arrivals-journey">
-      <div className="ops-arrivals-journey-head">
+    <div className="ops-journey" data-testid="ops-arrivals-journey">
+      <div className="ops-journey-head">
         <h4>WALLET JOURNEY</h4>
         <span>wallets reaching at least each stage · each door on its own scale · doors never sum</span>
       </div>
-      <div className="ops-arrivals-journey-doors">
-        {doors.map((door) => (
-          <div className="ops-ladder" key={door.door} data-testid={`ops-arrivals-ladder-${door.door}`}>
-            <div className="ops-ladder-head">
-              <span className="ops-ladder-door">{door.label}</span>
-              <span className="ops-ladder-since">since {formatDate(door.sinceMs)}</span>
-              <WindowBadge window={door.window} />
-            </div>
-            {door.stages.length === 0 ? (
-              <p className="ops-ladder-absent">no wallet-stage rows reported for this door</p>
-            ) : (
-              door.stages.map((s) => (
-                <div
-                  className="ops-ladder-row"
-                  key={s.stage}
-                  data-testid={`ops-arrivals-ladder-${door.door}-${s.stage}`}
-                >
-                  <span className="ops-ladder-stage">{s.stage}</span>
-                  <span className="ops-ladder-track" aria-hidden>
-                    {/* Zero draws NO fill — the min-width that keeps one wallet
-                        visible must never invent one. */}
-                    {s.fillPct > 0 ? <i style={{ width: `${s.fillPct}%` }} /> : null}
-                  </span>
-                  <span className="ops-ladder-count">{s.count}</span>
-                </div>
-              ))
-            )}
+      {stageOrder.length === 0 ? (
+        <p className="ops-journey-absent" data-testid="ops-arrivals-journey-absent">
+          no wallet-stage rows reported by either door
+        </p>
+      ) : (
+        <div className="ops-journey-grid" role="table" aria-label="Outsider wallets by stage, per door">
+          <div className="ops-journey-row ops-journey-row--head" role="row">
+            <span role="columnheader" className="ops-journey-stage-head">
+              stage
+            </span>
+            {doors.map((door) => (
+              <span role="columnheader" className="ops-journey-door" key={door.door}>
+                {door.label}
+                <small>since {formatDate(door.sinceMs)}</small>
+                <WindowBadge window={door.window} />
+              </span>
+            ))}
           </div>
-        ))}
-      </div>
+          {stageOrder.map((stage) => (
+            <div className="ops-journey-row" role="row" key={stage} data-testid={`ops-arrivals-journey-${stage}`}>
+              <span role="cell" className="ops-journey-stage">
+                {stage}
+              </span>
+              {doors.map((door) => {
+                const reading = door.stages.find((s) => s.stage === stage);
+                return (
+                  <span
+                    role="cell"
+                    className="ops-journey-cell"
+                    key={door.door}
+                    data-testid={`ops-arrivals-journey-${door.door}-${stage}`}
+                  >
+                    {/* A stage this door never reported is a dash, not a zero. */}
+                    {reading ? (
+                      <>
+                        <span className="ops-journey-fill" aria-hidden>
+                          {reading.fillPct > 0 ? <i style={{ width: `${reading.fillPct}%` }} /> : null}
+                        </span>
+                        <b>{reading.count}</b>
+                      </>
+                    ) : (
+                      <b className="ops-journey-none">—</b>
+                    )}
+                  </span>
+                );
+              })}
+            </div>
+          ))}
+        </div>
+      )}
     </div>
-  );
-}
-
-/**
- * Where in fixed time bands the last outsider activity sits. The bands are
- * rungs (1h / 24h / 7d), not a linear axis, and the clock is the snapshot's
- * own. No activity ever → nothing: an empty strip still looks like a reading.
- */
-function RecencyStrip({ atMs, generatedAtMs }: { atMs: number | null; generatedAtMs: number }) {
-  const band = recencyBand(atMs, generatedAtMs);
-  if (!band) return null;
-  return (
-    <span
-      className="ops-recency"
-      role="img"
-      aria-label={`last outsider activity falls in the ${band} band`}
-      data-band={band}
-      data-testid="ops-arrivals-recency"
-    >
-      {RECENCY_BANDS.map((b) => (
-        <i key={b.key} data-active={b.key === band ? "yes" : "no"}>
-          {b.label}
-        </i>
-      ))}
-    </span>
-  );
-}
-
-/**
- * The 7d identified/worked counts as two bars on ONE shared scale — beside
- * the words that carry the exact numbers. Not nested: nothing in the payload
- * proves worked ⊆ identified, so neither bar contains the other.
- */
-function WeekBars({ week }: { week: { identified: number; worked: number } }) {
-  const pair = weekPair(week);
-  if (!pair) return null;
-  return (
-    <span className="ops-weekpair" data-testid="ops-arrivals-weekpair" aria-hidden>
-      {/* A zero count gets no bar at all — the words beside carry the zero. */}
-      {pair.identified.fillPct > 0 ? (
-        <i data-kind="identified" title={`${pair.identified.count} identified (7d)`} style={{ width: `${pair.identified.fillPct}%` }} />
-      ) : null}
-      {pair.worked.fillPct > 0 ? (
-        <i data-kind="worked" title={`${pair.worked.count} worked (7d)`} style={{ width: `${pair.worked.fillPct}%` }} />
-      ) : null}
-    </span>
   );
 }
 
@@ -313,28 +329,6 @@ function DoorRow({ door, row, window }: { door: "mcp" | "http"; row: ArrivalOper
       ))}
     </div>
   );
-}
-
-function formatFurthest(reading: ArrivalOperatorView["outsiders"]["furthestEver"]): string {
-  if (!reading) return "NO IDENTIFIED OUTSIDER YET";
-  const payout = reading.payouts === undefined
-    ? ""
-    : ` · ${reading.payouts} payouts in ${reading.payoutWindow ?? "the measured burst"}`;
-  return `${reading.stage.toUpperCase()}${payout} · ${formatDate(reading.atMs)} (${reading.door.toUpperCase()})`;
-}
-
-function formatLastActivity(
-  reading: ArrivalOperatorView["outsiders"]["lastActivity"],
-  generatedAtMs: number,
-): string {
-  if (!reading) return "NO IDENTIFIED OUTSIDER ACTIVITY YET";
-  return `${formatAgo(reading.atMs, generatedAtMs)} · ${reading.stage} (${reading.door.toUpperCase()})`;
-}
-
-function formatPostedWork(reading: ArrivalOperatorView["outsiders"]["postedWork"]): string {
-  if (reading.status === "never") return "NEVER — THE OPEN GATE";
-  if (reading.status === "unknown") return "UNKNOWN — JOB CATALOGUE UNREADABLE";
-  return `${reading.count ?? 0} POSTED · FIRST ${formatDate(reading.firstAtMs)}`;
 }
 
 function formatDate(atMs: number | null): string {

--- a/packages/monitor-ui/src/components/ops/ArrivalsPanel.tsx
+++ b/packages/monitor-ui/src/components/ops/ArrivalsPanel.tsx
@@ -5,9 +5,15 @@
 // so would make canaries look like demand and compare unlike instrumentation.
 
 import { formatAgo } from "../../lib/monitor/ops-model.js";
+import {
+  RECENCY_BANDS,
+  doorLadders,
+  recencyBand,
+  weekPair,
+} from "../../lib/monitor/arrivals-view.js";
 import type {
-  ArrivalOperatorDoorRow,
   ArrivalOperatorView,
+  ArrivalOperatorDoorRow,
   ArrivalsBlock,
 } from "../../lib/monitor/product-health.js";
 
@@ -42,34 +48,44 @@ export function ArrivalsPanel({ arrivals }: ArrivalsPanelProps) {
           <h3>OUTSIDERS</h3>
           <span>the only demand signal</span>
         </div>
-        <dl className="ops-arrivals-verdict-lines">
-          <VerdictLine label="furthest ever" testId="ops-arrivals-furthest-ever">
-            <Figure window={outsiders.furthestEver?.window ?? "all-time"} testId="ops-arrivals-figure-furthest">
-              {formatFurthest(outsiders.furthestEver)}
-            </Figure>
-          </VerdictLine>
-          <VerdictLine label="last activity" testId="ops-arrivals-last-activity">
-            <Figure window={outsiders.lastActivity?.window ?? "all-time"} testId="ops-arrivals-figure-last">
-              {formatLastActivity(outsiders.lastActivity, generatedAtMs)}
-            </Figure>
-          </VerdictLine>
-          <VerdictLine label="this week" testId="ops-arrivals-this-week">
-            <span className="ops-arrivals-pair">
-              <Figure window={outsiders.week.window} testId="ops-arrivals-figure-week-identified">
-                {outsiders.week.identified} identified
+        {/* Two halves of one answer: the verdict lines (records and windows,
+            in words) and the wallet-journey ladders (the same instrumentation
+            as marks). The ladders draw ONLY the wallet-unit rows — the
+            pre-identity call counters stay un-charted in the DOORS drawer,
+            where their unlike instruments are labelled. */}
+        <div className="ops-arrivals-verdict-body">
+          <dl className="ops-arrivals-verdict-lines">
+            <VerdictLine label="furthest ever" testId="ops-arrivals-furthest-ever">
+              <Figure window={outsiders.furthestEver?.window ?? "all-time"} testId="ops-arrivals-figure-furthest">
+                {formatFurthest(outsiders.furthestEver)}
               </Figure>
-              <span aria-hidden>·</span>
-              <Figure window={outsiders.week.window} testId="ops-arrivals-figure-week-worked">
-                {outsiders.week.worked} worked
+            </VerdictLine>
+            <VerdictLine label="last activity" testId="ops-arrivals-last-activity">
+              <Figure window={outsiders.lastActivity?.window ?? "all-time"} testId="ops-arrivals-figure-last">
+                {formatLastActivity(outsiders.lastActivity, generatedAtMs)}
               </Figure>
-            </span>
-          </VerdictLine>
-          <VerdictLine label="posted work" testId="ops-arrivals-posted-work">
-            <Figure window={outsiders.postedWork.window} testId="ops-arrivals-figure-posted">
-              {formatPostedWork(outsiders.postedWork)}
-            </Figure>
-          </VerdictLine>
-        </dl>
+              <RecencyStrip atMs={outsiders.lastActivity?.atMs ?? null} generatedAtMs={generatedAtMs} />
+            </VerdictLine>
+            <VerdictLine label="this week" testId="ops-arrivals-this-week">
+              <span className="ops-arrivals-pair">
+                <Figure window={outsiders.week.window} testId="ops-arrivals-figure-week-identified">
+                  {outsiders.week.identified} identified
+                </Figure>
+                <span aria-hidden>·</span>
+                <Figure window={outsiders.week.window} testId="ops-arrivals-figure-week-worked">
+                  {outsiders.week.worked} worked
+                </Figure>
+              </span>
+              <WeekBars week={outsiders.week} />
+            </VerdictLine>
+            <VerdictLine label="posted work" testId="ops-arrivals-posted-work">
+              <Figure window={outsiders.postedWork.window} testId="ops-arrivals-figure-posted">
+                {formatPostedWork(outsiders.postedWork)}
+              </Figure>
+            </VerdictLine>
+          </dl>
+          <JourneyLadders view={operatorView} />
+        </div>
       </section>
 
       <div className="ops-arrivals-secondary">
@@ -149,6 +165,103 @@ function VerdictLine({ label, testId, children }: { label: string; testId: strin
       <dt>{label}</dt>
       <dd>{children}</dd>
     </div>
+  );
+}
+
+/**
+ * The wallet-journey ladders — one per door, never summed, never compared.
+ *
+ * Only rows the producer declared in the `agents` unit are drawn: distinct
+ * SIWE wallets reaching AT LEAST each stage, which is monotonic by
+ * construction and therefore honest as bars. Each door fills against its OWN
+ * busiest stage, so a 1-wallet MCP door and a 160-wallet HTTP door are both
+ * legible without the widths implying a comparison the windows cannot support.
+ */
+function JourneyLadders({ view }: { view: ArrivalOperatorView }) {
+  const doors = doorLadders(view);
+  return (
+    <div className="ops-arrivals-journey" data-testid="ops-arrivals-journey">
+      <div className="ops-arrivals-journey-head">
+        <h4>WALLET JOURNEY</h4>
+        <span>wallets reaching at least each stage · each door on its own scale · doors never sum</span>
+      </div>
+      <div className="ops-arrivals-journey-doors">
+        {doors.map((door) => (
+          <div className="ops-ladder" key={door.door} data-testid={`ops-arrivals-ladder-${door.door}`}>
+            <div className="ops-ladder-head">
+              <span className="ops-ladder-door">{door.label}</span>
+              <span className="ops-ladder-since">since {formatDate(door.sinceMs)}</span>
+              <WindowBadge window={door.window} />
+            </div>
+            {door.stages.length === 0 ? (
+              <p className="ops-ladder-absent">no wallet-stage rows reported for this door</p>
+            ) : (
+              door.stages.map((s) => (
+                <div
+                  className="ops-ladder-row"
+                  key={s.stage}
+                  data-testid={`ops-arrivals-ladder-${door.door}-${s.stage}`}
+                >
+                  <span className="ops-ladder-stage">{s.stage}</span>
+                  <span className="ops-ladder-track" aria-hidden>
+                    {/* Zero draws NO fill — the min-width that keeps one wallet
+                        visible must never invent one. */}
+                    {s.fillPct > 0 ? <i style={{ width: `${s.fillPct}%` }} /> : null}
+                  </span>
+                  <span className="ops-ladder-count">{s.count}</span>
+                </div>
+              ))
+            )}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Where in fixed time bands the last outsider activity sits. The bands are
+ * rungs (1h / 24h / 7d), not a linear axis, and the clock is the snapshot's
+ * own. No activity ever → nothing: an empty strip still looks like a reading.
+ */
+function RecencyStrip({ atMs, generatedAtMs }: { atMs: number | null; generatedAtMs: number }) {
+  const band = recencyBand(atMs, generatedAtMs);
+  if (!band) return null;
+  return (
+    <span
+      className="ops-recency"
+      role="img"
+      aria-label={`last outsider activity falls in the ${band} band`}
+      data-band={band}
+      data-testid="ops-arrivals-recency"
+    >
+      {RECENCY_BANDS.map((b) => (
+        <i key={b.key} data-active={b.key === band ? "yes" : "no"}>
+          {b.label}
+        </i>
+      ))}
+    </span>
+  );
+}
+
+/**
+ * The 7d identified/worked counts as two bars on ONE shared scale — beside
+ * the words that carry the exact numbers. Not nested: nothing in the payload
+ * proves worked ⊆ identified, so neither bar contains the other.
+ */
+function WeekBars({ week }: { week: { identified: number; worked: number } }) {
+  const pair = weekPair(week);
+  if (!pair) return null;
+  return (
+    <span className="ops-weekpair" data-testid="ops-arrivals-weekpair" aria-hidden>
+      {/* A zero count gets no bar at all — the words beside carry the zero. */}
+      {pair.identified.fillPct > 0 ? (
+        <i data-kind="identified" title={`${pair.identified.count} identified (7d)`} style={{ width: `${pair.identified.fillPct}%` }} />
+      ) : null}
+      {pair.worked.fillPct > 0 ? (
+        <i data-kind="worked" title={`${pair.worked.count} worked (7d)`} style={{ width: `${pair.worked.fillPct}%` }} />
+      ) : null}
+    </span>
   );
 }
 

--- a/packages/monitor-ui/src/lib/monitor/arrivals-view.test.ts
+++ b/packages/monitor-ui/src/lib/monitor/arrivals-view.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "vitest";
 
-import { doorLadders, recencyBand, weekPair } from "./arrivals-view.js";
+import { doorJourneys } from "./arrivals-view.js";
 import type { ArrivalOperatorView } from "./product-health.js";
 
 const NOW = Date.parse("2026-08-16T12:00:00.000Z");
@@ -56,19 +56,19 @@ function view(over: Partial<ArrivalOperatorView["doors"]["http"]> = {}): Arrival
   };
 }
 
-describe("doorLadders — the wallet half only, per-door scale", () => {
-  test("call rows never enter the ladder — the un-charted counters stay un-charted", () => {
-    const [mcp, http] = doorLadders(view());
+describe("doorJourneys — the wallet half only, per-door scale", () => {
+  test("call rows never enter the journey — the un-charted counters stay un-charted", () => {
+    const [mcp, http] = doorJourneys(view());
     expect(mcp!.stages.map((s) => s.stage)).toEqual(["identified", "claimed", "submitted"]);
     expect(http!.stages.map((s) => s.stage)).toEqual(["identified", "authenticated", "claimed", "submitted"]);
-    // The 15,000-call reached row must not have become a bar anywhere.
+    // The 15,000-call reached row must not have become a fill anywhere.
     for (const door of [mcp!, http!]) {
       expect(door.stages.every((s) => s.count < 1000)).toBe(true);
     }
   });
 
   test("each door scales to its own maximum — doors are never comparable", () => {
-    const [mcp, http] = doorLadders(view());
+    const [mcp, http] = doorJourneys(view());
     // MCP's single wallet fills MCP's own scale; HTTP's 162 sits just under
     // HTTP's 164. Equal fills for unequal counts is the point: no cross-door
     // comparison is encoded.
@@ -77,53 +77,17 @@ describe("doorLadders — the wallet half only, per-door scale", () => {
     expect(http!.stages[2]!.fillPct).toBe(99);
   });
 
-  test("zero draws no bar; a tiny nonzero always draws one", () => {
-    const [mcp] = doorLadders(view());
+  test("zero draws no fill; a tiny nonzero always draws one", () => {
+    const [mcp] = doorJourneys(view());
     const submitted = mcp!.stages.find((s) => s.stage === "submitted")!;
     expect(submitted.fillPct).toBe(0);
     const identified = mcp!.stages.find((s) => s.stage === "identified")!;
     expect(identified.fillPct).toBeGreaterThanOrEqual(5);
   });
 
-  test("a door with no wallet-unit rows yields an empty ladder, not zeros", () => {
+  test("a door with no wallet-unit rows yields an empty journey, not zeros", () => {
     const v = view({ rows: [] });
-    const [, http] = doorLadders(v);
+    const [, http] = doorJourneys(v);
     expect(http!.stages).toEqual([]);
-  });
-});
-
-describe("recencyBand — fixed rungs against the snapshot clock", () => {
-  test("bands split at 1h / 24h / 7d", () => {
-    expect(recencyBand(NOW - 2 * 60_000, NOW)).toBe("1h");
-    expect(recencyBand(NOW - 5 * 3_600_000, NOW)).toBe("24h");
-    expect(recencyBand(NOW - 3 * 86_400_000, NOW)).toBe("7d");
-    expect(recencyBand(NOW - 30 * 86_400_000, NOW)).toBe("older");
-  });
-
-  test("no activity ever → null, so no strip renders at all", () => {
-    expect(recencyBand(null, NOW)).toBeNull();
-    expect(recencyBand(undefined, NOW)).toBeNull();
-    expect(recencyBand(Number.NaN, NOW)).toBeNull();
-  });
-});
-
-describe("weekPair — one shared scale, no containment claim", () => {
-  test("both counts fill against the larger of the two", () => {
-    const pair = weekPair({ identified: 18, worked: 16 })!;
-    expect(pair.identified.fillPct).toBe(100);
-    expect(pair.worked.fillPct).toBe(89);
-    expect(pair.worked.count).toBe(16);
-  });
-
-  test("a zero week renders no bars — the words already say it", () => {
-    expect(weekPair({ identified: 0, worked: 0 })).toBeNull();
-  });
-
-  test("worked can exceed identified without breaking the scale", () => {
-    // Nothing in the payload proves worked ⊆ identified; the scale must not
-    // assume it.
-    const pair = weekPair({ identified: 2, worked: 5 })!;
-    expect(pair.worked.fillPct).toBe(100);
-    expect(pair.identified.fillPct).toBe(40);
   });
 });

--- a/packages/monitor-ui/src/lib/monitor/arrivals-view.test.ts
+++ b/packages/monitor-ui/src/lib/monitor/arrivals-view.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, test } from "vitest";
+
+import { doorLadders, recencyBand, weekPair } from "./arrivals-view.js";
+import type { ArrivalOperatorView } from "./product-health.js";
+
+const NOW = Date.parse("2026-08-16T12:00:00.000Z");
+
+function view(over: Partial<ArrivalOperatorView["doors"]["http"]> = {}): ArrivalOperatorView {
+  const callRow = (stage: string, outsider: number) => ({
+    stage: stage as never,
+    unit: "calls" as const,
+    instrumentation: `${stage} route/tool calls`,
+    outsider,
+    ours: 0,
+    unknown: 0,
+  });
+  const walletRow = (stage: string, outsider: number) => ({
+    stage: stage as never,
+    unit: "agents" as const,
+    instrumentation: "distinct SIWE wallets reaching at least this stage",
+    outsider,
+    ours: 0,
+    unknown: 0,
+  });
+  return {
+    version: "averray.arrivals.operator.v1",
+    generatedAtMs: NOW,
+    outsiders: {
+      furthestEver: null,
+      lastActivity: null,
+      week: { window: "7d", identified: 0, worked: 0 },
+      postedWork: { window: "all-time", status: "never", count: null, firstAtMs: null },
+    },
+    ours: { day: { window: "24h", agents: 0, canaryRuns: 0, acceptanceRuns: 0, adminConsoleAgents: 0, operatorAgents: 0 } },
+    unknown: { window: "all-time", sharedClientNames: 0, preSplitCalls: 0 },
+    doors: {
+      mcp: {
+        window: "all-time",
+        sinceMs: NOW - 8 * 86_400_000,
+        rows: [callRow("reached", 2000), walletRow("identified", 1), walletRow("claimed", 1), walletRow("submitted", 0)],
+      },
+      http: {
+        window: "all-time",
+        sinceMs: NOW - 5 * 86_400_000,
+        rows: [
+          callRow("reached", 15_000),
+          callRow("browsed", 400),
+          walletRow("identified", 164),
+          walletRow("authenticated", 164),
+          walletRow("claimed", 162),
+          walletRow("submitted", 162),
+        ],
+        ...over,
+      },
+    },
+  };
+}
+
+describe("doorLadders — the wallet half only, per-door scale", () => {
+  test("call rows never enter the ladder — the un-charted counters stay un-charted", () => {
+    const [mcp, http] = doorLadders(view());
+    expect(mcp!.stages.map((s) => s.stage)).toEqual(["identified", "claimed", "submitted"]);
+    expect(http!.stages.map((s) => s.stage)).toEqual(["identified", "authenticated", "claimed", "submitted"]);
+    // The 15,000-call reached row must not have become a bar anywhere.
+    for (const door of [mcp!, http!]) {
+      expect(door.stages.every((s) => s.count < 1000)).toBe(true);
+    }
+  });
+
+  test("each door scales to its own maximum — doors are never comparable", () => {
+    const [mcp, http] = doorLadders(view());
+    // MCP's single wallet fills MCP's own scale; HTTP's 162 sits just under
+    // HTTP's 164. Equal fills for unequal counts is the point: no cross-door
+    // comparison is encoded.
+    expect(mcp!.stages[0]!.fillPct).toBe(100);
+    expect(http!.stages[0]!.fillPct).toBe(100);
+    expect(http!.stages[2]!.fillPct).toBe(99);
+  });
+
+  test("zero draws no bar; a tiny nonzero always draws one", () => {
+    const [mcp] = doorLadders(view());
+    const submitted = mcp!.stages.find((s) => s.stage === "submitted")!;
+    expect(submitted.fillPct).toBe(0);
+    const identified = mcp!.stages.find((s) => s.stage === "identified")!;
+    expect(identified.fillPct).toBeGreaterThanOrEqual(5);
+  });
+
+  test("a door with no wallet-unit rows yields an empty ladder, not zeros", () => {
+    const v = view({ rows: [] });
+    const [, http] = doorLadders(v);
+    expect(http!.stages).toEqual([]);
+  });
+});
+
+describe("recencyBand — fixed rungs against the snapshot clock", () => {
+  test("bands split at 1h / 24h / 7d", () => {
+    expect(recencyBand(NOW - 2 * 60_000, NOW)).toBe("1h");
+    expect(recencyBand(NOW - 5 * 3_600_000, NOW)).toBe("24h");
+    expect(recencyBand(NOW - 3 * 86_400_000, NOW)).toBe("7d");
+    expect(recencyBand(NOW - 30 * 86_400_000, NOW)).toBe("older");
+  });
+
+  test("no activity ever → null, so no strip renders at all", () => {
+    expect(recencyBand(null, NOW)).toBeNull();
+    expect(recencyBand(undefined, NOW)).toBeNull();
+    expect(recencyBand(Number.NaN, NOW)).toBeNull();
+  });
+});
+
+describe("weekPair — one shared scale, no containment claim", () => {
+  test("both counts fill against the larger of the two", () => {
+    const pair = weekPair({ identified: 18, worked: 16 })!;
+    expect(pair.identified.fillPct).toBe(100);
+    expect(pair.worked.fillPct).toBe(89);
+    expect(pair.worked.count).toBe(16);
+  });
+
+  test("a zero week renders no bars — the words already say it", () => {
+    expect(weekPair({ identified: 0, worked: 0 })).toBeNull();
+  });
+
+  test("worked can exceed identified without breaking the scale", () => {
+    // Nothing in the payload proves worked ⊆ identified; the scale must not
+    // assume it.
+    const pair = weekPair({ identified: 2, worked: 5 })!;
+    expect(pair.worked.fillPct).toBe(100);
+    expect(pair.identified.fillPct).toBe(40);
+  });
+});

--- a/packages/monitor-ui/src/lib/monitor/arrivals-view.ts
+++ b/packages/monitor-ui/src/lib/monitor/arrivals-view.ts
@@ -1,50 +1,48 @@
-// ARRIVALS view-model — the derived shapes behind the OUTSIDERS block.
+// ARRIVALS view-model — the wallet-journey shape behind the OUTSIDERS panel.
 //
-// The operator view was four prose lines and two collapsed tables; the shapes
-// here give the same facts marks, without crossing the lines the registry
-// design drew:
+// The visual grammar comes from the Averray design system's operator kit
+// (records as KPI cards, instrumentation as a table, counts in mono); this
+// module derives the one shape that needs derivation, without crossing the
+// lines the registry design drew:
 //
 //   · pre-identity counters (reached/browsed/evaluated) are CALLS from
 //     independent instruments and stay un-charted — a bar chart over them was
 //     deliberately removed once, and this module must not resurrect it;
 //   · from `identified` onward, rows are distinct SIWE wallets reaching AT
 //     LEAST that stage — monotonic by construction, which is what makes a
-//     ladder of bars honest;
+//     fill drawn behind the count honest;
 //   · the two doors carry different windows and different cut-overs, so each
 //     door scales to its OWN maximum and nothing ever sums or compares them.
-//
-// Pure; the clock is always the SNAPSHOT's own (`generatedAtMs`), never the
-// wall clock — the same rule the trust panel follows.
 
 import type { ArrivalOperatorView } from "./product-health.js";
 
-export interface LadderStageView {
+export interface JourneyStageView {
   stage: string;
   /** Distinct wallets reaching at least this stage, this door, its window. */
   count: number;
-  /** 0..100 against THIS door's own busiest wallet stage. Zero draws no bar. */
+  /** 0..100 against THIS door's own busiest wallet stage. Zero draws no fill. */
   fillPct: number;
 }
 
-export interface DoorLadderView {
+export interface DoorJourneyView {
   door: "mcp" | "http";
   label: string;
   sinceMs: number | null;
   window: string;
   /** Empty when the producer reported no wallet-unit rows for this door. */
-  stages: LadderStageView[];
+  stages: JourneyStageView[];
 }
 
 /**
- * The wallet half of each door's instrumentation, as a ladder.
+ * The wallet half of each door's instrumentation.
  *
  * Only rows whose unit is `agents` qualify — the producer's own declaration of
- * "distinct wallets reaching at least this stage". Rows are kept in producer
- * order; a nonzero count always gets a visible bar (a 1-wallet stage beside a
+ * "distinct wallets reaching at least this stage". Rows keep producer order; a
+ * nonzero count always gets a visible fill (a 1-wallet stage beside a
  * 164-wallet stage rounds to nothing, and "too small to draw" must not look
  * like "nobody ever got here").
  */
-export function doorLadders(view: ArrivalOperatorView): DoorLadderView[] {
+export function doorJourneys(view: ArrivalOperatorView): DoorJourneyView[] {
   return (["mcp", "http"] as const).map((door) => {
     const evidence = view.doors[door];
     const wallets = (evidence?.rows ?? []).filter((r) => r.unit === "agents");
@@ -61,52 +59,4 @@ export function doorLadders(view: ArrivalOperatorView): DoorLadderView[] {
       })),
     };
   });
-}
-
-/** Fixed recency rungs — a scale that does not move with the value on it. */
-export const RECENCY_BANDS = [
-  { key: "1h", label: "<1h", maxMs: 3_600_000 },
-  { key: "24h", label: "<24h", maxMs: 86_400_000 },
-  { key: "7d", label: "<7d", maxMs: 604_800_000 },
-  { key: "older", label: "older", maxMs: Number.POSITIVE_INFINITY },
-] as const;
-
-export type RecencyBandKey = (typeof RECENCY_BANDS)[number]["key"];
-
-/**
- * Which band the last outsider activity falls in, against the snapshot clock.
- * `null` when there has never been any — the caller renders the words and no
- * strip, because a strip with no marker still looks like a reading.
- */
-export function recencyBand(atMs: number | null | undefined, generatedAtMs: number): RecencyBandKey | null {
-  if (atMs == null || !Number.isFinite(atMs)) return null;
-  const age = Math.max(0, generatedAtMs - atMs);
-  for (const band of RECENCY_BANDS) {
-    if (age < band.maxMs) return band.key;
-  }
-  return "older";
-}
-
-export interface WeekPairView {
-  identified: { count: number; fillPct: number };
-  worked: { count: number; fillPct: number };
-}
-
-/**
- * The 7d identified/worked counts on ONE shared scale.
- *
- * Two comparable magnitudes, not a containment: nothing in the payload proves
- * `worked ⊆ identified`, so the bars sit side by side and neither nests in the
- * other. Null when both are zero — the words already say it, and two empty
- * tracks would dress a quiet week as a chart.
- */
-export function weekPair(week: { identified: number; worked: number } | undefined): WeekPairView | null {
-  if (!week) return null;
-  const max = Math.max(week.identified, week.worked);
-  if (max <= 0) return null;
-  const fill = (n: number) => (n === 0 ? 0 : Math.max(5, Math.round((n / max) * 100)));
-  return {
-    identified: { count: week.identified, fillPct: fill(week.identified) },
-    worked: { count: week.worked, fillPct: fill(week.worked) },
-  };
 }

--- a/packages/monitor-ui/src/lib/monitor/arrivals-view.ts
+++ b/packages/monitor-ui/src/lib/monitor/arrivals-view.ts
@@ -1,0 +1,112 @@
+// ARRIVALS view-model — the derived shapes behind the OUTSIDERS block.
+//
+// The operator view was four prose lines and two collapsed tables; the shapes
+// here give the same facts marks, without crossing the lines the registry
+// design drew:
+//
+//   · pre-identity counters (reached/browsed/evaluated) are CALLS from
+//     independent instruments and stay un-charted — a bar chart over them was
+//     deliberately removed once, and this module must not resurrect it;
+//   · from `identified` onward, rows are distinct SIWE wallets reaching AT
+//     LEAST that stage — monotonic by construction, which is what makes a
+//     ladder of bars honest;
+//   · the two doors carry different windows and different cut-overs, so each
+//     door scales to its OWN maximum and nothing ever sums or compares them.
+//
+// Pure; the clock is always the SNAPSHOT's own (`generatedAtMs`), never the
+// wall clock — the same rule the trust panel follows.
+
+import type { ArrivalOperatorView } from "./product-health.js";
+
+export interface LadderStageView {
+  stage: string;
+  /** Distinct wallets reaching at least this stage, this door, its window. */
+  count: number;
+  /** 0..100 against THIS door's own busiest wallet stage. Zero draws no bar. */
+  fillPct: number;
+}
+
+export interface DoorLadderView {
+  door: "mcp" | "http";
+  label: string;
+  sinceMs: number | null;
+  window: string;
+  /** Empty when the producer reported no wallet-unit rows for this door. */
+  stages: LadderStageView[];
+}
+
+/**
+ * The wallet half of each door's instrumentation, as a ladder.
+ *
+ * Only rows whose unit is `agents` qualify — the producer's own declaration of
+ * "distinct wallets reaching at least this stage". Rows are kept in producer
+ * order; a nonzero count always gets a visible bar (a 1-wallet stage beside a
+ * 164-wallet stage rounds to nothing, and "too small to draw" must not look
+ * like "nobody ever got here").
+ */
+export function doorLadders(view: ArrivalOperatorView): DoorLadderView[] {
+  return (["mcp", "http"] as const).map((door) => {
+    const evidence = view.doors[door];
+    const wallets = (evidence?.rows ?? []).filter((r) => r.unit === "agents");
+    const max = Math.max(1, ...wallets.map((r) => r.outsider));
+    return {
+      door,
+      label: door === "mcp" ? "MCP" : "HTTP",
+      sinceMs: evidence?.sinceMs ?? null,
+      window: evidence?.window ?? "all-time",
+      stages: wallets.map((r) => ({
+        stage: r.stage,
+        count: r.outsider,
+        fillPct: r.outsider === 0 ? 0 : Math.max(5, Math.round((r.outsider / max) * 100)),
+      })),
+    };
+  });
+}
+
+/** Fixed recency rungs — a scale that does not move with the value on it. */
+export const RECENCY_BANDS = [
+  { key: "1h", label: "<1h", maxMs: 3_600_000 },
+  { key: "24h", label: "<24h", maxMs: 86_400_000 },
+  { key: "7d", label: "<7d", maxMs: 604_800_000 },
+  { key: "older", label: "older", maxMs: Number.POSITIVE_INFINITY },
+] as const;
+
+export type RecencyBandKey = (typeof RECENCY_BANDS)[number]["key"];
+
+/**
+ * Which band the last outsider activity falls in, against the snapshot clock.
+ * `null` when there has never been any — the caller renders the words and no
+ * strip, because a strip with no marker still looks like a reading.
+ */
+export function recencyBand(atMs: number | null | undefined, generatedAtMs: number): RecencyBandKey | null {
+  if (atMs == null || !Number.isFinite(atMs)) return null;
+  const age = Math.max(0, generatedAtMs - atMs);
+  for (const band of RECENCY_BANDS) {
+    if (age < band.maxMs) return band.key;
+  }
+  return "older";
+}
+
+export interface WeekPairView {
+  identified: { count: number; fillPct: number };
+  worked: { count: number; fillPct: number };
+}
+
+/**
+ * The 7d identified/worked counts on ONE shared scale.
+ *
+ * Two comparable magnitudes, not a containment: nothing in the payload proves
+ * `worked ⊆ identified`, so the bars sit side by side and neither nests in the
+ * other. Null when both are zero — the words already say it, and two empty
+ * tracks would dress a quiet week as a chart.
+ */
+export function weekPair(week: { identified: number; worked: number } | undefined): WeekPairView | null {
+  if (!week) return null;
+  const max = Math.max(week.identified, week.worked);
+  if (max <= 0) return null;
+  const fill = (n: number) => (n === 0 ? 0 : Math.max(5, Math.round((n / max) * 100)));
+  return {
+    identified: { count: week.identified, fillPct: fill(week.identified) },
+    worked: { count: week.worked, fillPct: fill(week.worked) },
+  };
+}

--- a/packages/monitor-ui/src/lib/monitor/ops-fixtures.ts
+++ b/packages/monitor-ui/src/lib/monitor/ops-fixtures.ts
@@ -9,6 +9,9 @@
 //   OPS_FIXTURE_RED        a mainnet page-worthy incident → soft-banner / auto-flip
 
 import type {
+  ArrivalOperatorDoorRow,
+  ArrivalStage,
+  ArrivalsSnapshot,
   ProductHealth,
   ProductHealthProbe,
   ProbeStatus,
@@ -511,6 +514,113 @@ export const OPS_FIXTURE_UNVERIFIED: ProductHealth = {
       settledCount: 14,
       windowBlocks: null,
       window: { status: "unknown", detail: "block time not sampled", blockSeconds: null, spanHours: null },
+    },
+  },
+};
+
+// ── ARRIVALS, shaped like the live board on 2026-08-17 ──────────────────────
+//
+// Counts transcribed from the production operator view that day (doors,
+// records and windows included), so the preview exercises the OUTSIDERS
+// visualization with realistic asymmetry: an HTTP door with ~160 wallets and
+// an MCP door with one. The legacy pre-registry counters are DERIVED from the
+// MCP door rows (external = outsider, self = ours) rather than invented — the
+// panel renders `operatorView` and never reads them when it is present.
+//
+// NOT spread into the base fixtures: the phone-board tests compose their own
+// arrivals blocks over OPS_FIXTURE_NOMINAL and assert exact lane text; the
+// preview harness merges this in itself.
+
+const ARRIVAL_STAGE_LIST = [
+  "reached",
+  "browsed",
+  "evaluated",
+  "identified",
+  "authenticated",
+  "claimed",
+  "submitted",
+] as const;
+
+function doorRows(
+  counts: Record<(typeof ARRIVAL_STAGE_LIST)[number], [number, number, number]>,
+): ArrivalOperatorDoorRow[] {
+  return ARRIVAL_STAGE_LIST.map((stage, index) => ({
+    stage,
+    unit: index < 3 ? ("calls" as const) : ("agents" as const),
+    instrumentation:
+      index < 3 ? `${stage} route/tool calls` : "distinct SIWE wallets reaching at least this stage",
+    outsider: counts[stage][0],
+    ours: counts[stage][1],
+    unknown: counts[stage][2],
+  }));
+}
+
+const MCP_DOOR_ROWS = doorRows({
+  reached: [2362, 0, 511],
+  browsed: [16, 0, 7],
+  evaluated: [0, 0, 0],
+  identified: [1, 0, 0],
+  authenticated: [1, 0, 0],
+  claimed: [1, 0, 0],
+  submitted: [0, 0, 0],
+});
+
+const stageRecord = (pick: (row: ArrivalOperatorDoorRow) => number): Record<ArrivalStage, number> =>
+  Object.fromEntries(MCP_DOOR_ROWS.map((row) => [row.stage, pick(row)])) as Record<ArrivalStage, number>;
+
+export const OPS_FIXTURE_ARRIVALS: ArrivalsSnapshot = {
+  schemaVersion: "averray.arrivals.v1",
+  generatedAtMs: FIXTURE_NOW - 1 * MIN,
+  observingSinceMs: FIXTURE_NOW - 9 * DAY,
+  // Legacy MCP-scoped counters, derived from the door table above.
+  funnel: stageRecord((r) => r.outsider + r.ours + r.unknown),
+  funnelExternal: stageRecord((r) => r.outsider),
+  funnelSelf: stageRecord((r) => r.ours),
+  distinct: { declared: 1, anonymous: 0, self: 0, furthest: "claimed", furthestExternal: "claimed" },
+  clients: [],
+  httpCutover: {
+    atMs: FIXTURE_NOW - 6 * DAY,
+    at: new Date(FIXTURE_NOW - 6 * DAY).toISOString(),
+    backfilled: false,
+    note: "HTTP arrivals are measured from this cut-over only; earlier HTTP traffic was not backfilled.",
+  },
+  operatorView: {
+    version: "averray.arrivals.operator.v1",
+    generatedAtMs: FIXTURE_NOW - 1 * MIN,
+    outsiders: {
+      furthestEver: {
+        window: "all-time",
+        stage: "settled",
+        atMs: FIXTURE_NOW - 6 * DAY,
+        door: "http",
+        agents: 1,
+        payouts: 52,
+        payoutWindow: "12h",
+        payoutSpanMs: 12 * HOUR,
+      },
+      lastActivity: { window: "all-time", atMs: FIXTURE_NOW - 3 * MIN, stage: "authenticated", door: "http" },
+      week: { window: "7d", identified: 18, worked: 16 },
+      postedWork: { window: "all-time", status: "observed", count: 3, firstAtMs: FIXTURE_NOW - 17 * DAY },
+    },
+    ours: {
+      day: { window: "24h", agents: 4, canaryRuns: 2, acceptanceRuns: 0, adminConsoleAgents: 1, operatorAgents: 1 },
+    },
+    unknown: { window: "all-time", sharedClientNames: 1, preSplitCalls: 455 },
+    doors: {
+      mcp: { window: "all-time", sinceMs: FIXTURE_NOW - 9 * DAY, rows: MCP_DOOR_ROWS },
+      http: {
+        window: "all-time",
+        sinceMs: FIXTURE_NOW - 6 * DAY,
+        rows: doorRows({
+          reached: [15_431, 829, 0],
+          browsed: [431, 2074, 0],
+          evaluated: [1973, 133, 0],
+          identified: [164, 35, 0],
+          authenticated: [164, 35, 0],
+          claimed: [162, 34, 0],
+          submitted: [162, 34, 0],
+        }),
+      },
     },
   },
 };

--- a/packages/monitor-ui/src/ops-preview.tsx
+++ b/packages/monitor-ui/src/ops-preview.tsx
@@ -22,6 +22,7 @@ import "./styles/hermes4-mobile.css";
 import { OpsBoard } from "./components/ops/OpsBoard.js";
 import { MobileBoard } from "./components/mobile/MobileBoard.js";
 import {
+  OPS_FIXTURE_ARRIVALS,
   OPS_FIXTURE_NOMINAL,
   OPS_FIXTURE_STRESS,
   OPS_FIXTURE_UNVERIFIED,
@@ -29,10 +30,17 @@ import {
   FIXTURE_NOW,
 } from "./lib/monitor/ops-fixtures.js";
 
+// The arrivals block is merged HERE rather than baked into the base fixtures:
+// the phone-board tests compose their own arrivals over OPS_FIXTURE_NOMINAL
+// and assert exact lane text, so the base fixtures stay arrivals-free while
+// the preview still exercises the OUTSIDERS visualization. LIVE keeps no
+// arrivals on purpose — that is the UNREACHABLE state.
+const withArrivals = (health: typeof OPS_FIXTURE_NOMINAL) => ({ ...health, arrivals: OPS_FIXTURE_ARRIVALS });
+
 const FIXTURES = {
-  nominal: { label: "FIG. 1 — Nominal", health: OPS_FIXTURE_NOMINAL, degraded: false },
-  stress: { label: "FIG. 2 — Stress", health: OPS_FIXTURE_STRESS, degraded: true },
-  unverified: { label: "Blind instrument", health: OPS_FIXTURE_UNVERIFIED, degraded: false },
+  nominal: { label: "FIG. 1 — Nominal", health: withArrivals(OPS_FIXTURE_NOMINAL), degraded: false },
+  stress: { label: "FIG. 2 — Stress", health: withArrivals(OPS_FIXTURE_STRESS), degraded: true },
+  unverified: { label: "Blind instrument", health: withArrivals(OPS_FIXTURE_UNVERIFIED), degraded: false },
   awaiting: { label: "Awaiting blocks", health: OPS_FIXTURE_LIVE, degraded: false },
 } as const;
 type FixtureKey = keyof typeof FIXTURES;

--- a/packages/monitor-ui/src/styles/hermes4-ops.css
+++ b/packages/monitor-ui/src/styles/hermes4-ops.css
@@ -1387,6 +1387,141 @@ body,
   color: var(--h4-muted);
   background: var(--h4-paper);
 }
+
+/* ---- OUTSIDERS — words beside marks ------------------------------
+   Left: the verdict lines (records, in words, with their windows).
+   Right: the wallet-journey ladders — the same instrumentation as
+   marks. Only wallet-unit rows are drawn ("at least this stage" is
+   monotonic, which is what makes bars honest); the pre-identity call
+   counters stay un-charted in the DOORS drawer. Fills are ink, not
+   sage: a count is not a verdict. */
+.ops-arrivals-verdict-body {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(calc(320 * var(--ops-u)), 42%);
+  gap: calc(6 * var(--ops-u)) calc(26 * var(--ops-u));
+  align-items: start;
+  margin-top: calc(6 * var(--ops-u));
+}
+.ops-arrivals-verdict-body > .ops-arrivals-verdict-lines { margin-top: 0; }
+.ops-arrivals-journey { min-width: 0; }
+.ops-arrivals-journey-head {
+  display: flex;
+  align-items: baseline;
+  gap: calc(10 * var(--ops-u));
+  flex-wrap: wrap;
+}
+.ops-arrivals-journey-head h4 {
+  margin: 0;
+  font-family: var(--h4-font-mono);
+  font-size: calc(9.5 * var(--ops-u));
+  font-weight: 600;
+  letter-spacing: 0.14em;
+  color: var(--h4-muted);
+}
+.ops-arrivals-journey-head span {
+  font-family: var(--h4-font-mono);
+  font-size: calc(8.5 * var(--ops-u));
+  color: var(--h4-tel);
+}
+.ops-arrivals-journey-doors {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: calc(16 * var(--ops-u));
+  margin-top: calc(6 * var(--ops-u));
+}
+.ops-ladder { min-width: 0; }
+.ops-ladder-head {
+  display: flex;
+  align-items: baseline;
+  gap: calc(8 * var(--ops-u));
+  padding-bottom: calc(3 * var(--ops-u));
+  border-bottom: 1px solid var(--ops-hair);
+}
+.ops-ladder-door {
+  font-family: var(--h4-font-display);
+  font-size: calc(11.5 * var(--ops-u));
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  color: var(--h4-ink);
+}
+.ops-ladder-since {
+  margin-left: auto;
+  font-family: var(--h4-font-mono);
+  font-size: calc(8.5 * var(--ops-u));
+  color: var(--h4-muted);
+}
+.ops-ladder-row {
+  display: grid;
+  grid-template-columns: calc(84 * var(--ops-u)) minmax(0, 1fr) calc(30 * var(--ops-u));
+  gap: calc(8 * var(--ops-u));
+  align-items: center;
+  padding: calc(3 * var(--ops-u)) 0;
+}
+.ops-ladder-stage {
+  font-family: var(--h4-font-mono);
+  font-size: calc(8.5 * var(--ops-u));
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--h4-muted);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.ops-ladder-track {
+  position: relative;
+  height: calc(7 * var(--ops-u));
+  border: 1px solid var(--ops-hair);
+  background: var(--h4-paper-sunken);
+}
+.ops-ladder-track i {
+  position: absolute;
+  inset: 0 auto 0 0;
+  background: var(--h4-ink-2);
+}
+.ops-ladder-count {
+  font-family: var(--h4-font-mono);
+  font-size: calc(10.5 * var(--ops-u));
+  text-align: right;
+  color: var(--h4-ink);
+}
+.ops-ladder-absent {
+  margin: calc(6 * var(--ops-u)) 0 0;
+  font-family: var(--h4-font-mono);
+  font-size: calc(9 * var(--ops-u));
+  color: var(--h4-tel);
+}
+
+/* Recency rungs — fixed bands, the snapshot's own clock. The active band is
+   inked, the rest stay hairline: one marker on a scale that never moves. */
+.ops-recency {
+  display: inline-flex;
+  gap: calc(3 * var(--ops-u));
+  margin-top: calc(5 * var(--ops-u));
+}
+.ops-recency i {
+  padding: calc(1 * var(--ops-u)) calc(7 * var(--ops-u));
+  border: 1px solid var(--ops-hair);
+  font-family: var(--h4-font-mono);
+  font-size: calc(8 * var(--ops-u));
+  font-style: normal;
+  letter-spacing: 0.06em;
+  color: var(--h4-muted);
+}
+.ops-recency i[data-active="yes"] {
+  border-color: var(--h4-line-strong);
+  background: var(--h4-tel-chip);
+  color: var(--h4-ink);
+}
+
+/* The 7d pair — two bars, one shared scale, deliberately NOT nested. */
+.ops-weekpair {
+  display: grid;
+  gap: calc(2 * var(--ops-u));
+  margin-top: calc(5 * var(--ops-u));
+  max-width: calc(260 * var(--ops-u));
+}
+.ops-weekpair i { display: block; height: calc(5 * var(--ops-u)); background: var(--h4-ink-2); }
+.ops-weekpair i[data-kind="worked"] { opacity: 0.68; }
 .ops-arrivals-secondary {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
@@ -1832,6 +1967,7 @@ body,
   .ops-arrivals > .ops-panel-head,
   .ops-arrivals-unattributed,
   .ops-arrivals-unreachable { grid-column: auto; }
+  .ops-arrivals-verdict-body { grid-template-columns: minmax(0, 1fr); }
   .ops-pillars { grid-template-columns: repeat(2, 1fr); }
   .ops-pillar:nth-child(3) { border-left: 0; }
   /* Fifth column: on the two-column layout the incident log takes a full row

--- a/packages/monitor-ui/src/styles/hermes4-ops.css
+++ b/packages/monitor-ui/src/styles/hermes4-ops.css
@@ -1306,13 +1306,13 @@ body,
 }
 /* The OUTSIDERS edge was a permanent 3px sage rail — a health colour on a
    panel that reports demand, lit regardless of what the panel said. Green
-   that cannot go out is decoration wearing a status colour; the edge is now
-   neutral and tone stays with the readings themselves. */
+   that cannot go out is decoration wearing a status colour. In the kit
+   grammar the KPI cards carry their own framing, so the section keeps one
+   plain hairline and no accent edge at all. */
 .ops-arrivals-verdict {
   padding: calc(9 * var(--ops-u)) calc(12 * var(--ops-u));
   border: 1px solid var(--ops-rule);
-  border-left: 3px solid var(--h4-line-strong);
-  background: var(--h4-paper-sunken);
+  border-radius: 10px;
 }
 .ops-arrivals-block-head {
   display: flex;
@@ -1388,140 +1388,180 @@ body,
   background: var(--h4-paper);
 }
 
-/* ---- OUTSIDERS — words beside marks ------------------------------
-   Left: the verdict lines (records, in words, with their windows).
-   Right: the wallet-journey ladders — the same instrumentation as
-   marks. Only wallet-unit rows are drawn ("at least this stage" is
-   monotonic, which is what makes bars honest); the pre-identity call
-   counters stay un-charted in the DOORS drawer. Fills are ink, not
-   sage: a count is not a verdict. */
-.ops-arrivals-verdict-body {
+/* ---- OUTSIDERS — operator-kit grammar --------------------------
+   Records as KPI cards (uppercase display eyebrow · one large display
+   value · mono provenance), the wallet journey as the kit's table
+   pattern, OURS / UNKNOWN as pills. Composed from the Averray design
+   system's operator UI kit, expressed in the board's --h4 tokens so
+   every color profile keeps working. Fills are ink, not sage: a count
+   is not a verdict. */
+.ops-arrivals-kpis {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) minmax(calc(320 * var(--ops-u)), 42%);
-  gap: calc(6 * var(--ops-u)) calc(26 * var(--ops-u));
-  align-items: start;
-  margin-top: calc(6 * var(--ops-u));
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: calc(10 * var(--ops-u));
+  margin-top: calc(8 * var(--ops-u));
 }
-.ops-arrivals-verdict-body > .ops-arrivals-verdict-lines { margin-top: 0; }
-.ops-arrivals-journey { min-width: 0; }
-.ops-arrivals-journey-head {
+.ops-kpi {
+  display: grid;
+  gap: calc(6 * var(--ops-u));
+  align-content: start;
+  padding: calc(11 * var(--ops-u)) calc(13 * var(--ops-u));
+  border: 1px solid var(--ops-hair);
+  border-radius: 10px;
+  background: var(--h4-paper-sunken);
+}
+.ops-kpi-lbl {
+  font-family: var(--h4-font-display);
+  font-size: calc(9.5 * var(--ops-u));
+  font-weight: 800;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--h4-muted);
+}
+.ops-kpi-val {
+  display: inline-flex;
+  align-items: baseline;
+  gap: calc(6 * var(--ops-u));
+  font-family: var(--h4-font-display);
+  font-weight: 700;
+  font-size: calc(23 * var(--ops-u));
+  line-height: 1.05;
+  color: var(--h4-ink);
+}
+.ops-kpi-word {
+  font-size: calc(10.5 * var(--ops-u));
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  color: var(--h4-muted);
+}
+/* Provenance figures inside a card: mono, quiet, badge riding along. */
+.ops-kpi .ops-arrivals-figure {
+  font-family: var(--h4-font-mono);
+  font-size: calc(10 * var(--ops-u));
+  line-height: 1.5;
+  color: var(--h4-muted);
+}
+.ops-kpi .ops-arrivals-figure .ops-kpi-val { color: var(--h4-ink); }
+
+/* ---- the wallet journey — the kit's table pattern ---------------- */
+.ops-journey {
+  margin-top: calc(10 * var(--ops-u));
+  border: 1px solid var(--ops-hair);
+  border-radius: 10px;
+  overflow: hidden;
+  background: var(--h4-paper-sunken);
+}
+.ops-journey-head {
   display: flex;
   align-items: baseline;
   gap: calc(10 * var(--ops-u));
   flex-wrap: wrap;
+  padding: calc(7 * var(--ops-u)) calc(13 * var(--ops-u));
+  border-bottom: 1px solid var(--ops-hair);
 }
-.ops-arrivals-journey-head h4 {
+.ops-journey-head h4 {
   margin: 0;
-  font-family: var(--h4-font-mono);
-  font-size: calc(9.5 * var(--ops-u));
-  font-weight: 600;
-  letter-spacing: 0.14em;
-  color: var(--h4-muted);
+  font-family: var(--h4-font-display);
+  font-size: calc(11 * var(--ops-u));
+  font-weight: 800;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--h4-ink);
 }
-.ops-arrivals-journey-head span {
+.ops-journey-head span {
+  margin-left: auto;
   font-family: var(--h4-font-mono);
   font-size: calc(8.5 * var(--ops-u));
   color: var(--h4-tel);
 }
-.ops-arrivals-journey-doors {
+.ops-journey-grid { padding: calc(2 * var(--ops-u)) calc(13 * var(--ops-u)) calc(9 * var(--ops-u)); }
+.ops-journey-row {
   display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
+  grid-template-columns: calc(100 * var(--ops-u)) repeat(2, minmax(0, 1fr));
   gap: calc(16 * var(--ops-u));
-  margin-top: calc(6 * var(--ops-u));
+  align-items: center;
+  padding: calc(4 * var(--ops-u)) 0;
 }
-.ops-ladder { min-width: 0; }
-.ops-ladder-head {
-  display: flex;
-  align-items: baseline;
-  gap: calc(8 * var(--ops-u));
-  padding-bottom: calc(3 * var(--ops-u));
+.ops-journey-row--head {
+  padding: calc(6 * var(--ops-u)) 0;
   border-bottom: 1px solid var(--ops-hair);
 }
-.ops-ladder-door {
+.ops-journey-row--head [role="columnheader"] {
   font-family: var(--h4-font-display);
-  font-size: calc(11.5 * var(--ops-u));
-  font-weight: 600;
-  letter-spacing: 0.08em;
-  color: var(--h4-ink);
-}
-.ops-ladder-since {
-  margin-left: auto;
-  font-family: var(--h4-font-mono);
-  font-size: calc(8.5 * var(--ops-u));
+  font-size: calc(10 * var(--ops-u));
+  font-weight: 800;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
   color: var(--h4-muted);
 }
-.ops-ladder-row {
-  display: grid;
-  grid-template-columns: calc(84 * var(--ops-u)) minmax(0, 1fr) calc(30 * var(--ops-u));
-  gap: calc(8 * var(--ops-u));
-  align-items: center;
-  padding: calc(3 * var(--ops-u)) 0;
+.ops-journey-door {
+  display: flex;
+  align-items: baseline;
+  gap: calc(7 * var(--ops-u));
 }
-.ops-ladder-stage {
+.ops-journey-door small {
   font-family: var(--h4-font-mono);
-  font-size: calc(8.5 * var(--ops-u));
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
+  font-size: calc(8 * var(--ops-u));
+  font-weight: 400;
+  letter-spacing: 0;
+  text-transform: none;
+  color: var(--h4-muted);
+}
+.ops-journey-stage {
+  font-family: var(--h4-font-mono);
+  font-size: calc(9.5 * var(--ops-u));
   color: var(--h4-muted);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
-.ops-ladder-track {
-  position: relative;
-  height: calc(7 * var(--ops-u));
-  border: 1px solid var(--ops-hair);
-  background: var(--h4-paper-sunken);
+.ops-journey-cell {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) calc(32 * var(--ops-u));
+  gap: calc(8 * var(--ops-u));
+  align-items: center;
 }
-.ops-ladder-track i {
-  position: absolute;
-  inset: 0 auto 0 0;
+.ops-journey-fill { display: block; min-width: 0; }
+.ops-journey-fill i {
+  display: block;
+  height: calc(6 * var(--ops-u));
+  border-radius: 3px;
   background: var(--h4-ink-2);
+  opacity: 0.5;
 }
-.ops-ladder-count {
+.ops-journey-cell b {
   font-family: var(--h4-font-mono);
-  font-size: calc(10.5 * var(--ops-u));
+  font-size: calc(11 * var(--ops-u));
+  font-weight: 600;
   text-align: right;
   color: var(--h4-ink);
 }
-.ops-ladder-absent {
-  margin: calc(6 * var(--ops-u)) 0 0;
+.ops-journey-cell .ops-journey-none { color: var(--h4-tel); font-weight: 400; }
+.ops-journey-absent {
+  margin: 0;
+  padding: calc(9 * var(--ops-u)) calc(13 * var(--ops-u));
   font-family: var(--h4-font-mono);
   font-size: calc(9 * var(--ops-u));
   color: var(--h4-tel);
 }
 
-/* Recency rungs — fixed bands, the snapshot's own clock. The active band is
-   inked, the rest stay hairline: one marker on a scale that never moves. */
-.ops-recency {
-  display: inline-flex;
-  gap: calc(3 * var(--ops-u));
-  margin-top: calc(5 * var(--ops-u));
-}
-.ops-recency i {
-  padding: calc(1 * var(--ops-u)) calc(7 * var(--ops-u));
+/* ---- OURS / UNKNOWN as pills ------------------------------------
+   The kit carries operational counts in pills, not prose: 999px, soft
+   neutral wash, uppercase display type. Neutral on purpose — none of
+   these counts are demand, and none are health. */
+.ops-arrivals-figures .ops-arrivals-figure {
+  padding: calc(3 * var(--ops-u)) calc(10 * var(--ops-u));
   border: 1px solid var(--ops-hair);
-  font-family: var(--h4-font-mono);
-  font-size: calc(8 * var(--ops-u));
-  font-style: normal;
-  letter-spacing: 0.06em;
-  color: var(--h4-muted);
-}
-.ops-recency i[data-active="yes"] {
-  border-color: var(--h4-line-strong);
+  border-radius: 999px;
   background: var(--h4-tel-chip);
-  color: var(--h4-ink);
+  font-family: var(--h4-font-display);
+  font-size: calc(9.5 * var(--ops-u));
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--h4-ink-2);
 }
-
-/* The 7d pair — two bars, one shared scale, deliberately NOT nested. */
-.ops-weekpair {
-  display: grid;
-  gap: calc(2 * var(--ops-u));
-  margin-top: calc(5 * var(--ops-u));
-  max-width: calc(260 * var(--ops-u));
-}
-.ops-weekpair i { display: block; height: calc(5 * var(--ops-u)); background: var(--h4-ink-2); }
-.ops-weekpair i[data-kind="worked"] { opacity: 0.68; }
+.ops-arrivals-unknown .ops-arrivals-figures .ops-arrivals-figure { color: var(--h4-tel); }
 .ops-arrivals-secondary {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
@@ -1967,7 +2007,7 @@ body,
   .ops-arrivals > .ops-panel-head,
   .ops-arrivals-unattributed,
   .ops-arrivals-unreachable { grid-column: auto; }
-  .ops-arrivals-verdict-body { grid-template-columns: minmax(0, 1fr); }
+  .ops-arrivals-kpis { grid-template-columns: repeat(2, minmax(0, 1fr)); }
   .ops-pillars { grid-template-columns: repeat(2, 1fr); }
   .ops-pillar:nth-child(3) { border-left: 0; }
   /* Fifth column: on the two-column layout the incident log takes a full row


### PR DESCRIPTION
## What

A focused redesign of the ARRIVALS section, composed from the **Averray Design System** project (its `SKILL.md` + operator UI kit) rather than ad-hoc board styling, translated into the board's `--h4` tokens so every color profile keeps working.

**The kit patterns applied**
- **OUTSIDERS records → KPI cards** (the kit's dashboard strip): uppercase display eyebrow, one large display value, mono provenance line, window badge riding every figure. FURTHEST EVER `SETTLED`, LAST ACTIVITY `2m ago`, THIS WEEK `18 identified · 16 worked`, POSTED WORK `3 POSTED`.
- **Wallet journey → the kit's table pattern**: one row per wallet stage, one column per door (`MCP` / `HTTP`, each with its own `since` date + window badge), a thin ink fill behind each count.
- **OURS / UNKNOWN → the kit's pills**: 999px, neutral wash, uppercase display type — deliberately neutral because none of these counts are demand and none are health.

**The registry design's lines all hold**
- Only rows the producer declares in the `agents` unit are drawn — distinct SIWE wallets reaching *at least* each stage, monotonic by construction, which is what makes a fill honest. The pre-identity call counters (reached/browsed/evaluated) stay un-charted in the DOORS drawer.
- Each door fills against its **own** busiest stage; doors never sum, and the caption says so on screen.
- A stage a door never reported is a dash, not a zero; a zero keeps its row and draws no fill.
- Fills are ink, not sage — a count is not a verdict.
- `UNREACHABLE` and `VERDICT VIEW UNAVAILABLE` states unchanged.

**Fixture**: `OPS_FIXTURE_ARRIVALS` transcribes the live 2026-08-17 operator view (including the real asymmetry: one MCP wallet vs ~160 HTTP). Merged only by the preview harness — the phone tests compose their own arrivals, and the component source stays free of live literals (the design-handback guard test pins that).

## Contracts held

- All existing testids, window badges, DOORS drawer, and cut-over note unchanged; the furthest-ever assertion updated from one concatenated string to per-fact assertions (same facts, layout-independent).
- All sizes in `--ops-u`; no border in the scaled unit (ops-scaling/ops-overflow suites green).
- 494 tests green (34 files), `tsc -b` clean; verified in the preview harness against the live-shaped fixture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
