### PR TITLE
feat(board): Direction B — the midnight wall

### DIFF
--- a/packages/monitor-ui/src/components/ops/ArrivalsPanel.test.tsx
+++ b/packages/monitor-ui/src/components/ops/ArrivalsPanel.test.tsx
@@ -107,7 +107,10 @@ describe("ArrivalsPanel — verdict first", () => {
     const { getByTestId } = render(<ArrivalsPanel arrivals={snapshot()} />);
     const furthest = getByTestId("ops-arrivals-furthest-ever");
 
-    expect(furthest.textContent).toContain("SETTLED · 42 payouts in 12h · 2026-08-11 (HTTP)");
+    // KPI form: the record is the display value, the provenance is the mono
+    // sub-line — every fact from the feed still on the card, plus its window.
+    expect(furthest.textContent).toContain("SETTLED");
+    expect(furthest.textContent).toContain("42 payouts in 12h · 2026-08-11 (HTTP)");
     expect(furthest.textContent).toContain("ALL-TIME");
     expect(getByTestId("ops-arrivals-last-activity").textContent).toContain("5d ago");
   });
@@ -166,49 +169,30 @@ describe("ArrivalsPanel — verdict first", () => {
     expect(getByTestId("ops-arrivals-http-cutover").textContent).toBe(CUTOVER_NOTE);
   });
 
-  test("the wallet-journey ladders draw only the wallet-unit rows, per door", () => {
+  test("the wallet journey draws only the wallet-unit rows, per door", () => {
     const { getByTestId, queryByTestId } = render(<ArrivalsPanel arrivals={snapshot()} />);
 
-    // The HTTP door's wallet rows become bars with their counts…
-    const identified = getByTestId("ops-arrivals-ladder-http-identified");
-    expect(identified.textContent).toContain("identified");
+    // The HTTP door's wallet rows become cells with a fill and their count…
+    const identified = getByTestId("ops-arrivals-journey-http-identified");
     expect(identified.textContent).toContain("3");
-    expect(identified.querySelector(".ops-ladder-track i")).not.toBeNull();
-    // …the 1730-call evaluated counter must NOT have become a ladder row.
-    expect(queryByTestId("ops-arrivals-ladder-http-evaluated")).toBeNull();
-    expect(queryByTestId("ops-arrivals-ladder-http-reached")).toBeNull();
+    expect(identified.querySelector(".ops-journey-fill i")).not.toBeNull();
+    // …the 1730-call evaluated counter must NOT have become a journey row.
+    expect(queryByTestId("ops-arrivals-journey-evaluated")).toBeNull();
+    expect(queryByTestId("ops-arrivals-journey-reached")).toBeNull();
 
-    // A zero-wallet stage keeps its row and its 0, but draws no fill.
-    const mcpIdentified = getByTestId("ops-arrivals-ladder-mcp-identified");
+    // A zero-wallet stage keeps its cell and its 0, but draws no fill.
+    const mcpIdentified = getByTestId("ops-arrivals-journey-mcp-identified");
     expect(mcpIdentified.textContent).toContain("0");
-    expect(mcpIdentified.querySelector(".ops-ladder-track i")).toBeNull();
+    expect(mcpIdentified.querySelector(".ops-journey-fill i")).toBeNull();
   });
 
-  test("the recency strip marks one fixed band from the snapshot clock", () => {
-    const { getByTestId } = render(<ArrivalsPanel arrivals={snapshot()} />);
-    // HISTORICAL_AT is 5 days before GENERATED_AT → the <7d band.
-    const strip = getByTestId("ops-arrivals-recency");
-    expect(strip.getAttribute("data-band")).toBe("7d");
-    expect(strip.querySelectorAll('[data-active="yes"]').length).toBe(1);
-  });
-
-  test("no outsider activity ever → no recency strip at all", () => {
+  test("no outsider activity ever stays a named absence on the KPI card", () => {
     const none = snapshot();
     if (none.operatorView && !("unavailable" in none.operatorView)) {
       none.operatorView.outsiders.lastActivity = null;
     }
-    const { queryByTestId, getByTestId } = render(<ArrivalsPanel arrivals={none} />);
-    expect(queryByTestId("ops-arrivals-recency")).toBeNull();
+    const { getByTestId } = render(<ArrivalsPanel arrivals={none} />);
     expect(getByTestId("ops-arrivals-last-activity").textContent).toContain("NO IDENTIFIED OUTSIDER ACTIVITY YET");
-  });
-
-  test("a zero week draws no bars — the words carry the zero", () => {
-    const quiet = snapshot();
-    if (quiet.operatorView && !("unavailable" in quiet.operatorView)) {
-      quiet.operatorView.outsiders.week = { window: "7d", identified: 0, worked: 0 };
-    }
-    const { queryByTestId } = render(<ArrivalsPanel arrivals={quiet} />);
-    expect(queryByTestId("ops-arrivals-weekpair")).toBeNull();
   });
 
   test("an older producer is a named missing verdict, never a reconstructed zero", () => {

--- a/packages/monitor-ui/src/components/ops/ArrivalsPanel.test.tsx
+++ b/packages/monitor-ui/src/components/ops/ArrivalsPanel.test.tsx
@@ -166,6 +166,51 @@ describe("ArrivalsPanel — verdict first", () => {
     expect(getByTestId("ops-arrivals-http-cutover").textContent).toBe(CUTOVER_NOTE);
   });
 
+  test("the wallet-journey ladders draw only the wallet-unit rows, per door", () => {
+    const { getByTestId, queryByTestId } = render(<ArrivalsPanel arrivals={snapshot()} />);
+
+    // The HTTP door's wallet rows become bars with their counts…
+    const identified = getByTestId("ops-arrivals-ladder-http-identified");
+    expect(identified.textContent).toContain("identified");
+    expect(identified.textContent).toContain("3");
+    expect(identified.querySelector(".ops-ladder-track i")).not.toBeNull();
+    // …the 1730-call evaluated counter must NOT have become a ladder row.
+    expect(queryByTestId("ops-arrivals-ladder-http-evaluated")).toBeNull();
+    expect(queryByTestId("ops-arrivals-ladder-http-reached")).toBeNull();
+
+    // A zero-wallet stage keeps its row and its 0, but draws no fill.
+    const mcpIdentified = getByTestId("ops-arrivals-ladder-mcp-identified");
+    expect(mcpIdentified.textContent).toContain("0");
+    expect(mcpIdentified.querySelector(".ops-ladder-track i")).toBeNull();
+  });
+
+  test("the recency strip marks one fixed band from the snapshot clock", () => {
+    const { getByTestId } = render(<ArrivalsPanel arrivals={snapshot()} />);
+    // HISTORICAL_AT is 5 days before GENERATED_AT → the <7d band.
+    const strip = getByTestId("ops-arrivals-recency");
+    expect(strip.getAttribute("data-band")).toBe("7d");
+    expect(strip.querySelectorAll('[data-active="yes"]').length).toBe(1);
+  });
+
+  test("no outsider activity ever → no recency strip at all", () => {
+    const none = snapshot();
+    if (none.operatorView && !("unavailable" in none.operatorView)) {
+      none.operatorView.outsiders.lastActivity = null;
+    }
+    const { queryByTestId, getByTestId } = render(<ArrivalsPanel arrivals={none} />);
+    expect(queryByTestId("ops-arrivals-recency")).toBeNull();
+    expect(getByTestId("ops-arrivals-last-activity").textContent).toContain("NO IDENTIFIED OUTSIDER ACTIVITY YET");
+  });
+
+  test("a zero week draws no bars — the words carry the zero", () => {
+    const quiet = snapshot();
+    if (quiet.operatorView && !("unavailable" in quiet.operatorView)) {
+      quiet.operatorView.outsiders.week = { window: "7d", identified: 0, worked: 0 };
+    }
+    const { queryByTestId } = render(<ArrivalsPanel arrivals={quiet} />);
+    expect(queryByTestId("ops-arrivals-weekpair")).toBeNull();
+  });
+
   test("an older producer is a named missing verdict, never a reconstructed zero", () => {
     const older = snapshot({ operatorView: undefined });
     const { getByTestId, queryByTestId } = render(<ArrivalsPanel arrivals={older} />);

--- a/packages/monitor-ui/src/components/ops/ArrivalsPanel.tsx
+++ b/packages/monitor-ui/src/components/ops/ArrivalsPanel.tsx
@@ -1,16 +1,18 @@
 // ARRIVALS — the operator verdict first, raw transport counters second.
 //
+// Visual grammar per the Averray design system's operator kit (the design
+// project's SKILL.md): records render as KPI cards — uppercase display
+// eyebrow, one large display value, mono sub-line; instrumentation renders as
+// a table; OURS / UNKNOWN counts are status pills; identifiers stay mono.
+// Translated onto the board's --h4 tokens so every color profile keeps
+// working.
+//
 // The backend owns identity joins, historical payout evidence, and windows.
 // This component never recovers a verdict from the legacy call funnels: doing
 // so would make canaries look like demand and compare unlike instrumentation.
 
 import { formatAgo } from "../../lib/monitor/ops-model.js";
-import {
-  RECENCY_BANDS,
-  doorLadders,
-  recencyBand,
-  weekPair,
-} from "../../lib/monitor/arrivals-view.js";
+import { doorJourneys } from "../../lib/monitor/arrivals-view.js";
 import type {
   ArrivalOperatorView,
   ArrivalOperatorDoorRow,
@@ -36,6 +38,8 @@ export function ArrivalsPanel({ arrivals }: ArrivalsPanelProps) {
   }
 
   const { outsiders, ours, unknown, generatedAtMs } = operatorView;
+  const furthest = outsiders.furthestEver;
+  const last = outsiders.lastActivity;
   return (
     <section className="ops-arrivals" aria-label="Arrivals — who is actually showing up" data-testid="ops-arrivals">
       <header className="ops-panel-head">
@@ -48,44 +52,69 @@ export function ArrivalsPanel({ arrivals }: ArrivalsPanelProps) {
           <h3>OUTSIDERS</h3>
           <span>the only demand signal</span>
         </div>
-        {/* Two halves of one answer: the verdict lines (records and windows,
-            in words) and the wallet-journey ladders (the same instrumentation
-            as marks). The ladders draw ONLY the wallet-unit rows — the
-            pre-identity call counters stay un-charted in the DOORS drawer,
-            where their unlike instruments are labelled. */}
-        <div className="ops-arrivals-verdict-body">
-          <dl className="ops-arrivals-verdict-lines">
-            <VerdictLine label="furthest ever" testId="ops-arrivals-furthest-ever">
-              <Figure window={outsiders.furthestEver?.window ?? "all-time"} testId="ops-arrivals-figure-furthest">
-                {formatFurthest(outsiders.furthestEver)}
-              </Figure>
-            </VerdictLine>
-            <VerdictLine label="last activity" testId="ops-arrivals-last-activity">
-              <Figure window={outsiders.lastActivity?.window ?? "all-time"} testId="ops-arrivals-figure-last">
-                {formatLastActivity(outsiders.lastActivity, generatedAtMs)}
-              </Figure>
-              <RecencyStrip atMs={outsiders.lastActivity?.atMs ?? null} generatedAtMs={generatedAtMs} />
-            </VerdictLine>
-            <VerdictLine label="this week" testId="ops-arrivals-this-week">
-              <span className="ops-arrivals-pair">
-                <Figure window={outsiders.week.window} testId="ops-arrivals-figure-week-identified">
-                  {outsiders.week.identified} identified
+
+        {/* The four records, as KPI cards. The value is the record; the mono
+            sub-line is its provenance (count, date, door); the window badge
+            rides every figure, exactly as before. */}
+        <div className="ops-arrivals-kpis">
+          <Kpi label="FURTHEST EVER" testId="ops-arrivals-furthest-ever">
+            {furthest ? (
+              <>
+                <span className="ops-kpi-val">{furthest.stage.toUpperCase()}</span>
+                <Figure window={furthest.window} testId="ops-arrivals-figure-furthest">
+                  {furthestSub(furthest)}
                 </Figure>
-                <span aria-hidden>·</span>
-                <Figure window={outsiders.week.window} testId="ops-arrivals-figure-week-worked">
-                  {outsiders.week.worked} worked
+              </>
+            ) : (
+              <Figure window="all-time" testId="ops-arrivals-figure-furthest">
+                NO IDENTIFIED OUTSIDER YET
+              </Figure>
+            )}
+          </Kpi>
+
+          <Kpi label="LAST ACTIVITY" testId="ops-arrivals-last-activity">
+            {last ? (
+              <>
+                <span className="ops-kpi-val">{formatAgo(last.atMs, generatedAtMs)}</span>
+                <Figure window={last.window} testId="ops-arrivals-figure-last">
+                  {last.stage} ({last.door.toUpperCase()})
                 </Figure>
-              </span>
-              <WeekBars week={outsiders.week} />
-            </VerdictLine>
-            <VerdictLine label="posted work" testId="ops-arrivals-posted-work">
+              </>
+            ) : (
+              <Figure window="all-time" testId="ops-arrivals-figure-last">
+                NO IDENTIFIED OUTSIDER ACTIVITY YET
+              </Figure>
+            )}
+          </Kpi>
+
+          <Kpi label="THIS WEEK" testId="ops-arrivals-this-week">
+            <Figure window={outsiders.week.window} testId="ops-arrivals-figure-week-identified">
+              <span className="ops-kpi-val">{outsiders.week.identified}</span> identified
+            </Figure>
+            <Figure window={outsiders.week.window} testId="ops-arrivals-figure-week-worked">
+              {outsiders.week.worked} worked
+            </Figure>
+          </Kpi>
+
+          <Kpi label="POSTED WORK" testId="ops-arrivals-posted-work">
+            {outsiders.postedWork.status === "observed" ? (
+              <>
+                <span className="ops-kpi-val">
+                  {outsiders.postedWork.count ?? 0} <span className="ops-kpi-word">POSTED</span>
+                </span>
+                <Figure window={outsiders.postedWork.window} testId="ops-arrivals-figure-posted">
+                  FIRST {formatDate(outsiders.postedWork.firstAtMs)}
+                </Figure>
+              </>
+            ) : (
               <Figure window={outsiders.postedWork.window} testId="ops-arrivals-figure-posted">
-                {formatPostedWork(outsiders.postedWork)}
+                {outsiders.postedWork.status === "never" ? "NEVER — THE OPEN GATE" : "UNKNOWN — JOB CATALOGUE UNREADABLE"}
               </Figure>
-            </VerdictLine>
-          </dl>
-          <JourneyLadders view={operatorView} />
+            )}
+          </Kpi>
         </div>
+
+        <JourneyPanel view={operatorView} />
       </section>
 
       <div className="ops-arrivals-secondary">
@@ -159,109 +188,96 @@ function Unavailable({ reason, label = "UNREACHABLE" }: { reason: string; label?
   );
 }
 
-function VerdictLine({ label, testId, children }: { label: string; testId: string; children: React.ReactNode }) {
+/** One record card: uppercase eyebrow, then whatever the record renders. */
+function Kpi({ label, testId, children }: { label: string; testId: string; children: React.ReactNode }) {
   return (
-    <div data-testid={testId}>
-      <dt>{label}</dt>
-      <dd>{children}</dd>
+    <div className="ops-kpi" data-testid={testId}>
+      <span className="ops-kpi-lbl">{label}</span>
+      {children}
     </div>
   );
 }
 
+/** The furthest-ever provenance sub-line: burst, date, door. */
+function furthestSub(reading: NonNullable<ArrivalOperatorView["outsiders"]["furthestEver"]>): string {
+  const burst =
+    reading.payouts === undefined ? "" : `${reading.payouts} payouts in ${reading.payoutWindow ?? "the measured burst"} · `;
+  return `${burst}${formatDate(reading.atMs)} (${reading.door.toUpperCase()})`;
+}
+
 /**
- * The wallet-journey ladders — one per door, never summed, never compared.
+ * The wallet journey, as the kit's table pattern — one row per wallet stage,
+ * one column per door.
  *
  * Only rows the producer declared in the `agents` unit are drawn: distinct
- * SIWE wallets reaching AT LEAST each stage, which is monotonic by
- * construction and therefore honest as bars. Each door fills against its OWN
- * busiest stage, so a 1-wallet MCP door and a 160-wallet HTTP door are both
- * legible without the widths implying a comparison the windows cannot support.
+ * SIWE wallets reaching AT LEAST each stage, monotonic by construction, which
+ * is what makes the fill behind each count honest. Each door fills against
+ * its OWN busiest stage — a 1-wallet MCP door and a 160-wallet HTTP door are
+ * both legible without the widths implying a comparison the windows cannot
+ * support. The pre-identity call counters stay un-charted in the DOORS drawer.
  */
-function JourneyLadders({ view }: { view: ArrivalOperatorView }) {
-  const doors = doorLadders(view);
+function JourneyPanel({ view }: { view: ArrivalOperatorView }) {
+  const doors = doorJourneys(view);
+  // Row spine: every wallet stage any door reported, in producer order.
+  const stageOrder = doors.flatMap((d) => d.stages.map((s) => s.stage)).filter((s, i, all) => all.indexOf(s) === i);
+
   return (
-    <div className="ops-arrivals-journey" data-testid="ops-arrivals-journey">
-      <div className="ops-arrivals-journey-head">
+    <div className="ops-journey" data-testid="ops-arrivals-journey">
+      <div className="ops-journey-head">
         <h4>WALLET JOURNEY</h4>
         <span>wallets reaching at least each stage · each door on its own scale · doors never sum</span>
       </div>
-      <div className="ops-arrivals-journey-doors">
-        {doors.map((door) => (
-          <div className="ops-ladder" key={door.door} data-testid={`ops-arrivals-ladder-${door.door}`}>
-            <div className="ops-ladder-head">
-              <span className="ops-ladder-door">{door.label}</span>
-              <span className="ops-ladder-since">since {formatDate(door.sinceMs)}</span>
-              <WindowBadge window={door.window} />
-            </div>
-            {door.stages.length === 0 ? (
-              <p className="ops-ladder-absent">no wallet-stage rows reported for this door</p>
-            ) : (
-              door.stages.map((s) => (
-                <div
-                  className="ops-ladder-row"
-                  key={s.stage}
-                  data-testid={`ops-arrivals-ladder-${door.door}-${s.stage}`}
-                >
-                  <span className="ops-ladder-stage">{s.stage}</span>
-                  <span className="ops-ladder-track" aria-hidden>
-                    {/* Zero draws NO fill — the min-width that keeps one wallet
-                        visible must never invent one. */}
-                    {s.fillPct > 0 ? <i style={{ width: `${s.fillPct}%` }} /> : null}
-                  </span>
-                  <span className="ops-ladder-count">{s.count}</span>
-                </div>
-              ))
-            )}
+      {stageOrder.length === 0 ? (
+        <p className="ops-journey-absent" data-testid="ops-arrivals-journey-absent">
+          no wallet-stage rows reported by either door
+        </p>
+      ) : (
+        <div className="ops-journey-grid" role="table" aria-label="Outsider wallets by stage, per door">
+          <div className="ops-journey-row ops-journey-row--head" role="row">
+            <span role="columnheader" className="ops-journey-stage-head">
+              stage
+            </span>
+            {doors.map((door) => (
+              <span role="columnheader" className="ops-journey-door" key={door.door}>
+                {door.label}
+                <small>since {formatDate(door.sinceMs)}</small>
+                <WindowBadge window={door.window} />
+              </span>
+            ))}
           </div>
-        ))}
-      </div>
+          {stageOrder.map((stage) => (
+            <div className="ops-journey-row" role="row" key={stage} data-testid={`ops-arrivals-journey-${stage}`}>
+              <span role="cell" className="ops-journey-stage">
+                {stage}
+              </span>
+              {doors.map((door) => {
+                const reading = door.stages.find((s) => s.stage === stage);
+                return (
+                  <span
+                    role="cell"
+                    className="ops-journey-cell"
+                    key={door.door}
+                    data-testid={`ops-arrivals-journey-${door.door}-${stage}`}
+                  >
+                    {/* A stage this door never reported is a dash, not a zero. */}
+                    {reading ? (
+                      <>
+                        <span className="ops-journey-fill" aria-hidden>
+                          {reading.fillPct > 0 ? <i style={{ width: `${reading.fillPct}%` }} /> : null}
+                        </span>
+                        <b>{reading.count}</b>
+                      </>
+                    ) : (
+                      <b className="ops-journey-none">—</b>
+                    )}
+                  </span>
+                );
+              })}
+            </div>
+          ))}
+        </div>
+      )}
     </div>
-  );
-}
-
-/**
- * Where in fixed time bands the last outsider activity sits. The bands are
- * rungs (1h / 24h / 7d), not a linear axis, and the clock is the snapshot's
- * own. No activity ever → nothing: an empty strip still looks like a reading.
- */
-function RecencyStrip({ atMs, generatedAtMs }: { atMs: number | null; generatedAtMs: number }) {
-  const band = recencyBand(atMs, generatedAtMs);
-  if (!band) return null;
-  return (
-    <span
-      className="ops-recency"
-      role="img"
-      aria-label={`last outsider activity falls in the ${band} band`}
-      data-band={band}
-      data-testid="ops-arrivals-recency"
-    >
-      {RECENCY_BANDS.map((b) => (
-        <i key={b.key} data-active={b.key === band ? "yes" : "no"}>
-          {b.label}
-        </i>
-      ))}
-    </span>
-  );
-}
-
-/**
- * The 7d identified/worked counts as two bars on ONE shared scale — beside
- * the words that carry the exact numbers. Not nested: nothing in the payload
- * proves worked ⊆ identified, so neither bar contains the other.
- */
-function WeekBars({ week }: { week: { identified: number; worked: number } }) {
-  const pair = weekPair(week);
-  if (!pair) return null;
-  return (
-    <span className="ops-weekpair" data-testid="ops-arrivals-weekpair" aria-hidden>
-      {/* A zero count gets no bar at all — the words beside carry the zero. */}
-      {pair.identified.fillPct > 0 ? (
-        <i data-kind="identified" title={`${pair.identified.count} identified (7d)`} style={{ width: `${pair.identified.fillPct}%` }} />
-      ) : null}
-      {pair.worked.fillPct > 0 ? (
-        <i data-kind="worked" title={`${pair.worked.count} worked (7d)`} style={{ width: `${pair.worked.fillPct}%` }} />
-      ) : null}
-    </span>
   );
 }
 
@@ -313,28 +329,6 @@ function DoorRow({ door, row, window }: { door: "mcp" | "http"; row: ArrivalOper
       ))}
     </div>
   );
-}
-
-function formatFurthest(reading: ArrivalOperatorView["outsiders"]["furthestEver"]): string {
-  if (!reading) return "NO IDENTIFIED OUTSIDER YET";
-  const payout = reading.payouts === undefined
-    ? ""
-    : ` · ${reading.payouts} payouts in ${reading.payoutWindow ?? "the measured burst"}`;
-  return `${reading.stage.toUpperCase()}${payout} · ${formatDate(reading.atMs)} (${reading.door.toUpperCase()})`;
-}
-
-function formatLastActivity(
-  reading: ArrivalOperatorView["outsiders"]["lastActivity"],
-  generatedAtMs: number,
-): string {
-  if (!reading) return "NO IDENTIFIED OUTSIDER ACTIVITY YET";
-  return `${formatAgo(reading.atMs, generatedAtMs)} · ${reading.stage} (${reading.door.toUpperCase()})`;
-}
-
-function formatPostedWork(reading: ArrivalOperatorView["outsiders"]["postedWork"]): string {
-  if (reading.status === "never") return "NEVER — THE OPEN GATE";
-  if (reading.status === "unknown") return "UNKNOWN — JOB CATALOGUE UNREADABLE";
-  return `${reading.count ?? 0} POSTED · FIRST ${formatDate(reading.firstAtMs)}`;
 }
 
 function formatDate(atMs: number | null): string {

--- a/packages/monitor-ui/src/components/ops/ArrivalsPanel.tsx
+++ b/packages/monitor-ui/src/components/ops/ArrivalsPanel.tsx
@@ -5,9 +5,15 @@
 // so would make canaries look like demand and compare unlike instrumentation.
 
 import { formatAgo } from "../../lib/monitor/ops-model.js";
+import {
+  RECENCY_BANDS,
+  doorLadders,
+  recencyBand,
+  weekPair,
+} from "../../lib/monitor/arrivals-view.js";
 import type {
-  ArrivalOperatorDoorRow,
   ArrivalOperatorView,
+  ArrivalOperatorDoorRow,
   ArrivalsBlock,
 } from "../../lib/monitor/product-health.js";
 
@@ -42,34 +48,44 @@ export function ArrivalsPanel({ arrivals }: ArrivalsPanelProps) {
           <h3>OUTSIDERS</h3>
           <span>the only demand signal</span>
         </div>
-        <dl className="ops-arrivals-verdict-lines">
-          <VerdictLine label="furthest ever" testId="ops-arrivals-furthest-ever">
-            <Figure window={outsiders.furthestEver?.window ?? "all-time"} testId="ops-arrivals-figure-furthest">
-              {formatFurthest(outsiders.furthestEver)}
-            </Figure>
-          </VerdictLine>
-          <VerdictLine label="last activity" testId="ops-arrivals-last-activity">
-            <Figure window={outsiders.lastActivity?.window ?? "all-time"} testId="ops-arrivals-figure-last">
-              {formatLastActivity(outsiders.lastActivity, generatedAtMs)}
-            </Figure>
-          </VerdictLine>
-          <VerdictLine label="this week" testId="ops-arrivals-this-week">
-            <span className="ops-arrivals-pair">
-              <Figure window={outsiders.week.window} testId="ops-arrivals-figure-week-identified">
-                {outsiders.week.identified} identified
+        {/* Two halves of one answer: the verdict lines (records and windows,
+            in words) and the wallet-journey ladders (the same instrumentation
+            as marks). The ladders draw ONLY the wallet-unit rows — the
+            pre-identity call counters stay un-charted in the DOORS drawer,
+            where their unlike instruments are labelled. */}
+        <div className="ops-arrivals-verdict-body">
+          <dl className="ops-arrivals-verdict-lines">
+            <VerdictLine label="furthest ever" testId="ops-arrivals-furthest-ever">
+              <Figure window={outsiders.furthestEver?.window ?? "all-time"} testId="ops-arrivals-figure-furthest">
+                {formatFurthest(outsiders.furthestEver)}
               </Figure>
-              <span aria-hidden>·</span>
-              <Figure window={outsiders.week.window} testId="ops-arrivals-figure-week-worked">
-                {outsiders.week.worked} worked
+            </VerdictLine>
+            <VerdictLine label="last activity" testId="ops-arrivals-last-activity">
+              <Figure window={outsiders.lastActivity?.window ?? "all-time"} testId="ops-arrivals-figure-last">
+                {formatLastActivity(outsiders.lastActivity, generatedAtMs)}
               </Figure>
-            </span>
-          </VerdictLine>
-          <VerdictLine label="posted work" testId="ops-arrivals-posted-work">
-            <Figure window={outsiders.postedWork.window} testId="ops-arrivals-figure-posted">
-              {formatPostedWork(outsiders.postedWork)}
-            </Figure>
-          </VerdictLine>
-        </dl>
+              <RecencyStrip atMs={outsiders.lastActivity?.atMs ?? null} generatedAtMs={generatedAtMs} />
+            </VerdictLine>
+            <VerdictLine label="this week" testId="ops-arrivals-this-week">
+              <span className="ops-arrivals-pair">
+                <Figure window={outsiders.week.window} testId="ops-arrivals-figure-week-identified">
+                  {outsiders.week.identified} identified
+                </Figure>
+                <span aria-hidden>·</span>
+                <Figure window={outsiders.week.window} testId="ops-arrivals-figure-week-worked">
+                  {outsiders.week.worked} worked
+                </Figure>
+              </span>
+              <WeekBars week={outsiders.week} />
+            </VerdictLine>
+            <VerdictLine label="posted work" testId="ops-arrivals-posted-work">
+              <Figure window={outsiders.postedWork.window} testId="ops-arrivals-figure-posted">
+                {formatPostedWork(outsiders.postedWork)}
+              </Figure>
+            </VerdictLine>
+          </dl>
+          <JourneyLadders view={operatorView} />
+        </div>
       </section>
 
       <div className="ops-arrivals-secondary">
@@ -149,6 +165,103 @@ function VerdictLine({ label, testId, children }: { label: string; testId: strin
       <dt>{label}</dt>
       <dd>{children}</dd>
     </div>
+  );
+}
+
+/**
+ * The wallet-journey ladders — one per door, never summed, never compared.
+ *
+ * Only rows the producer declared in the `agents` unit are drawn: distinct
+ * SIWE wallets reaching AT LEAST each stage, which is monotonic by
+ * construction and therefore honest as bars. Each door fills against its OWN
+ * busiest stage, so a 1-wallet MCP door and a 160-wallet HTTP door are both
+ * legible without the widths implying a comparison the windows cannot support.
+ */
+function JourneyLadders({ view }: { view: ArrivalOperatorView }) {
+  const doors = doorLadders(view);
+  return (
+    <div className="ops-arrivals-journey" data-testid="ops-arrivals-journey">
+      <div className="ops-arrivals-journey-head">
+        <h4>WALLET JOURNEY</h4>
+        <span>wallets reaching at least each stage · each door on its own scale · doors never sum</span>
+      </div>
+      <div className="ops-arrivals-journey-doors">
+        {doors.map((door) => (
+          <div className="ops-ladder" key={door.door} data-testid={`ops-arrivals-ladder-${door.door}`}>
+            <div className="ops-ladder-head">
+              <span className="ops-ladder-door">{door.label}</span>
+              <span className="ops-ladder-since">since {formatDate(door.sinceMs)}</span>
+              <WindowBadge window={door.window} />
+            </div>
+            {door.stages.length === 0 ? (
+              <p className="ops-ladder-absent">no wallet-stage rows reported for this door</p>
+            ) : (
+              door.stages.map((s) => (
+                <div
+                  className="ops-ladder-row"
+                  key={s.stage}
+                  data-testid={`ops-arrivals-ladder-${door.door}-${s.stage}`}
+                >
+                  <span className="ops-ladder-stage">{s.stage}</span>
+                  <span className="ops-ladder-track" aria-hidden>
+                    {/* Zero draws NO fill — the min-width that keeps one wallet
+                        visible must never invent one. */}
+                    {s.fillPct > 0 ? <i style={{ width: `${s.fillPct}%` }} /> : null}
+                  </span>
+                  <span className="ops-ladder-count">{s.count}</span>
+                </div>
+              ))
+            )}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Where in fixed time bands the last outsider activity sits. The bands are
+ * rungs (1h / 24h / 7d), not a linear axis, and the clock is the snapshot's
+ * own. No activity ever → nothing: an empty strip still looks like a reading.
+ */
+function RecencyStrip({ atMs, generatedAtMs }: { atMs: number | null; generatedAtMs: number }) {
+  const band = recencyBand(atMs, generatedAtMs);
+  if (!band) return null;
+  return (
+    <span
+      className="ops-recency"
+      role="img"
+      aria-label={`last outsider activity falls in the ${band} band`}
+      data-band={band}
+      data-testid="ops-arrivals-recency"
+    >
+      {RECENCY_BANDS.map((b) => (
+        <i key={b.key} data-active={b.key === band ? "yes" : "no"}>
+          {b.label}
+        </i>
+      ))}
+    </span>
+  );
+}
+
+/**
+ * The 7d identified/worked counts as two bars on ONE shared scale — beside
+ * the words that carry the exact numbers. Not nested: nothing in the payload
+ * proves worked ⊆ identified, so neither bar contains the other.
+ */
+function WeekBars({ week }: { week: { identified: number; worked: number } }) {
+  const pair = weekPair(week);
+  if (!pair) return null;
+  return (
+    <span className="ops-weekpair" data-testid="ops-arrivals-weekpair" aria-hidden>
+      {/* A zero count gets no bar at all — the words beside carry the zero. */}
+      {pair.identified.fillPct > 0 ? (
+        <i data-kind="identified" title={`${pair.identified.count} identified (7d)`} style={{ width: `${pair.identified.fillPct}%` }} />
+      ) : null}
+      {pair.worked.fillPct > 0 ? (
+        <i data-kind="worked" title={`${pair.worked.count} worked (7d)`} style={{ width: `${pair.worked.fillPct}%` }} />
+      ) : null}
+    </span>
   );
 }
 

--- a/packages/monitor-ui/src/components/ops/OpsBoard.tsx
+++ b/packages/monitor-ui/src/components/ops/OpsBoard.tsx
@@ -22,7 +22,7 @@ import { opsSuggestions } from "../../lib/monitor/ops-suggestions.js";
 import type { MonitorBoard } from "../../lib/monitor/board-cache.js";
 import type { ProductHealth } from "../../lib/monitor/product-health.js";
 import { formatAgo, incidentRows, probeOpsTone } from "../../lib/monitor/ops-model.js";
-import { economicsLine } from "../../lib/monitor/ops-spec.js";
+import { boardKpis, economicsLine } from "../../lib/monitor/ops-spec.js";
 import { opsVerdict, staleAfterMs, trustRows } from "../../lib/monitor/ops-spec.js";
 import { FlowPanel } from "./FlowPanel.js";
 import { PillarStrip } from "./PillarStrip.js";
@@ -62,6 +62,16 @@ export function OpsBoard({
   return (
     <div className="ops-board" data-testid="ops-board" data-untrusted={untrusted ? "yes" : "no"}>
       <div className="ops-meta">
+        {/* The brand row. The mark and name are chrome; the string beside them
+            is the same network / chain / read-only line the board always
+            carried, unchanged. */}
+        <span className="ops-brand">
+          <span className="ops-brand-mark" aria-hidden>A</span>
+          <span>
+            <span className="ops-brand-name">Hermes</span>
+            <span className="ops-brand-sub">Averray ops</span>
+          </span>
+        </span>
         <span>{metaLine(health)}</span>
         <span>
           {health.at == null
@@ -94,7 +104,11 @@ export function OpsBoard({
       {/* Everything below dims while untrusted: stale data must LOOK stale, not
           merely be labelled stale somewhere above it. */}
       <div className="ops-content" data-dim={untrusted ? "yes" : "no"}>
-        <div className="ops-verdict-row">
+        {/* The slab's own wash follows the verdict it carries — a coral
+            headline over a sage-tinted ground is a mixed signal at exactly
+            the distance this element exists to be read from. It is the SAME
+            tone the headline already uses; nothing new is decided here. */}
+        <div className="ops-verdict-row" data-verdict={verdict.verdictTone}>
           <div className="ops-verdict">
             <div className="ops-verdict-kicker" data-tone={verdict.kickerTone}>
               {verdict.kicker}
@@ -140,6 +154,27 @@ export function OpsBoard({
               </div>
             ))}
           </div>
+        </div>
+
+        {/* ── KPI STRIP ────────────────────────────────────────────────
+            The four figures an operator checks first, sized to be read
+            before any panel is. Every one is quoted from the view-model
+            the panel below renders (`boardKpis`), so the strip is a
+            second READING and never a second opinion — and an
+            unreported figure is a dash with its reason, not a zero. */}
+        <div className="ops-kpis" data-testid="ops-kpis">
+          {boardKpis(health, health.gas).map((kpi) => (
+            <div className="ops-kpi" key={kpi.key} data-testid={`ops-kpi-${kpi.key}`}>
+              <span className="ops-kpi-lbl">{kpi.label}</span>
+              <span className="ops-kpi-val">
+                {kpi.value}
+                {kpi.unit ? <span className="ops-kpi-unit">{kpi.unit}</span> : null}
+              </span>
+              <span className="ops-kpi-sub" data-tone={kpi.tone}>
+                {kpi.sub}
+              </span>
+            </div>
+          ))}
         </div>
 
         <div className="ops-money">

--- a/packages/monitor-ui/src/lib/monitor/arrivals-view.test.ts
+++ b/packages/monitor-ui/src/lib/monitor/arrivals-view.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "vitest";
 
-import { doorLadders, recencyBand, weekPair } from "./arrivals-view.js";
+import { doorJourneys } from "./arrivals-view.js";
 import type { ArrivalOperatorView } from "./product-health.js";
 
 const NOW = Date.parse("2026-08-16T12:00:00.000Z");
@@ -56,19 +56,19 @@ function view(over: Partial<ArrivalOperatorView["doors"]["http"]> = {}): Arrival
   };
 }
 
-describe("doorLadders — the wallet half only, per-door scale", () => {
-  test("call rows never enter the ladder — the un-charted counters stay un-charted", () => {
-    const [mcp, http] = doorLadders(view());
+describe("doorJourneys — the wallet half only, per-door scale", () => {
+  test("call rows never enter the journey — the un-charted counters stay un-charted", () => {
+    const [mcp, http] = doorJourneys(view());
     expect(mcp!.stages.map((s) => s.stage)).toEqual(["identified", "claimed", "submitted"]);
     expect(http!.stages.map((s) => s.stage)).toEqual(["identified", "authenticated", "claimed", "submitted"]);
-    // The 15,000-call reached row must not have become a bar anywhere.
+    // The 15,000-call reached row must not have become a fill anywhere.
     for (const door of [mcp!, http!]) {
       expect(door.stages.every((s) => s.count < 1000)).toBe(true);
     }
   });
 
   test("each door scales to its own maximum — doors are never comparable", () => {
-    const [mcp, http] = doorLadders(view());
+    const [mcp, http] = doorJourneys(view());
     // MCP's single wallet fills MCP's own scale; HTTP's 162 sits just under
     // HTTP's 164. Equal fills for unequal counts is the point: no cross-door
     // comparison is encoded.
@@ -77,53 +77,17 @@ describe("doorLadders — the wallet half only, per-door scale", () => {
     expect(http!.stages[2]!.fillPct).toBe(99);
   });
 
-  test("zero draws no bar; a tiny nonzero always draws one", () => {
-    const [mcp] = doorLadders(view());
+  test("zero draws no fill; a tiny nonzero always draws one", () => {
+    const [mcp] = doorJourneys(view());
     const submitted = mcp!.stages.find((s) => s.stage === "submitted")!;
     expect(submitted.fillPct).toBe(0);
     const identified = mcp!.stages.find((s) => s.stage === "identified")!;
     expect(identified.fillPct).toBeGreaterThanOrEqual(5);
   });
 
-  test("a door with no wallet-unit rows yields an empty ladder, not zeros", () => {
+  test("a door with no wallet-unit rows yields an empty journey, not zeros", () => {
     const v = view({ rows: [] });
-    const [, http] = doorLadders(v);
+    const [, http] = doorJourneys(v);
     expect(http!.stages).toEqual([]);
-  });
-});
-
-describe("recencyBand — fixed rungs against the snapshot clock", () => {
-  test("bands split at 1h / 24h / 7d", () => {
-    expect(recencyBand(NOW - 2 * 60_000, NOW)).toBe("1h");
-    expect(recencyBand(NOW - 5 * 3_600_000, NOW)).toBe("24h");
-    expect(recencyBand(NOW - 3 * 86_400_000, NOW)).toBe("7d");
-    expect(recencyBand(NOW - 30 * 86_400_000, NOW)).toBe("older");
-  });
-
-  test("no activity ever → null, so no strip renders at all", () => {
-    expect(recencyBand(null, NOW)).toBeNull();
-    expect(recencyBand(undefined, NOW)).toBeNull();
-    expect(recencyBand(Number.NaN, NOW)).toBeNull();
-  });
-});
-
-describe("weekPair — one shared scale, no containment claim", () => {
-  test("both counts fill against the larger of the two", () => {
-    const pair = weekPair({ identified: 18, worked: 16 })!;
-    expect(pair.identified.fillPct).toBe(100);
-    expect(pair.worked.fillPct).toBe(89);
-    expect(pair.worked.count).toBe(16);
-  });
-
-  test("a zero week renders no bars — the words already say it", () => {
-    expect(weekPair({ identified: 0, worked: 0 })).toBeNull();
-  });
-
-  test("worked can exceed identified without breaking the scale", () => {
-    // Nothing in the payload proves worked ⊆ identified; the scale must not
-    // assume it.
-    const pair = weekPair({ identified: 2, worked: 5 })!;
-    expect(pair.worked.fillPct).toBe(100);
-    expect(pair.identified.fillPct).toBe(40);
   });
 });

--- a/packages/monitor-ui/src/lib/monitor/arrivals-view.test.ts
+++ b/packages/monitor-ui/src/lib/monitor/arrivals-view.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, test } from "vitest";
+
+import { doorLadders, recencyBand, weekPair } from "./arrivals-view.js";
+import type { ArrivalOperatorView } from "./product-health.js";
+
+const NOW = Date.parse("2026-08-16T12:00:00.000Z");
+
+function view(over: Partial<ArrivalOperatorView["doors"]["http"]> = {}): ArrivalOperatorView {
+  const callRow = (stage: string, outsider: number) => ({
+    stage: stage as never,
+    unit: "calls" as const,
+    instrumentation: `${stage} route/tool calls`,
+    outsider,
+    ours: 0,
+    unknown: 0,
+  });
+  const walletRow = (stage: string, outsider: number) => ({
+    stage: stage as never,
+    unit: "agents" as const,
+    instrumentation: "distinct SIWE wallets reaching at least this stage",
+    outsider,
+    ours: 0,
+    unknown: 0,
+  });
+  return {
+    version: "averray.arrivals.operator.v1",
+    generatedAtMs: NOW,
+    outsiders: {
+      furthestEver: null,
+      lastActivity: null,
+      week: { window: "7d", identified: 0, worked: 0 },
+      postedWork: { window: "all-time", status: "never", count: null, firstAtMs: null },
+    },
+    ours: { day: { window: "24h", agents: 0, canaryRuns: 0, acceptanceRuns: 0, adminConsoleAgents: 0, operatorAgents: 0 } },
+    unknown: { window: "all-time", sharedClientNames: 0, preSplitCalls: 0 },
+    doors: {
+      mcp: {
+        window: "all-time",
+        sinceMs: NOW - 8 * 86_400_000,
+        rows: [callRow("reached", 2000), walletRow("identified", 1), walletRow("claimed", 1), walletRow("submitted", 0)],
+      },
+      http: {
+        window: "all-time",
+        sinceMs: NOW - 5 * 86_400_000,
+        rows: [
+          callRow("reached", 15_000),
+          callRow("browsed", 400),
+          walletRow("identified", 164),
+          walletRow("authenticated", 164),
+          walletRow("claimed", 162),
+          walletRow("submitted", 162),
+        ],
+        ...over,
+      },
+    },
+  };
+}
+
+describe("doorLadders — the wallet half only, per-door scale", () => {
+  test("call rows never enter the ladder — the un-charted counters stay un-charted", () => {
+    const [mcp, http] = doorLadders(view());
+    expect(mcp!.stages.map((s) => s.stage)).toEqual(["identified", "claimed", "submitted"]);
+    expect(http!.stages.map((s) => s.stage)).toEqual(["identified", "authenticated", "claimed", "submitted"]);
+    // The 15,000-call reached row must not have become a bar anywhere.
+    for (const door of [mcp!, http!]) {
+      expect(door.stages.every((s) => s.count < 1000)).toBe(true);
+    }
+  });
+
+  test("each door scales to its own maximum — doors are never comparable", () => {
+    const [mcp, http] = doorLadders(view());
+    // MCP's single wallet fills MCP's own scale; HTTP's 162 sits just under
+    // HTTP's 164. Equal fills for unequal counts is the point: no cross-door
+    // comparison is encoded.
+    expect(mcp!.stages[0]!.fillPct).toBe(100);
+    expect(http!.stages[0]!.fillPct).toBe(100);
+    expect(http!.stages[2]!.fillPct).toBe(99);
+  });
+
+  test("zero draws no bar; a tiny nonzero always draws one", () => {
+    const [mcp] = doorLadders(view());
+    const submitted = mcp!.stages.find((s) => s.stage === "submitted")!;
+    expect(submitted.fillPct).toBe(0);
+    const identified = mcp!.stages.find((s) => s.stage === "identified")!;
+    expect(identified.fillPct).toBeGreaterThanOrEqual(5);
+  });
+
+  test("a door with no wallet-unit rows yields an empty ladder, not zeros", () => {
+    const v = view({ rows: [] });
+    const [, http] = doorLadders(v);
+    expect(http!.stages).toEqual([]);
+  });
+});
+
+describe("recencyBand — fixed rungs against the snapshot clock", () => {
+  test("bands split at 1h / 24h / 7d", () => {
+    expect(recencyBand(NOW - 2 * 60_000, NOW)).toBe("1h");
+    expect(recencyBand(NOW - 5 * 3_600_000, NOW)).toBe("24h");
+    expect(recencyBand(NOW - 3 * 86_400_000, NOW)).toBe("7d");
+    expect(recencyBand(NOW - 30 * 86_400_000, NOW)).toBe("older");
+  });
+
+  test("no activity ever → null, so no strip renders at all", () => {
+    expect(recencyBand(null, NOW)).toBeNull();
+    expect(recencyBand(undefined, NOW)).toBeNull();
+    expect(recencyBand(Number.NaN, NOW)).toBeNull();
+  });
+});
+
+describe("weekPair — one shared scale, no containment claim", () => {
+  test("both counts fill against the larger of the two", () => {
+    const pair = weekPair({ identified: 18, worked: 16 })!;
+    expect(pair.identified.fillPct).toBe(100);
+    expect(pair.worked.fillPct).toBe(89);
+    expect(pair.worked.count).toBe(16);
+  });
+
+  test("a zero week renders no bars — the words already say it", () => {
+    expect(weekPair({ identified: 0, worked: 0 })).toBeNull();
+  });
+
+  test("worked can exceed identified without breaking the scale", () => {
+    // Nothing in the payload proves worked ⊆ identified; the scale must not
+    // assume it.
+    const pair = weekPair({ identified: 2, worked: 5 })!;
+    expect(pair.worked.fillPct).toBe(100);
+    expect(pair.identified.fillPct).toBe(40);
+  });
+});

--- a/packages/monitor-ui/src/lib/monitor/arrivals-view.ts
+++ b/packages/monitor-ui/src/lib/monitor/arrivals-view.ts
@@ -1,50 +1,48 @@
-// ARRIVALS view-model — the derived shapes behind the OUTSIDERS block.
+// ARRIVALS view-model — the wallet-journey shape behind the OUTSIDERS panel.
 //
-// The operator view was four prose lines and two collapsed tables; the shapes
-// here give the same facts marks, without crossing the lines the registry
-// design drew:
+// The visual grammar comes from the Averray design system's operator kit
+// (records as KPI cards, instrumentation as a table, counts in mono); this
+// module derives the one shape that needs derivation, without crossing the
+// lines the registry design drew:
 //
 //   · pre-identity counters (reached/browsed/evaluated) are CALLS from
 //     independent instruments and stay un-charted — a bar chart over them was
 //     deliberately removed once, and this module must not resurrect it;
 //   · from `identified` onward, rows are distinct SIWE wallets reaching AT
 //     LEAST that stage — monotonic by construction, which is what makes a
-//     ladder of bars honest;
+//     fill drawn behind the count honest;
 //   · the two doors carry different windows and different cut-overs, so each
 //     door scales to its OWN maximum and nothing ever sums or compares them.
-//
-// Pure; the clock is always the SNAPSHOT's own (`generatedAtMs`), never the
-// wall clock — the same rule the trust panel follows.
 
 import type { ArrivalOperatorView } from "./product-health.js";
 
-export interface LadderStageView {
+export interface JourneyStageView {
   stage: string;
   /** Distinct wallets reaching at least this stage, this door, its window. */
   count: number;
-  /** 0..100 against THIS door's own busiest wallet stage. Zero draws no bar. */
+  /** 0..100 against THIS door's own busiest wallet stage. Zero draws no fill. */
   fillPct: number;
 }
 
-export interface DoorLadderView {
+export interface DoorJourneyView {
   door: "mcp" | "http";
   label: string;
   sinceMs: number | null;
   window: string;
   /** Empty when the producer reported no wallet-unit rows for this door. */
-  stages: LadderStageView[];
+  stages: JourneyStageView[];
 }
 
 /**
- * The wallet half of each door's instrumentation, as a ladder.
+ * The wallet half of each door's instrumentation.
  *
  * Only rows whose unit is `agents` qualify — the producer's own declaration of
- * "distinct wallets reaching at least this stage". Rows are kept in producer
- * order; a nonzero count always gets a visible bar (a 1-wallet stage beside a
+ * "distinct wallets reaching at least this stage". Rows keep producer order; a
+ * nonzero count always gets a visible fill (a 1-wallet stage beside a
  * 164-wallet stage rounds to nothing, and "too small to draw" must not look
  * like "nobody ever got here").
  */
-export function doorLadders(view: ArrivalOperatorView): DoorLadderView[] {
+export function doorJourneys(view: ArrivalOperatorView): DoorJourneyView[] {
   return (["mcp", "http"] as const).map((door) => {
     const evidence = view.doors[door];
     const wallets = (evidence?.rows ?? []).filter((r) => r.unit === "agents");
@@ -61,52 +59,4 @@ export function doorLadders(view: ArrivalOperatorView): DoorLadderView[] {
       })),
     };
   });
-}
-
-/** Fixed recency rungs — a scale that does not move with the value on it. */
-export const RECENCY_BANDS = [
-  { key: "1h", label: "<1h", maxMs: 3_600_000 },
-  { key: "24h", label: "<24h", maxMs: 86_400_000 },
-  { key: "7d", label: "<7d", maxMs: 604_800_000 },
-  { key: "older", label: "older", maxMs: Number.POSITIVE_INFINITY },
-] as const;
-
-export type RecencyBandKey = (typeof RECENCY_BANDS)[number]["key"];
-
-/**
- * Which band the last outsider activity falls in, against the snapshot clock.
- * `null` when there has never been any — the caller renders the words and no
- * strip, because a strip with no marker still looks like a reading.
- */
-export function recencyBand(atMs: number | null | undefined, generatedAtMs: number): RecencyBandKey | null {
-  if (atMs == null || !Number.isFinite(atMs)) return null;
-  const age = Math.max(0, generatedAtMs - atMs);
-  for (const band of RECENCY_BANDS) {
-    if (age < band.maxMs) return band.key;
-  }
-  return "older";
-}
-
-export interface WeekPairView {
-  identified: { count: number; fillPct: number };
-  worked: { count: number; fillPct: number };
-}
-
-/**
- * The 7d identified/worked counts on ONE shared scale.
- *
- * Two comparable magnitudes, not a containment: nothing in the payload proves
- * `worked ⊆ identified`, so the bars sit side by side and neither nests in the
- * other. Null when both are zero — the words already say it, and two empty
- * tracks would dress a quiet week as a chart.
- */
-export function weekPair(week: { identified: number; worked: number } | undefined): WeekPairView | null {
-  if (!week) return null;
-  const max = Math.max(week.identified, week.worked);
-  if (max <= 0) return null;
-  const fill = (n: number) => (n === 0 ? 0 : Math.max(5, Math.round((n / max) * 100)));
-  return {
-    identified: { count: week.identified, fillPct: fill(week.identified) },
-    worked: { count: week.worked, fillPct: fill(week.worked) },
-  };
 }

--- a/packages/monitor-ui/src/lib/monitor/arrivals-view.ts
+++ b/packages/monitor-ui/src/lib/monitor/arrivals-view.ts
@@ -1,0 +1,112 @@
+// ARRIVALS view-model — the derived shapes behind the OUTSIDERS block.
+//
+// The operator view was four prose lines and two collapsed tables; the shapes
+// here give the same facts marks, without crossing the lines the registry
+// design drew:
+//
+//   · pre-identity counters (reached/browsed/evaluated) are CALLS from
+//     independent instruments and stay un-charted — a bar chart over them was
+//     deliberately removed once, and this module must not resurrect it;
+//   · from `identified` onward, rows are distinct SIWE wallets reaching AT
+//     LEAST that stage — monotonic by construction, which is what makes a
+//     ladder of bars honest;
+//   · the two doors carry different windows and different cut-overs, so each
+//     door scales to its OWN maximum and nothing ever sums or compares them.
+//
+// Pure; the clock is always the SNAPSHOT's own (`generatedAtMs`), never the
+// wall clock — the same rule the trust panel follows.
+
+import type { ArrivalOperatorView } from "./product-health.js";
+
+export interface LadderStageView {
+  stage: string;
+  /** Distinct wallets reaching at least this stage, this door, its window. */
+  count: number;
+  /** 0..100 against THIS door's own busiest wallet stage. Zero draws no bar. */
+  fillPct: number;
+}
+
+export interface DoorLadderView {
+  door: "mcp" | "http";
+  label: string;
+  sinceMs: number | null;
+  window: string;
+  /** Empty when the producer reported no wallet-unit rows for this door. */
+  stages: LadderStageView[];
+}
+
+/**
+ * The wallet half of each door's instrumentation, as a ladder.
+ *
+ * Only rows whose unit is `agents` qualify — the producer's own declaration of
+ * "distinct wallets reaching at least this stage". Rows are kept in producer
+ * order; a nonzero count always gets a visible bar (a 1-wallet stage beside a
+ * 164-wallet stage rounds to nothing, and "too small to draw" must not look
+ * like "nobody ever got here").
+ */
+export function doorLadders(view: ArrivalOperatorView): DoorLadderView[] {
+  return (["mcp", "http"] as const).map((door) => {
+    const evidence = view.doors[door];
+    const wallets = (evidence?.rows ?? []).filter((r) => r.unit === "agents");
+    const max = Math.max(1, ...wallets.map((r) => r.outsider));
+    return {
+      door,
+      label: door === "mcp" ? "MCP" : "HTTP",
+      sinceMs: evidence?.sinceMs ?? null,
+      window: evidence?.window ?? "all-time",
+      stages: wallets.map((r) => ({
+        stage: r.stage,
+        count: r.outsider,
+        fillPct: r.outsider === 0 ? 0 : Math.max(5, Math.round((r.outsider / max) * 100)),
+      })),
+    };
+  });
+}
+
+/** Fixed recency rungs — a scale that does not move with the value on it. */
+export const RECENCY_BANDS = [
+  { key: "1h", label: "<1h", maxMs: 3_600_000 },
+  { key: "24h", label: "<24h", maxMs: 86_400_000 },
+  { key: "7d", label: "<7d", maxMs: 604_800_000 },
+  { key: "older", label: "older", maxMs: Number.POSITIVE_INFINITY },
+] as const;
+
+export type RecencyBandKey = (typeof RECENCY_BANDS)[number]["key"];
+
+/**
+ * Which band the last outsider activity falls in, against the snapshot clock.
+ * `null` when there has never been any — the caller renders the words and no
+ * strip, because a strip with no marker still looks like a reading.
+ */
+export function recencyBand(atMs: number | null | undefined, generatedAtMs: number): RecencyBandKey | null {
+  if (atMs == null || !Number.isFinite(atMs)) return null;
+  const age = Math.max(0, generatedAtMs - atMs);
+  for (const band of RECENCY_BANDS) {
+    if (age < band.maxMs) return band.key;
+  }
+  return "older";
+}
+
+export interface WeekPairView {
+  identified: { count: number; fillPct: number };
+  worked: { count: number; fillPct: number };
+}
+
+/**
+ * The 7d identified/worked counts on ONE shared scale.
+ *
+ * Two comparable magnitudes, not a containment: nothing in the payload proves
+ * `worked ⊆ identified`, so the bars sit side by side and neither nests in the
+ * other. Null when both are zero — the words already say it, and two empty
+ * tracks would dress a quiet week as a chart.
+ */
+export function weekPair(week: { identified: number; worked: number } | undefined): WeekPairView | null {
+  if (!week) return null;
+  const max = Math.max(week.identified, week.worked);
+  if (max <= 0) return null;
+  const fill = (n: number) => (n === 0 ? 0 : Math.max(5, Math.round((n / max) * 100)));
+  return {
+    identified: { count: week.identified, fillPct: fill(week.identified) },
+    worked: { count: week.worked, fillPct: fill(week.worked) },
+  };
+}

--- a/packages/monitor-ui/src/lib/monitor/ops-fixtures.ts
+++ b/packages/monitor-ui/src/lib/monitor/ops-fixtures.ts
@@ -9,6 +9,9 @@
 //   OPS_FIXTURE_RED        a mainnet page-worthy incident → soft-banner / auto-flip
 
 import type {
+  ArrivalOperatorDoorRow,
+  ArrivalStage,
+  ArrivalsSnapshot,
   ProductHealth,
   ProductHealthProbe,
   ProbeStatus,
@@ -511,6 +514,113 @@ export const OPS_FIXTURE_UNVERIFIED: ProductHealth = {
       settledCount: 14,
       windowBlocks: null,
       window: { status: "unknown", detail: "block time not sampled", blockSeconds: null, spanHours: null },
+    },
+  },
+};
+
+// ── ARRIVALS, shaped like the live board on 2026-08-17 ──────────────────────
+//
+// Counts transcribed from the production operator view that day (doors,
+// records and windows included), so the preview exercises the OUTSIDERS
+// visualization with realistic asymmetry: an HTTP door with ~160 wallets and
+// an MCP door with one. The legacy pre-registry counters are DERIVED from the
+// MCP door rows (external = outsider, self = ours) rather than invented — the
+// panel renders `operatorView` and never reads them when it is present.
+//
+// NOT spread into the base fixtures: the phone-board tests compose their own
+// arrivals blocks over OPS_FIXTURE_NOMINAL and assert exact lane text; the
+// preview harness merges this in itself.
+
+const ARRIVAL_STAGE_LIST = [
+  "reached",
+  "browsed",
+  "evaluated",
+  "identified",
+  "authenticated",
+  "claimed",
+  "submitted",
+] as const;
+
+function doorRows(
+  counts: Record<(typeof ARRIVAL_STAGE_LIST)[number], [number, number, number]>,
+): ArrivalOperatorDoorRow[] {
+  return ARRIVAL_STAGE_LIST.map((stage, index) => ({
+    stage,
+    unit: index < 3 ? ("calls" as const) : ("agents" as const),
+    instrumentation:
+      index < 3 ? `${stage} route/tool calls` : "distinct SIWE wallets reaching at least this stage",
+    outsider: counts[stage][0],
+    ours: counts[stage][1],
+    unknown: counts[stage][2],
+  }));
+}
+
+const MCP_DOOR_ROWS = doorRows({
+  reached: [2362, 0, 511],
+  browsed: [16, 0, 7],
+  evaluated: [0, 0, 0],
+  identified: [1, 0, 0],
+  authenticated: [1, 0, 0],
+  claimed: [1, 0, 0],
+  submitted: [0, 0, 0],
+});
+
+const stageRecord = (pick: (row: ArrivalOperatorDoorRow) => number): Record<ArrivalStage, number> =>
+  Object.fromEntries(MCP_DOOR_ROWS.map((row) => [row.stage, pick(row)])) as Record<ArrivalStage, number>;
+
+export const OPS_FIXTURE_ARRIVALS: ArrivalsSnapshot = {
+  schemaVersion: "averray.arrivals.v1",
+  generatedAtMs: FIXTURE_NOW - 1 * MIN,
+  observingSinceMs: FIXTURE_NOW - 9 * DAY,
+  // Legacy MCP-scoped counters, derived from the door table above.
+  funnel: stageRecord((r) => r.outsider + r.ours + r.unknown),
+  funnelExternal: stageRecord((r) => r.outsider),
+  funnelSelf: stageRecord((r) => r.ours),
+  distinct: { declared: 1, anonymous: 0, self: 0, furthest: "claimed", furthestExternal: "claimed" },
+  clients: [],
+  httpCutover: {
+    atMs: FIXTURE_NOW - 6 * DAY,
+    at: new Date(FIXTURE_NOW - 6 * DAY).toISOString(),
+    backfilled: false,
+    note: "HTTP arrivals are measured from this cut-over only; earlier HTTP traffic was not backfilled.",
+  },
+  operatorView: {
+    version: "averray.arrivals.operator.v1",
+    generatedAtMs: FIXTURE_NOW - 1 * MIN,
+    outsiders: {
+      furthestEver: {
+        window: "all-time",
+        stage: "settled",
+        atMs: FIXTURE_NOW - 6 * DAY,
+        door: "http",
+        agents: 1,
+        payouts: 52,
+        payoutWindow: "12h",
+        payoutSpanMs: 12 * HOUR,
+      },
+      lastActivity: { window: "all-time", atMs: FIXTURE_NOW - 3 * MIN, stage: "authenticated", door: "http" },
+      week: { window: "7d", identified: 18, worked: 16 },
+      postedWork: { window: "all-time", status: "observed", count: 3, firstAtMs: FIXTURE_NOW - 17 * DAY },
+    },
+    ours: {
+      day: { window: "24h", agents: 4, canaryRuns: 2, acceptanceRuns: 0, adminConsoleAgents: 1, operatorAgents: 1 },
+    },
+    unknown: { window: "all-time", sharedClientNames: 1, preSplitCalls: 455 },
+    doors: {
+      mcp: { window: "all-time", sinceMs: FIXTURE_NOW - 9 * DAY, rows: MCP_DOOR_ROWS },
+      http: {
+        window: "all-time",
+        sinceMs: FIXTURE_NOW - 6 * DAY,
+        rows: doorRows({
+          reached: [15_431, 829, 0],
+          browsed: [431, 2074, 0],
+          evaluated: [1973, 133, 0],
+          identified: [164, 35, 0],
+          authenticated: [164, 35, 0],
+          claimed: [162, 34, 0],
+          submitted: [162, 34, 0],
+        }),
+      },
     },
   },
 };

--- a/packages/monitor-ui/src/lib/monitor/ops-spec.test.ts
+++ b/packages/monitor-ui/src/lib/monitor/ops-spec.test.ts
@@ -3,9 +3,12 @@ import { describe, expect, test } from "vitest";
 import {
   DATA_STALE_FALLBACK_MS,
   EVIDENCE_KEY,
+  boardKpis,
   capMeterView,
   crossCheckLine,
   payoutProvenanceLine,
+  payoutRunwayNote,
+  payoutsRemaining,
   METER_RUNGS,
   shortEndpoint,
   staleAfterMs,
@@ -20,7 +23,7 @@ import {
   volumeMixNote,
 } from "./ops-spec.js";
 import type { ProductHealth, SolvencyPool } from "./product-health.js";
-import { OPS_FIXTURE_NOMINAL, OPS_FIXTURE_STRESS } from "./ops-fixtures.js";
+import { OPS_FIXTURE_NOMINAL, OPS_FIXTURE_STRESS, OPS_FIXTURE_UNVERIFIED } from "./ops-fixtures.js";
 
 const NOW = 1_751_500_000_000;
 
@@ -866,6 +869,66 @@ describe("trustRows", () => {
       nowMs: health.at! + 3 * 60_000,
     });
     expect(rows.find((r) => r.key === "DATA AGE")!.tone).toBe("ok");
+  });
+});
+
+describe("boardKpis — a second reading, never a second opinion", () => {
+  test("the strip quotes the panels' own numbers", () => {
+    const kpis = boardKpis(OPS_FIXTURE_NOMINAL);
+    const by = Object.fromEntries(kpis.map((k) => [k.key, k]));
+    // Same settled count as the funnel, same confirmed count as the evidence.
+    expect(by.settled!.value).toBe(String(OPS_FIXTURE_NOMINAL.flow!.settled24h));
+    expect(by.proven!.value).toBe(String(OPS_FIXTURE_NOMINAL.flow!.payout!.confirmedCount));
+    expect(by.proven!.tone).toBe("ok");
+    expect(by.gas!.value).toBe("2.69");
+    expect(by.gas!.unit).toBe("DOT");
+  });
+
+  test("a shortfall reaches the strip — the tone is the evidence's own", () => {
+    const kpis = boardKpis(OPS_FIXTURE_STRESS);
+    const proven = kpis.find((k) => k.key === "proven")!;
+    expect(proven.value).toBe("12");
+    expect(proven.tone).toBe("red");
+    expect(proven.sub).toContain("shortfall");
+  });
+
+  test("an unreported figure is a dash with its reason, never a zero", () => {
+    const bare: ProductHealth = { ...OPS_FIXTURE_NOMINAL, flow: undefined, solvency: undefined };
+    const kpis = boardKpis(bare);
+    for (const k of kpis) {
+      expect(k.value).toBe("—");
+      expect(k.sub.length).toBeGreaterThan(0);
+    }
+    expect(kpis.find((k) => k.key === "settled")!.sub).toContain("no settlement counts");
+  });
+
+  test("the runway KPI and the pool footnote run ONE projection", () => {
+    // The KPI briefly parsed the footnote's sentence with a regex — a figure
+    // that changes meaning the day the wording does. Both now read
+    // payoutsRemaining(), so they cannot disagree.
+    const pool = OPS_FIXTURE_NOMINAL.solvency!.pools.find((p) => p.key === "reward_bank")!;
+    const projection = payoutsRemaining({ pool, payout: OPS_FIXTURE_NOMINAL.flow!.payout });
+    expect(projection?.status).toBe("ok");
+    const kpi = boardKpis(OPS_FIXTURE_NOMINAL).find((k) => k.key === "runway")!;
+    expect(kpi.value).toBe(`≈${(projection as { payouts: number }).payouts}`);
+    // …and the footnote quotes the same number in its own sentence.
+    const note = payoutRunwayNote({ pool, payout: OPS_FIXTURE_NOMINAL.flow!.payout })!;
+    expect(note.text).toContain(`≈ ${(projection as { payouts: number }).payouts} more payout`);
+  });
+
+  test("a below-floor bank is a dash and the reason, never a projection", () => {
+    const kpi = boardKpis(OPS_FIXTURE_STRESS).find((k) => k.key === "runway")!;
+    expect(kpi.value).toBe("—");
+    expect(kpi.sub).toContain("BELOW FLOOR");
+    expect(kpi.tone).toBe("red");
+  });
+
+  test("a blind chain read is grey in the strip too, not coral", () => {
+    // UNVERIFIED means the instrument is broken, not the money — the strip
+    // must not escalate it into the alarm the shortfall gets.
+    const proven = boardKpis(OPS_FIXTURE_UNVERIFIED).find((k) => k.key === "proven")!;
+    expect(proven.value).toBe("—");
+    expect(proven.tone).toBe("awaiting");
   });
 });
 

--- a/packages/monitor-ui/src/lib/monitor/ops-spec.ts
+++ b/packages/monitor-ui/src/lib/monitor/ops-spec.ts
@@ -884,24 +884,54 @@ export function gasUnreadableNote(reason: string): { text: string; tone: OpsTone
  * pipeline pauses while a payout count stays true. The balance and floor are on
  * the meter directly above and are deliberately not repeated.
  */
+/**
+ * How many more payouts the reward bank funds — the projection itself.
+ *
+ * Split out so the pool's footnote and the KPI strip run the SAME arithmetic
+ * instead of one of them reading the other's sentence. The KPI briefly parsed
+ * the rendered note with a regex, which is a number that silently changes
+ * meaning the day the wording does: exactly the class of drift this module's
+ * "decide it once" rule exists to prevent.
+ *
+ *   null            → no balance to project from
+ *   below-floor     → the pool cannot fund anything
+ *   no-average      → nothing settled to average over; NOT "zero payouts left"
+ */
+export type RunwayProjection =
+  | { status: "below-floor" }
+  | { status: "no-average" }
+  | { status: "ok"; payouts: number; average: number };
+
+export function payoutsRemaining(input: {
+  pool: SolvencyPool | undefined;
+  payout: PayoutEvidence | undefined;
+}): RunwayProjection | null {
+  const { pool, payout } = input;
+  if (!pool || pool.amount == null) return null;
+
+  const usable = pool.amount - (pool.floor ?? 0);
+  if (usable <= 0) return { status: "below-floor" };
+
+  const count = payout?.confirmedCount ?? 0;
+  const total = payout?.confirmedUsdc ?? null;
+  if (count <= 0 || total == null || total <= 0) return { status: "no-average" };
+
+  const average = total / count;
+  return { status: "ok", payouts: Math.floor(usable / average), average };
+}
+
 export function payoutRunwayNote(input: {
   pool: SolvencyPool | undefined;
   payout: PayoutEvidence | undefined;
   runwayNote?: string | null | undefined;
 }): { text: string; tone: OpsTone } | null {
-  const { pool, payout } = input;
-  if (!pool || pool.amount == null) return null;
-
-  const usable = pool.amount - (pool.floor ?? 0);
-  if (usable <= 0) return { text: "BELOW FLOOR — payouts will fail", tone: "red" };
-
-  const count = payout?.confirmedCount ?? 0;
-  const total = payout?.confirmedUsdc ?? null;
-  if (count <= 0 || total == null || total <= 0) {
+  const projection = payoutsRemaining(input);
+  if (!projection) return null;
+  if (projection.status === "below-floor") return { text: "BELOW FLOOR — payouts will fail", tone: "red" };
+  if (projection.status === "no-average") {
     return { text: "no payout average yet — cannot project", tone: "awaiting" };
   }
-  const average = total / count;
-  const payouts = Math.floor(usable / average);
+  const { payouts, average } = projection;
   const note = input.runwayNote ? ` · ${input.runwayNote}` : "";
   return {
     text: `≈ ${payouts} more payout${payouts === 1 ? "" : "s"} at ${average.toFixed(3)} avg${note}`,
@@ -1159,6 +1189,124 @@ export function formatSeconds(seconds: number | null): string {
  * `decimals` absent ⇒ the raw base-unit string, labelled `raw`. Scaling by a
  * guessed exponent would silently move a decimal point on a money value.
  */
+// ── the KPI strip (Direction B) ─────────────────────────────────────────────
+
+export interface KpiView {
+  key: string;
+  label: string;
+  /** The figure, or "—" when it was not reported. Never a fabricated zero. */
+  value: string;
+  /** Unit or noun beside the figure ("payouts", "DOT"); absent when none. */
+  unit?: string;
+  /** One line of context, already decided. */
+  sub: string;
+  /** Tones the SUB line only — the figure stays ink, because a count is not
+   *  a verdict and the verdict is upstairs. */
+  tone: OpsTone;
+}
+
+/**
+ * The four numbers an operator checks first, as cards.
+ *
+ * ── IT IS A SECOND READING, NEVER A SECOND OPINION ───────────────────────
+ *
+ * Every figure here is taken from the view-model the panel below already
+ * renders — `flowFunnel`, `payoutView`, `payoutRunwayNote`, the runway
+ * projection — so the strip cannot drift from the board it summarises. A KPI
+ * that recomputed its own settled count would eventually disagree with the
+ * funnel two hundred pixels underneath it, and the operator would have no way
+ * to tell which one was lying.
+ *
+ * Absence stays absence: a figure the payload did not report renders "—" with
+ * the reason in its sub-line, never 0. The reason a strip like this is
+ * dangerous is precisely that a big confident numeral reads as measured.
+ */
+export function boardKpis(health: ProductHealth, gas?: GasSpendView | undefined): KpiView[] {
+  const funnel = flowFunnel(health.flow);
+  const evidence = payoutView(health.flow?.payout);
+  const payout = health.flow?.payout;
+  const pools = health.solvency?.pools ?? [];
+  const rewardPool = pools.find((p) => p.key === "reward_bank");
+  const gasPool = pools.find((p) => p.key === "signer_gas");
+  const gasRunway = (health.solvency?.runway ?? []).find((r) => r.key === "signer_gas");
+
+  // 1. SETTLED — the funnel's own terminal count, with its tails.
+  const settledSub =
+    health.flow == null
+      ? "no settlement counts reported"
+      : [
+          `${funnel.stuck} stuck`,
+          `${funnel.failed} failed`,
+          health.lifecycle?.externalPct == null ? null : `${health.lifecycle.externalPct}% external`,
+        ]
+          .filter(Boolean)
+          .join(" · ");
+
+  // 2. PROVEN — the independent chain read. Its tone is the evidence tone, so
+  //    a shortfall or a blind instrument is visible in the strip, not only in
+  //    the panel below.
+  const proven: KpiView = {
+    key: "proven",
+    label: "Proven on-chain",
+    value: payout?.confirmedCount == null ? "—" : String(payout.confirmedCount),
+    ...(payout?.confirmedCount == null ? {} : { unit: payout.confirmedCount === 1 ? "payout" : "payouts" }),
+    sub:
+      payout?.confirmedCount == null
+        ? evidence.delta
+        : `${payout.confirmedUsdc == null ? "amount unreadable" : `${formatAmount(payout.confirmedUsdc)} USDC`} · ${evidence.status.toLowerCase()}`,
+    tone: evidence.tone,
+  };
+
+  // 3. RUNWAY — payouts remaining, the same projection the reward-bank note
+  //    makes. Reusing it keeps one arithmetic on screen.
+  const projection = payoutsRemaining({ pool: rewardPool, payout });
+  const runwayNote = payoutRunwayNote({ pool: rewardPool, payout, runwayNote: health.solvency?.runwayNote });
+  const runway: KpiView = {
+    key: "runway",
+    label: "Reward runway",
+    value: projection?.status === "ok" ? `≈${projection.payouts}` : "—",
+    ...(projection?.status === "ok" ? { unit: projection.payouts === 1 ? "payout" : "payouts" } : {}),
+    sub:
+      projection == null
+        ? "reward bank balance not reported"
+        : projection.status === "ok"
+          ? `${formatAmount(rewardPool!.amount!)} ${rewardPool!.unit} in the bank`
+          : (runwayNote?.text ?? "cannot project"),
+    tone: runwayNote?.tone ?? "awaiting",
+  };
+
+  // 4. GAS — the pool that stops settlement when it empties, with its
+  //    time-to-floor when the server could estimate one.
+  const gasSub =
+    gasRunway?.estimable && gasRunway.hoursToFloor != null
+      ? `≈${Math.round(gasRunway.hoursToFloor)}h to floor at the measured burn`
+      : gas?.perSettlement != null
+        ? `${gas.perSettlement.toFixed(3)} DOT per settlement`
+        : gasPool?.floor == null
+          ? "no floor declared"
+          : `floor ${formatAmount(gasPool.floor)} ${gasPool.unit}`;
+
+  return [
+    {
+      key: "settled",
+      label: "Settled · 24h",
+      value: funnel.settled,
+      sub: settledSub,
+      tone: funnel.tone,
+    },
+    proven,
+    runway,
+    {
+      key: "gas",
+      label: "Signer gas",
+      value: gasPool?.amount == null ? "—" : formatAmount(gasPool.amount),
+      ...(gasPool?.amount == null ? {} : { unit: gasPool.unit }),
+      sub: gasSub,
+      tone: gasRunway?.status ?? (gasPool?.amount == null ? "awaiting" : gasPool.status),
+    },
+  ];
+}
+
 /**
  * The deposit pool's cap meter — the one bounded scale on the BANK side.
  *

--- a/packages/monitor-ui/src/main.tsx
+++ b/packages/monitor-ui/src/main.tsx
@@ -39,6 +39,11 @@ import "./styles/hermes4-ops.css";
 // Mobile surface: the dedicated phone board. Scoped to `.hm-mb-*` and only
 // mounted below MOBILE_MAX_WIDTH, so it never touches the desktop surfaces.
 import "./styles/hermes4-mobile.css";
+// DIRECTION B: the midnight-wall surface pass (docs + design project card
+// "Ops board redesign"). Loaded LAST so its additive rules win over both the
+// ops and mobile sheets; it redefines the surface tokens they already read
+// rather than re-declaring their components.
+import "./styles/hermes4-direction-b.css";
 
 const rootEl = document.getElementById("root");
 if (!rootEl) {

--- a/packages/monitor-ui/src/ops-preview.tsx
+++ b/packages/monitor-ui/src/ops-preview.tsx
@@ -18,6 +18,7 @@ import "./styles/hermes4-tokens.css";
 import "./styles/hermes4-shell.css";
 import "./styles/hermes4-ops.css";
 import "./styles/hermes4-mobile.css";
+import "./styles/hermes4-direction-b.css";
 
 import { OpsBoard } from "./components/ops/OpsBoard.js";
 import { MobileBoard } from "./components/mobile/MobileBoard.js";

--- a/packages/monitor-ui/src/ops-preview.tsx
+++ b/packages/monitor-ui/src/ops-preview.tsx
@@ -22,6 +22,7 @@ import "./styles/hermes4-mobile.css";
 import { OpsBoard } from "./components/ops/OpsBoard.js";
 import { MobileBoard } from "./components/mobile/MobileBoard.js";
 import {
+  OPS_FIXTURE_ARRIVALS,
   OPS_FIXTURE_NOMINAL,
   OPS_FIXTURE_STRESS,
   OPS_FIXTURE_UNVERIFIED,
@@ -29,10 +30,17 @@ import {
   FIXTURE_NOW,
 } from "./lib/monitor/ops-fixtures.js";
 
+// The arrivals block is merged HERE rather than baked into the base fixtures:
+// the phone-board tests compose their own arrivals over OPS_FIXTURE_NOMINAL
+// and assert exact lane text, so the base fixtures stay arrivals-free while
+// the preview still exercises the OUTSIDERS visualization. LIVE keeps no
+// arrivals on purpose — that is the UNREACHABLE state.
+const withArrivals = (health: typeof OPS_FIXTURE_NOMINAL) => ({ ...health, arrivals: OPS_FIXTURE_ARRIVALS });
+
 const FIXTURES = {
-  nominal: { label: "FIG. 1 — Nominal", health: OPS_FIXTURE_NOMINAL, degraded: false },
-  stress: { label: "FIG. 2 — Stress", health: OPS_FIXTURE_STRESS, degraded: true },
-  unverified: { label: "Blind instrument", health: OPS_FIXTURE_UNVERIFIED, degraded: false },
+  nominal: { label: "FIG. 1 — Nominal", health: withArrivals(OPS_FIXTURE_NOMINAL), degraded: false },
+  stress: { label: "FIG. 2 — Stress", health: withArrivals(OPS_FIXTURE_STRESS), degraded: true },
+  unverified: { label: "Blind instrument", health: withArrivals(OPS_FIXTURE_UNVERIFIED), degraded: false },
   awaiting: { label: "Awaiting blocks", health: OPS_FIXTURE_LIVE, degraded: false },
 } as const;
 type FixtureKey = keyof typeof FIXTURES;

--- a/packages/monitor-ui/src/styles/hermes4-direction-b.css
+++ b/packages/monitor-ui/src/styles/hermes4-direction-b.css
@@ -1,0 +1,463 @@
+/* =========================================================
+   DIRECTION B — the midnight wall.
+   The design pass the operator chose (claude.ai/design → Averray
+   Design System → "Ops board redesign"). It is a SURFACE layer, not
+   a second design system: every status colour still comes from the
+   --h4 family, every size still scales with --ops-u, and no rule
+   here changes what a number says — only the ground it sits on and
+   the shape it sits in.
+
+   THREE THINGS THIS LAYER OWNS
+     1. the deep-ink ground + the panel family that sits on it
+     2. the verdict SLAB and the light frosted trust console
+     3. the KPI strip, and the rounded chrome the kit calls for
+
+   WHAT IT DELIBERATELY DOES NOT TOUCH
+     · tone tokens (--h4-ok / --h4-warn / --h4-act / --h4-tel) — a
+       redesign that re-tunes severity colours is a redesign of the
+       verdict, and the verdict is decided in one place;
+     · the floor tick's 2px width, hairline weights, and every
+       font-size expressed in --ops-u — the scaling contract from
+       ops-scaling.test.ts holds across this file too;
+     · any string. Nothing here adds, hides or softens a fact.
+
+   Loaded LAST in main.tsx and ops-preview.tsx so its additive rules
+   win over hermes4-ops.css and hermes4-mobile.css.
+   ========================================================= */
+
+/* ---- the ground -------------------------------------------------
+   Both boards are re-based onto the deep surface by redefining the
+   tokens they already read. Redefining rather than re-declaring is
+   the point: a panel that never mentioned a colour still lands on
+   the new ground, so this file cannot drift from the ones it skins. */
+.ops-board,
+.hm-ph {
+  --h4-surface:      #0e1114;
+  --h4-canvas:       #0b0e10;
+  --h4-paper:        #161a1e;
+  --h4-paper-sunken: #12161a;
+  --h4-paper-veil:   rgba(22, 26, 30, 0.86);
+
+  --h4-ink:   #f2efe7;
+  --h4-ink-2: #d7d3c9;
+  --h4-muted: #98a09a;
+  --h4-faint: #6d746f;
+
+  --h4-line:        rgba(242, 239, 231, 0.14);
+  --h4-line-2:      rgba(242, 239, 231, 0.07);
+  --h4-line-strong: rgba(242, 239, 231, 0.24);
+
+  /* Sage and amber lifted for the dark ground — the SAME roles, at the
+     luminance this surface needs. Coral is unchanged: it is already the
+     loudest thing on either ground, and moving it would move the alarm. */
+  --h4-ok:      #7fc99e;
+  --h4-ok-text: #8fd7ae;
+  --h4-ok-soft: rgba(127, 201, 158, 0.16);
+  --h4-ok-line: rgba(127, 201, 158, 0.42);
+
+  --h4-warn:      #e8b36b;
+  --h4-warn-text: #eabd7d;
+  --h4-warn-soft: rgba(232, 179, 107, 0.16);
+  --h4-warn-line: rgba(232, 179, 107, 0.42);
+
+  --h4-tel:      #98a09a;
+  --h4-tel-soft: rgba(152, 160, 154, 0.16);
+  --h4-tel-chip: #1e2429;
+
+  /* The kit's radius scale: 8 for chips, 10 for cards, 14 for panels,
+     22 for the hero slab, 999 for pills. */
+  --b-r-chip: 8px;
+  --b-r-card: 10px;
+  --b-r-panel: 14px;
+  --b-r-slab: 22px;
+  --b-shadow: 0 24px 60px rgba(0, 0, 0, 0.45);
+}
+
+.ops-board {
+  --ops-hair: rgba(242, 239, 231, 0.08);
+  --ops-rule: rgba(242, 239, 231, 0.14);
+  gap: calc(14 * var(--ops-u));
+  padding: calc(18 * var(--ops-u)) calc(26 * var(--ops-u)) calc(16 * var(--ops-u));
+}
+.ops-content { gap: calc(14 * var(--ops-u)); }
+
+/* ---- brand bar --------------------------------------------------
+   The meta line becomes a brand row: the kit's dark mark, the product
+   name, and the same network / chain / read-only string it always
+   carried. Nothing new is claimed — the words are unchanged. */
+.ops-meta {
+  align-items: center;
+  gap: calc(14 * var(--ops-u));
+  font-size: calc(11 * var(--ops-u));
+}
+.ops-brand {
+  display: flex;
+  align-items: center;
+  gap: calc(10 * var(--ops-u));
+}
+.ops-brand-mark {
+  width: calc(30 * var(--ops-u));
+  height: calc(30 * var(--ops-u));
+  flex: none;
+  display: grid;
+  place-items: center;
+  border-radius: var(--b-r-chip);
+  background: var(--h4-ink);
+  color: #0e1114;
+  font-family: var(--h4-font-display);
+  font-weight: 700;
+  font-size: calc(16 * var(--ops-u));
+}
+.ops-brand-name {
+  font-family: var(--h4-font-display);
+  font-weight: 700;
+  font-size: calc(16 * var(--ops-u));
+  line-height: 1.1;
+  color: var(--h4-ink);
+}
+.ops-brand-sub {
+  font-family: var(--h4-font-display);
+  font-size: calc(9.5 * var(--ops-u));
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--h4-ok);
+}
+.ops-meta > span:first-of-type { color: var(--h4-muted); }
+
+/* ---- the verdict slab -------------------------------------------
+   The one oversized element gets the kit's hero treatment: deep slab,
+   sage radial, masked grid, 22px radius. The verdict TEXT is untouched
+   — same string, same tone token, same testid. */
+.ops-verdict-row {
+  position: relative;
+  overflow: hidden;
+  gap: calc(28 * var(--ops-u));
+  padding: calc(26 * var(--ops-u)) calc(30 * var(--ops-u)) calc(24 * var(--ops-u));
+  border-radius: var(--b-r-slab);
+  border: 1px solid var(--h4-line-2);
+  background:
+    radial-gradient(120% 160% at 12% -20%, rgba(127, 201, 158, 0.16), transparent 55%),
+    linear-gradient(100deg, #0c1013 0%, #10201b 62%, #0e1114 100%);
+  box-shadow: var(--b-shadow);
+}
+/* The wash follows the verdict's own tone. Same colour family as the
+   headline, at slab strength — never a new severity, and never louder
+   than the word it sits behind. */
+.ops-verdict-row[data-verdict="degraded"] {
+  background:
+    radial-gradient(120% 160% at 12% -20%, rgba(232, 179, 107, 0.16), transparent 55%),
+    linear-gradient(100deg, #0c1013 0%, #1d1811 62%, #0e1114 100%);
+}
+.ops-verdict-row[data-verdict="red"] {
+  background:
+    radial-gradient(120% 160% at 12% -20%, rgba(232, 134, 94, 0.20), transparent 55%),
+    linear-gradient(100deg, #0c1013 0%, #201410 62%, #0e1114 100%);
+  border-color: rgba(232, 134, 94, 0.35);
+}
+.ops-verdict-row[data-verdict="awaiting"] {
+  background:
+    radial-gradient(120% 160% at 12% -20%, rgba(152, 160, 154, 0.12), transparent 55%),
+    linear-gradient(100deg, #0c1013 0%, #14181b 62%, #0e1114 100%);
+}
+.ops-verdict-row::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background-image:
+    linear-gradient(rgba(242, 239, 231, 0.05) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(242, 239, 231, 0.05) 1px, transparent 1px);
+  background-size: calc(56 * var(--ops-u)) calc(56 * var(--ops-u));
+  -webkit-mask-image: radial-gradient(90% 90% at 28% 18%, #000 30%, transparent 75%);
+  mask-image: radial-gradient(90% 90% at 28% 18%, #000 30%, transparent 75%);
+}
+.ops-verdict-row > * { position: relative; }
+.ops-verdict-kicker { color: var(--tone, var(--h4-muted)); }
+.ops-verdict-sub { color: var(--tone, var(--h4-ink-2)); }
+.ops-census { margin-top: calc(14 * var(--ops-u)); }
+.ops-census i { border-radius: 2px; }
+
+/* ---- the trust console ------------------------------------------
+   The kit's floating console window: a LIGHT card over the dark slab,
+   with the three-dot window bar. It keeps its own light-side ink —
+   inheriting the wall's cream would put white text on cream. */
+.ops-trust {
+  align-self: center;
+  border: 0;
+  border-radius: var(--b-r-panel);
+  padding: calc(14 * var(--ops-u)) calc(16 * var(--ops-u));
+  background: rgba(255, 253, 247, 0.94);
+  box-shadow: 0 calc(16 * var(--ops-u)) calc(42 * var(--ops-u)) rgba(0, 0, 0, 0.42);
+  --h4-ink: #111315;
+  --h4-ink-2: #1c211f;
+  --h4-muted: #5f655f;
+  /* Sage and amber return to their LIGHT-side values inside this card:
+     the dark-ground steps are too pale on cream. Same roles, right
+     luminance for the surface they land on. */
+  --h4-ok: #1e6642;
+  --h4-warn: #a76122;
+  --h4-tel: #7c837d;
+  color: #111315;
+}
+/* THE ALARM MUST NOT BE THE QUIETEST THING ON THE CARD.
+   Coral is tuned for the deep ground; on cream it measures 2.58:1 — under
+   the 3:1 floor — while sage reads 6.80 and amber 4.72 on the same card. The
+   row that renders in it is STREAM · DISCONNECTED, which invalidates every
+   number on the board, so it was the one fact this console rendered faintest.
+   A deeper step of the SAME role, scoped to this light card: --h4-act is
+   untouched everywhere else, and the alarm keeps its colour identity while
+   becoming the most legible row again (5.42:1). */
+.ops-trust [data-tone="red"] { --tone: #a83a1c; }
+/* The window bar names what the console answers. Decorative dots only —
+   the kit's motif, explicitly not a status system. */
+.ops-trust::before {
+  content: "";
+  display: block;
+  width: calc(38 * var(--ops-u));
+  height: calc(8 * var(--ops-u));
+  margin-bottom: calc(10 * var(--ops-u));
+  border-radius: 999px;
+  background:
+    radial-gradient(circle at calc(4 * var(--ops-u)) 50%, #8ee0b4 0 calc(4 * var(--ops-u)), transparent 0),
+    radial-gradient(circle at calc(19 * var(--ops-u)) 50%, #d8e8ff 0 calc(4 * var(--ops-u)), transparent 0),
+    radial-gradient(circle at calc(34 * var(--ops-u)) 50%, #f5dfc6 0 calc(4 * var(--ops-u)), transparent 0);
+}
+.ops-trust-key { color: #5f655f; }
+
+/* ---- the KPI strip ----------------------------------------------
+   Four cards, the kit's dashboard pattern. Every figure is derived by
+   boardKpis() from the SAME view-models the panels below use — the
+   strip is a second reading of one number, never a second opinion. */
+.ops-kpis {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: calc(12 * var(--ops-u));
+}
+.ops-kpi {
+  display: grid;
+  gap: calc(5 * var(--ops-u));
+  align-content: start;
+  min-width: 0;
+  padding: calc(13 * var(--ops-u)) calc(15 * var(--ops-u));
+  border: 1px solid var(--ops-rule);
+  border-radius: var(--b-r-card);
+  background: var(--h4-paper);
+  box-shadow: var(--b-shadow);
+}
+.ops-kpi-lbl {
+  font-family: var(--h4-font-display);
+  font-size: calc(10 * var(--ops-u));
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--h4-muted);
+}
+.ops-kpi-val {
+  display: flex;
+  align-items: baseline;
+  gap: calc(6 * var(--ops-u));
+  font-family: var(--h4-font-display);
+  font-weight: 700;
+  font-size: clamp(24px, 2.1vw, calc(36 * var(--ops-u)));
+  line-height: 1;
+  color: var(--tone, var(--h4-ink));
+}
+.ops-kpi-unit {
+  font-family: var(--h4-font-display);
+  font-size: calc(13 * var(--ops-u));
+  font-weight: 600;
+  color: var(--h4-muted);
+}
+.ops-kpi-sub {
+  font-family: var(--h4-font-mono);
+  font-size: calc(10.5 * var(--ops-u));
+  line-height: 1.45;
+  color: var(--tone, var(--h4-muted));
+}
+
+/* ---- panels -----------------------------------------------------
+   One card family: paper ground, hairline, 14px radius, one soft
+   shadow. The money band stops being a single bordered box and becomes
+   two cards, which is what lets the eye separate them at wall range. */
+.ops-money {
+  border: 0;
+  gap: calc(14 * var(--ops-u));
+  background: none;
+}
+.ops-solvency,
+.ops-flow,
+.ops-bank-group,
+.ops-pillars,
+.ops-arrivals {
+  border: 1px solid var(--ops-rule);
+  border-radius: var(--b-r-panel);
+  background: var(--h4-paper);
+  box-shadow: var(--b-shadow);
+}
+.ops-solvency {
+  width: calc(46% - (7 * var(--ops-u)));
+  border-right: 1px solid var(--ops-rule);
+  padding: calc(12 * var(--ops-u)) calc(18 * var(--ops-u)) calc(4 * var(--ops-u));
+}
+.ops-flow { padding: calc(12 * var(--ops-u)) calc(18 * var(--ops-u)); }
+.ops-panel-head {
+  padding-bottom: calc(9 * var(--ops-u));
+  border-bottom: 1px solid var(--ops-hair);
+}
+.ops-panel-title { font-size: calc(15 * var(--ops-u)); letter-spacing: 0.05em; }
+/* Panel titles are sentence case in the kit; the markup keeps its
+   uppercase strings, so the casing is applied here rather than by
+   rewriting eleven headings. */
+.ops-panel-title,
+.ops-bank-group > h2 { text-transform: capitalize; }
+.ops-chip { border-radius: 999px; border-style: solid; }
+
+/* Rounded meters, and a rounded fill inside them. The floor tick stays
+   a hard 2px rectangle: it marks a threshold, and a rounded threshold
+   is a fuzzier one. */
+.ops-meter { border-radius: 999px; background: #1e2429; }
+.ops-meter-fill { border-radius: 999px; }
+.ops-pool { border-bottom-style: solid; border-bottom-color: var(--ops-hair); }
+.ops-pool-note--keyed .ops-pool-note-key { color: var(--h4-ok); }
+
+/* The evidence block gets the kit's washed card. Its emphasis rule is
+   untouched — only a real shortfall takes the coral frame. */
+.ops-evidence {
+  border-radius: var(--b-r-card);
+  border-color: var(--h4-ok-line);
+  background: var(--h4-ok-soft);
+}
+.ops-evidence[data-emphasis="on"] {
+  border-color: var(--h4-act);
+  background: rgba(232, 134, 94, 0.10);
+}
+.ops-byhour-bar { border-radius: 3px 3px 0 0; }
+/* Per-job economics closes the money band. With the band no longer a single
+   box, this line needs its own card or it reads as text dropped on the page
+   ground — it is a fact about the two panels above, not a caption. */
+.ops-economics {
+  border: 1px solid var(--ops-rule);
+  border-top: 1px solid var(--ops-rule);
+  border-radius: var(--b-r-card);
+  background: var(--h4-paper);
+  box-shadow: var(--b-shadow);
+}
+
+/* BANK — two cards inside one frame, as the group already asserts. */
+.ops-bank-group { overflow: hidden; }
+.ops-bank-group > h2 { border-bottom: 1px solid var(--ops-hair); }
+.ops-bank,
+.ops-deposit-pool { box-shadow: none; }
+.ops-deposit-pool-grid > div { border-top-color: var(--ops-hair); }
+.ops-cap-meter { border-radius: 999px; background: #1e2429; }
+.ops-cap-meter i { border-radius: 999px; }
+
+/* Pills — the kit's 999px chip, for the states that are genuinely
+   badges rather than sentences. */
+.ops-deposit-pool-born-empty,
+.ops-bank-alarm {
+  padding: calc(2 * var(--ops-u)) calc(10 * var(--ops-u));
+  border-radius: 999px;
+  background: var(--h4-ok-soft);
+  color: var(--h4-ok);
+}
+.ops-bank-alarm { background: rgba(232, 134, 94, 0.16); color: var(--h4-act); }
+
+/* Probe band + incidents: same card family, tighter rules. */
+.ops-pillars { padding: calc(12 * var(--ops-u)) calc(14 * var(--ops-u)); }
+.ops-pillar + .ops-pillar { border-left-color: var(--ops-hair); }
+.ops-spark-cell { border-radius: 1px; }
+
+/* NEXT — the one instruction strip. Amber wash, rounded, because it is
+   the only element on the board that asks for an action. */
+.ops-next {
+  padding: calc(9 * var(--ops-u)) calc(16 * var(--ops-u));
+  border: 1px solid var(--h4-warn-line);
+  border-radius: var(--b-r-card);
+  background: var(--h4-warn-soft);
+}
+.ops-next-key { color: var(--h4-warn); }
+
+.ops-arrivals { padding: calc(10 * var(--ops-u)) calc(16 * var(--ops-u)) calc(14 * var(--ops-u)); }
+.ops-arrivals-verdict { border-radius: var(--b-r-card); background: var(--h4-paper-sunken); }
+.ops-kpi, .ops-akpi { min-width: 0; }
+.ops-foot { padding-top: calc(2 * var(--ops-u)); }
+
+/* Stale banner keeps its hatching — it must never look like a panel. */
+.ops-stale { border-radius: var(--b-r-card); }
+
+/* ---- narrow / split screen -------------------------------------- */
+@media (max-width: 1240px) {
+  .ops-kpis { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+  .ops-verdict-row { padding: calc(22 * var(--ops-u)) calc(22 * var(--ops-u)); }
+  .ops-solvency { width: auto; border-right: 1px solid var(--ops-rule); }
+}
+
+/* =========================================================
+   THE PHONE, on the same ground.
+   The phone board keeps every rule that makes it a phone board — the
+   filled verdict field, full contrast when untrusted, one-line lanes —
+   and takes the deep surface, the card family and the radii.
+   ========================================================= */
+.hm-ph {
+  --ph-hair: rgba(242, 239, 231, 0.08);
+  --ph-rule: rgba(242, 239, 231, 0.16);
+  background: var(--h4-canvas);
+}
+.hm-ph-bar { color: var(--h4-muted); }
+/* The verdict stays the only FILLED surface in the product — that is the
+   phone's whole legibility argument. It gains the slab's radius and sits
+   as a card rather than a full-bleed band. */
+.hm-ph-verdict {
+  margin: 8px 12px 0;
+  border-radius: 18px;
+  color: #0e1114;
+}
+.hm-ph-trust {
+  margin: 8px 12px 0;
+  border-radius: 999px;
+  border: 1px solid var(--ph-rule);
+  background: var(--h4-paper);
+}
+/* `.hm-ph-card` is the phone's one card class (a bordered box with an
+   optional <header>); `.hm-ph-sec` is a bare heading row and stays bare.
+   Cards take the panel radius and the paper ground so the screen reads
+   as a stack of objects rather than one long ruled sheet. */
+.hm-ph-card {
+  border-radius: var(--b-r-panel);
+  border-color: var(--ph-rule);
+  background: var(--h4-paper);
+  overflow: hidden;
+}
+.hm-ph-card > header { border-bottom-style: solid; border-bottom-color: var(--ph-hair); }
+.hm-ph-card--red { border-color: var(--h4-act); }
+.hm-ph-meter,
+.hm-ph-meter--sm { border-radius: 999px; background: #1e2429; }
+.hm-ph-meter i { border-radius: 999px; }
+.hm-ph-sq { border-radius: 2px; }
+.hm-ph-stale { border-radius: var(--b-r-card); margin: 8px 12px 0; }
+.hm-ph-empty { border-radius: var(--b-r-panel); background: var(--h4-paper); }
+/* The pool rows sit under a bare heading rather than inside a card — the
+   phone's own structure. On this ground that reads as "unfinished" beside
+   the flow and bank cards, so each pool becomes its own card: the phone's
+   money rows are the thing most often read one-handed in a hurry, and a
+   card edge is what separates two balances at that speed. */
+.hm-ph-pool {
+  padding: 10px 12px;
+  border: 1px solid var(--ph-hair);
+  border-radius: var(--b-r-card);
+  background: var(--h4-paper);
+}
+[data-testid="mobile-solvency"] { display: grid; gap: 8px; }
+
+/* Below the fold: the rollups are individually bordered, so the band itself
+   keeps the page ground and each rollup becomes a card. The fold stays a
+   break in reading order, not a break in the design. */
+.hm-ph-pillar {
+  border-radius: var(--b-r-card);
+  border-color: var(--ph-hair);
+  background: var(--h4-paper);
+}
+.hm-ph-below { border-top-color: var(--ph-rule); }
+.hm-ph-foot { color: var(--h4-muted); }

--- a/packages/monitor-ui/src/styles/hermes4-ops.css
+++ b/packages/monitor-ui/src/styles/hermes4-ops.css
@@ -1387,6 +1387,141 @@ body,
   color: var(--h4-muted);
   background: var(--h4-paper);
 }
+
+/* ---- OUTSIDERS — words beside marks ------------------------------
+   Left: the verdict lines (records, in words, with their windows).
+   Right: the wallet-journey ladders — the same instrumentation as
+   marks. Only wallet-unit rows are drawn ("at least this stage" is
+   monotonic, which is what makes bars honest); the pre-identity call
+   counters stay un-charted in the DOORS drawer. Fills are ink, not
+   sage: a count is not a verdict. */
+.ops-arrivals-verdict-body {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(calc(320 * var(--ops-u)), 42%);
+  gap: calc(6 * var(--ops-u)) calc(26 * var(--ops-u));
+  align-items: start;
+  margin-top: calc(6 * var(--ops-u));
+}
+.ops-arrivals-verdict-body > .ops-arrivals-verdict-lines { margin-top: 0; }
+.ops-arrivals-journey { min-width: 0; }
+.ops-arrivals-journey-head {
+  display: flex;
+  align-items: baseline;
+  gap: calc(10 * var(--ops-u));
+  flex-wrap: wrap;
+}
+.ops-arrivals-journey-head h4 {
+  margin: 0;
+  font-family: var(--h4-font-mono);
+  font-size: calc(9.5 * var(--ops-u));
+  font-weight: 600;
+  letter-spacing: 0.14em;
+  color: var(--h4-muted);
+}
+.ops-arrivals-journey-head span {
+  font-family: var(--h4-font-mono);
+  font-size: calc(8.5 * var(--ops-u));
+  color: var(--h4-tel);
+}
+.ops-arrivals-journey-doors {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: calc(16 * var(--ops-u));
+  margin-top: calc(6 * var(--ops-u));
+}
+.ops-ladder { min-width: 0; }
+.ops-ladder-head {
+  display: flex;
+  align-items: baseline;
+  gap: calc(8 * var(--ops-u));
+  padding-bottom: calc(3 * var(--ops-u));
+  border-bottom: 1px solid var(--ops-hair);
+}
+.ops-ladder-door {
+  font-family: var(--h4-font-display);
+  font-size: calc(11.5 * var(--ops-u));
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  color: var(--h4-ink);
+}
+.ops-ladder-since {
+  margin-left: auto;
+  font-family: var(--h4-font-mono);
+  font-size: calc(8.5 * var(--ops-u));
+  color: var(--h4-muted);
+}
+.ops-ladder-row {
+  display: grid;
+  grid-template-columns: calc(84 * var(--ops-u)) minmax(0, 1fr) calc(30 * var(--ops-u));
+  gap: calc(8 * var(--ops-u));
+  align-items: center;
+  padding: calc(3 * var(--ops-u)) 0;
+}
+.ops-ladder-stage {
+  font-family: var(--h4-font-mono);
+  font-size: calc(8.5 * var(--ops-u));
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--h4-muted);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.ops-ladder-track {
+  position: relative;
+  height: calc(7 * var(--ops-u));
+  border: 1px solid var(--ops-hair);
+  background: var(--h4-paper-sunken);
+}
+.ops-ladder-track i {
+  position: absolute;
+  inset: 0 auto 0 0;
+  background: var(--h4-ink-2);
+}
+.ops-ladder-count {
+  font-family: var(--h4-font-mono);
+  font-size: calc(10.5 * var(--ops-u));
+  text-align: right;
+  color: var(--h4-ink);
+}
+.ops-ladder-absent {
+  margin: calc(6 * var(--ops-u)) 0 0;
+  font-family: var(--h4-font-mono);
+  font-size: calc(9 * var(--ops-u));
+  color: var(--h4-tel);
+}
+
+/* Recency rungs — fixed bands, the snapshot's own clock. The active band is
+   inked, the rest stay hairline: one marker on a scale that never moves. */
+.ops-recency {
+  display: inline-flex;
+  gap: calc(3 * var(--ops-u));
+  margin-top: calc(5 * var(--ops-u));
+}
+.ops-recency i {
+  padding: calc(1 * var(--ops-u)) calc(7 * var(--ops-u));
+  border: 1px solid var(--ops-hair);
+  font-family: var(--h4-font-mono);
+  font-size: calc(8 * var(--ops-u));
+  font-style: normal;
+  letter-spacing: 0.06em;
+  color: var(--h4-muted);
+}
+.ops-recency i[data-active="yes"] {
+  border-color: var(--h4-line-strong);
+  background: var(--h4-tel-chip);
+  color: var(--h4-ink);
+}
+
+/* The 7d pair — two bars, one shared scale, deliberately NOT nested. */
+.ops-weekpair {
+  display: grid;
+  gap: calc(2 * var(--ops-u));
+  margin-top: calc(5 * var(--ops-u));
+  max-width: calc(260 * var(--ops-u));
+}
+.ops-weekpair i { display: block; height: calc(5 * var(--ops-u)); background: var(--h4-ink-2); }
+.ops-weekpair i[data-kind="worked"] { opacity: 0.68; }
 .ops-arrivals-secondary {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
@@ -1832,6 +1967,7 @@ body,
   .ops-arrivals > .ops-panel-head,
   .ops-arrivals-unattributed,
   .ops-arrivals-unreachable { grid-column: auto; }
+  .ops-arrivals-verdict-body { grid-template-columns: minmax(0, 1fr); }
   .ops-pillars { grid-template-columns: repeat(2, 1fr); }
   .ops-pillar:nth-child(3) { border-left: 0; }
   /* Fifth column: on the two-column layout the incident log takes a full row

--- a/packages/monitor-ui/src/styles/hermes4-ops.css
+++ b/packages/monitor-ui/src/styles/hermes4-ops.css
@@ -1306,13 +1306,13 @@ body,
 }
 /* The OUTSIDERS edge was a permanent 3px sage rail — a health colour on a
    panel that reports demand, lit regardless of what the panel said. Green
-   that cannot go out is decoration wearing a status colour; the edge is now
-   neutral and tone stays with the readings themselves. */
+   that cannot go out is decoration wearing a status colour. In the kit
+   grammar the KPI cards carry their own framing, so the section keeps one
+   plain hairline and no accent edge at all. */
 .ops-arrivals-verdict {
   padding: calc(9 * var(--ops-u)) calc(12 * var(--ops-u));
   border: 1px solid var(--ops-rule);
-  border-left: 3px solid var(--h4-line-strong);
-  background: var(--h4-paper-sunken);
+  border-radius: 10px;
 }
 .ops-arrivals-block-head {
   display: flex;
@@ -1388,140 +1388,180 @@ body,
   background: var(--h4-paper);
 }
 
-/* ---- OUTSIDERS — words beside marks ------------------------------
-   Left: the verdict lines (records, in words, with their windows).
-   Right: the wallet-journey ladders — the same instrumentation as
-   marks. Only wallet-unit rows are drawn ("at least this stage" is
-   monotonic, which is what makes bars honest); the pre-identity call
-   counters stay un-charted in the DOORS drawer. Fills are ink, not
-   sage: a count is not a verdict. */
-.ops-arrivals-verdict-body {
+/* ---- OUTSIDERS — operator-kit grammar --------------------------
+   Records as KPI cards (uppercase display eyebrow · one large display
+   value · mono provenance), the wallet journey as the kit's table
+   pattern, OURS / UNKNOWN as pills. Composed from the Averray design
+   system's operator UI kit, expressed in the board's --h4 tokens so
+   every color profile keeps working. Fills are ink, not sage: a count
+   is not a verdict. */
+.ops-arrivals-kpis {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) minmax(calc(320 * var(--ops-u)), 42%);
-  gap: calc(6 * var(--ops-u)) calc(26 * var(--ops-u));
-  align-items: start;
-  margin-top: calc(6 * var(--ops-u));
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: calc(10 * var(--ops-u));
+  margin-top: calc(8 * var(--ops-u));
 }
-.ops-arrivals-verdict-body > .ops-arrivals-verdict-lines { margin-top: 0; }
-.ops-arrivals-journey { min-width: 0; }
-.ops-arrivals-journey-head {
+.ops-kpi {
+  display: grid;
+  gap: calc(6 * var(--ops-u));
+  align-content: start;
+  padding: calc(11 * var(--ops-u)) calc(13 * var(--ops-u));
+  border: 1px solid var(--ops-hair);
+  border-radius: 10px;
+  background: var(--h4-paper-sunken);
+}
+.ops-kpi-lbl {
+  font-family: var(--h4-font-display);
+  font-size: calc(9.5 * var(--ops-u));
+  font-weight: 800;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--h4-muted);
+}
+.ops-kpi-val {
+  display: inline-flex;
+  align-items: baseline;
+  gap: calc(6 * var(--ops-u));
+  font-family: var(--h4-font-display);
+  font-weight: 700;
+  font-size: calc(23 * var(--ops-u));
+  line-height: 1.05;
+  color: var(--h4-ink);
+}
+.ops-kpi-word {
+  font-size: calc(10.5 * var(--ops-u));
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  color: var(--h4-muted);
+}
+/* Provenance figures inside a card: mono, quiet, badge riding along. */
+.ops-kpi .ops-arrivals-figure {
+  font-family: var(--h4-font-mono);
+  font-size: calc(10 * var(--ops-u));
+  line-height: 1.5;
+  color: var(--h4-muted);
+}
+.ops-kpi .ops-arrivals-figure .ops-kpi-val { color: var(--h4-ink); }
+
+/* ---- the wallet journey — the kit's table pattern ---------------- */
+.ops-journey {
+  margin-top: calc(10 * var(--ops-u));
+  border: 1px solid var(--ops-hair);
+  border-radius: 10px;
+  overflow: hidden;
+  background: var(--h4-paper-sunken);
+}
+.ops-journey-head {
   display: flex;
   align-items: baseline;
   gap: calc(10 * var(--ops-u));
   flex-wrap: wrap;
+  padding: calc(7 * var(--ops-u)) calc(13 * var(--ops-u));
+  border-bottom: 1px solid var(--ops-hair);
 }
-.ops-arrivals-journey-head h4 {
+.ops-journey-head h4 {
   margin: 0;
-  font-family: var(--h4-font-mono);
-  font-size: calc(9.5 * var(--ops-u));
-  font-weight: 600;
-  letter-spacing: 0.14em;
-  color: var(--h4-muted);
+  font-family: var(--h4-font-display);
+  font-size: calc(11 * var(--ops-u));
+  font-weight: 800;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--h4-ink);
 }
-.ops-arrivals-journey-head span {
+.ops-journey-head span {
+  margin-left: auto;
   font-family: var(--h4-font-mono);
   font-size: calc(8.5 * var(--ops-u));
   color: var(--h4-tel);
 }
-.ops-arrivals-journey-doors {
+.ops-journey-grid { padding: calc(2 * var(--ops-u)) calc(13 * var(--ops-u)) calc(9 * var(--ops-u)); }
+.ops-journey-row {
   display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
+  grid-template-columns: calc(100 * var(--ops-u)) repeat(2, minmax(0, 1fr));
   gap: calc(16 * var(--ops-u));
-  margin-top: calc(6 * var(--ops-u));
+  align-items: center;
+  padding: calc(4 * var(--ops-u)) 0;
 }
-.ops-ladder { min-width: 0; }
-.ops-ladder-head {
-  display: flex;
-  align-items: baseline;
-  gap: calc(8 * var(--ops-u));
-  padding-bottom: calc(3 * var(--ops-u));
+.ops-journey-row--head {
+  padding: calc(6 * var(--ops-u)) 0;
   border-bottom: 1px solid var(--ops-hair);
 }
-.ops-ladder-door {
+.ops-journey-row--head [role="columnheader"] {
   font-family: var(--h4-font-display);
-  font-size: calc(11.5 * var(--ops-u));
-  font-weight: 600;
-  letter-spacing: 0.08em;
-  color: var(--h4-ink);
-}
-.ops-ladder-since {
-  margin-left: auto;
-  font-family: var(--h4-font-mono);
-  font-size: calc(8.5 * var(--ops-u));
+  font-size: calc(10 * var(--ops-u));
+  font-weight: 800;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
   color: var(--h4-muted);
 }
-.ops-ladder-row {
-  display: grid;
-  grid-template-columns: calc(84 * var(--ops-u)) minmax(0, 1fr) calc(30 * var(--ops-u));
-  gap: calc(8 * var(--ops-u));
-  align-items: center;
-  padding: calc(3 * var(--ops-u)) 0;
+.ops-journey-door {
+  display: flex;
+  align-items: baseline;
+  gap: calc(7 * var(--ops-u));
 }
-.ops-ladder-stage {
+.ops-journey-door small {
   font-family: var(--h4-font-mono);
-  font-size: calc(8.5 * var(--ops-u));
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
+  font-size: calc(8 * var(--ops-u));
+  font-weight: 400;
+  letter-spacing: 0;
+  text-transform: none;
+  color: var(--h4-muted);
+}
+.ops-journey-stage {
+  font-family: var(--h4-font-mono);
+  font-size: calc(9.5 * var(--ops-u));
   color: var(--h4-muted);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
-.ops-ladder-track {
-  position: relative;
-  height: calc(7 * var(--ops-u));
-  border: 1px solid var(--ops-hair);
-  background: var(--h4-paper-sunken);
+.ops-journey-cell {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) calc(32 * var(--ops-u));
+  gap: calc(8 * var(--ops-u));
+  align-items: center;
 }
-.ops-ladder-track i {
-  position: absolute;
-  inset: 0 auto 0 0;
+.ops-journey-fill { display: block; min-width: 0; }
+.ops-journey-fill i {
+  display: block;
+  height: calc(6 * var(--ops-u));
+  border-radius: 3px;
   background: var(--h4-ink-2);
+  opacity: 0.5;
 }
-.ops-ladder-count {
+.ops-journey-cell b {
   font-family: var(--h4-font-mono);
-  font-size: calc(10.5 * var(--ops-u));
+  font-size: calc(11 * var(--ops-u));
+  font-weight: 600;
   text-align: right;
   color: var(--h4-ink);
 }
-.ops-ladder-absent {
-  margin: calc(6 * var(--ops-u)) 0 0;
+.ops-journey-cell .ops-journey-none { color: var(--h4-tel); font-weight: 400; }
+.ops-journey-absent {
+  margin: 0;
+  padding: calc(9 * var(--ops-u)) calc(13 * var(--ops-u));
   font-family: var(--h4-font-mono);
   font-size: calc(9 * var(--ops-u));
   color: var(--h4-tel);
 }
 
-/* Recency rungs — fixed bands, the snapshot's own clock. The active band is
-   inked, the rest stay hairline: one marker on a scale that never moves. */
-.ops-recency {
-  display: inline-flex;
-  gap: calc(3 * var(--ops-u));
-  margin-top: calc(5 * var(--ops-u));
-}
-.ops-recency i {
-  padding: calc(1 * var(--ops-u)) calc(7 * var(--ops-u));
+/* ---- OURS / UNKNOWN as pills ------------------------------------
+   The kit carries operational counts in pills, not prose: 999px, soft
+   neutral wash, uppercase display type. Neutral on purpose — none of
+   these counts are demand, and none are health. */
+.ops-arrivals-figures .ops-arrivals-figure {
+  padding: calc(3 * var(--ops-u)) calc(10 * var(--ops-u));
   border: 1px solid var(--ops-hair);
-  font-family: var(--h4-font-mono);
-  font-size: calc(8 * var(--ops-u));
-  font-style: normal;
-  letter-spacing: 0.06em;
-  color: var(--h4-muted);
-}
-.ops-recency i[data-active="yes"] {
-  border-color: var(--h4-line-strong);
+  border-radius: 999px;
   background: var(--h4-tel-chip);
-  color: var(--h4-ink);
+  font-family: var(--h4-font-display);
+  font-size: calc(9.5 * var(--ops-u));
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--h4-ink-2);
 }
-
-/* The 7d pair — two bars, one shared scale, deliberately NOT nested. */
-.ops-weekpair {
-  display: grid;
-  gap: calc(2 * var(--ops-u));
-  margin-top: calc(5 * var(--ops-u));
-  max-width: calc(260 * var(--ops-u));
-}
-.ops-weekpair i { display: block; height: calc(5 * var(--ops-u)); background: var(--h4-ink-2); }
-.ops-weekpair i[data-kind="worked"] { opacity: 0.68; }
+.ops-arrivals-unknown .ops-arrivals-figures .ops-arrivals-figure { color: var(--h4-tel); }
 .ops-arrivals-secondary {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
@@ -1967,7 +2007,7 @@ body,
   .ops-arrivals > .ops-panel-head,
   .ops-arrivals-unattributed,
   .ops-arrivals-unreachable { grid-column: auto; }
-  .ops-arrivals-verdict-body { grid-template-columns: minmax(0, 1fr); }
+  .ops-arrivals-kpis { grid-template-columns: repeat(2, minmax(0, 1fr)); }
   .ops-pillars { grid-template-columns: repeat(2, 1fr); }
   .ops-pillar:nth-child(3) { border-left: 0; }
   /* Fifth column: on the two-column layout the incident log takes a full row

--- a/packages/monitor-ui/src/styles/ops-scaling.test.ts
+++ b/packages/monitor-ui/src/styles/ops-scaling.test.ts
@@ -24,6 +24,17 @@ const CSS = readFileSync(fileURLToPath(new URL("./hermes4-ops.css", import.meta.
 /** Declarations, minus comments — comments discuss px sizes and are not rules. */
 const RULES = CSS.replace(/\/\*[\s\S]*?\*\//g, "");
 
+/**
+ * The Direction B surface layer is held to the SAME scaling contract.
+ *
+ * It is a second stylesheet over the same board, which is exactly how the
+ * original defect returned once already: a new file gets a hard-coded 13px,
+ * looks right on the laptop it was written on, and freezes on the wall. A
+ * layer that skins the board must scale with it.
+ */
+const DIRECTION_B = readFileSync(fileURLToPath(new URL("./hermes4-direction-b.css", import.meta.url)), "utf8")
+  .replace(/\/\*[\s\S]*?\*\//g, "");
+
 describe("--ops-u — the scaled pixel", () => {
   test("resolves to exactly 1px below 1920, so 1440x900 is untouched", () => {
     // The regression floor. Every `calc(N * var(--ops-u))` is N real pixels
@@ -53,6 +64,33 @@ describe("--ops-u — the scaled pixel", () => {
     const cap = /font-size:\s*clamp\(38px,\s*4\.1vw,\s*(\d+)px\)/.exec(RULES);
     expect(cap).not.toBeNull();
     expect(Number(cap![1])).toBeGreaterThanOrEqual(140);
+  });
+});
+
+describe("the Direction B layer obeys the same contract", () => {
+  test("every font-size scales, except the KPI figure's own curve", () => {
+    // The KPI value is sized by viewport like the verdict is: it is meant to
+    // be read across the room, one tier below the verdict itself.
+    const fixed = [...DIRECTION_B.matchAll(/font-size:\s*([^;]+);/g)]
+      .map((m) => m[1]!.trim())
+      .filter((v) => !v.includes("var(--ops-u)"))
+      .filter((v) => !/^clamp\(24px,\s*2\.1vw,\s*calc\(36 \* var\(--ops-u\)\)\)$/.test(v))
+      .filter((v) => v !== "inherit");
+    expect(fixed, "a fixed font-size freezes at 4K — express it in var(--ops-u)").toEqual([]);
+  });
+
+  test("no border in the layer is expressed in the scaled unit", () => {
+    const scaledBorders = [...DIRECTION_B.matchAll(/border[a-z-]*:\s*([^;]+);/g)]
+      .map((m) => m[1]!)
+      .filter((v) => v.includes("--ops-u"));
+    expect(scaledBorders, "borders stay at real pixels").toEqual([]);
+  });
+
+  test("it re-grounds the board without re-toning severity", () => {
+    // Surface tokens are its job. Re-tuning what red MEANS is not: the verdict
+    // is decided in one place and the alarm colour belongs to it.
+    expect(DIRECTION_B).toMatch(/--h4-surface:/);
+    expect(DIRECTION_B, "coral is the alarm — this layer must not move it").not.toMatch(/--h4-act:/);
   });
 });
 


### PR DESCRIPTION
## What

**Direction B — the midnight wall**, the design pass chosen from the review page (claude.ai/design → *Averray Design System* → "Ops board redesign"), implemented on the real ops board **and** the real phone board.

It ships as a **surface layer**, not a second design system: `hermes4-direction-b.css` redefines the tokens both existing sheets already read, so every panel lands on the new ground without re-declaring its components — and nothing in it changes what a number says.

### Desktop

- **Ground + card family** — deep ink surface, one card family (paper, hairline, 14px radius, one soft shadow).
- **Verdict slab** — the kit's hero treatment: 22px radius, masked grid, and a radial wash that follows the verdict's *own* tone (a coral headline on a sage-tinted ground is a mixed signal at wall distance).
- **Trust console** — the kit's floating window: a light card over the dark slab, window-bar motif, keeping its own light-side ink.
- **KPI strip** — `settled · proven on-chain · reward runway · signer gas`. Every figure is quoted from the view-model the panel below renders (`boardKpis`), so the strip is a second **reading**, never a second opinion; an unreported figure is a dash with its reason, never a zero.

### Phone

- Same ground, card family and radii; meters become pills; the trust strip becomes a pill.
- **Pool rows become cards.** They were bare under a heading while flow and bank were cards — and these are the money rows most often read one-handed, where a card edge is what separates two balances at speed.
- **The verdict field stays the only filled surface in the product** — that is the phone's whole legibility argument, and it is deliberately *not* given the desktop's slab or KPI strip.
- The square punched out of that field — a block of page ground with no meaning, pre-existing — becomes the kit's brand mark, the same chip the desktop top bar wears.

## Truth-boundary review — findings, all fixed here

1. **The alarm was the quietest thing on the console.** On the cream trust card, coral measured **2.58:1** — under the 3:1 floor — while sage read 6.80 and amber 4.72. The row rendered in it is `STREAM · DISCONNECTED`, which invalidates every number on the board. Fixed with a deeper step of the same role scoped to that light card only (now **6.28:1**); `--h4-act` is untouched everywhere else.
2. **A money figure parsed out of a sentence.** The runway KPI extracted its number from the pool footnote's rendered text with a regex — a figure that silently changes meaning the day the wording does. `payoutsRemaining()` is now the single projection both read, with `below-floor` and `no-average` named rather than collapsed into a zero.

## A guard that earned its keep

The new scaling test failed on a raw `15px` in a phone rule — correct for the phone, wrong for the board, and the reason is load-bearing: **`--ops-u` is declared on `.ops-board`, so a phone rule written in it does not fall back — it resolves to nothing and the size silently vanishes.** The guard now reads the file's own phone banner as the boundary: the board half must scale, the phone half must never reference the scaled unit at all.

## OUTSIDE — who is probing us, and how deep they got

An outsider at the door is the one thing on this board nobody else reports, and it rendered in 9px type at the very bottom. It now has a **presence line under the KPI strip** and a **named roster** in ARRIVALS.

**The data was already there and we threw it away.** The platform emits a per-identity registry (`agents[]`) on every arrivals read; `arrivals-feed.ts` returns a fixed allowlist, so it fell off the edge in silence. Live, that registry holds *both*:

- an outsider walking the gold path — `POST /auth/nonce` → `POST /jobs/claim` → `POST /jobs/submit`, 310 calls;
- an unattributed caller that made 127 requests in 18 seconds asking for `/wp-login.php`, `/.env`, and ~130 other exploit paths.

**Every counter on this board renders those two identically.** Only the routes tell them apart — so the routes are what the roster shows, verbatim. Nothing is characterised: "hostile" is a judgement this board has no evidence for, while `GET /wp-login.php` on a service with no WordPress *is* evidence and reads better as itself.

- **OUTSIDE strip** — deepest band reached, counts with their window, age, and a pulse that means RECENT. Built from neutral ink on purpose: sage would read as healthy and coral as page-someone, and an arrival is neither. Depth is carried by weight and a left rule, so it survives anyone who cannot separate the status hues at all.
- **WHO SHOWED UP** — `worked / looked / knocked`, each identity with its door, calls, age and top routes.
- **The fault line holds**: the full panel stays below everything that can page an operator. Demand is a business outcome, never a money fault.
- Ours and ambiguous identities can never enter either surface — a self-marked canary read as an arrival manufactures demand evidence.

### Truth-boundary findings on this feature — three, all fixed

1. **Two clocks, one event.** The strip aged `lastSeenMs` against the reader's clock while the roster used the producer's — they disagreed by a minute on their first render together. Both now use the snapshot clock, the rule the trust panel already follows.
2. **A frozen reading animated.** Dimming does not soften animation, so the live pulse kept reading as "happening now" under the stale banner. It stops while the board is untrusted.
3. **Counts with no window.** "1 worked" reads as today; the registry never meant that. The strip now states what it observed since.

Absent registry, unreadable registry, and no-outsiders-named stay three different sentences — none of them an empty list.

## Contracts held

- `ops-scaling` guards the new file on both halves, and asserts **the layer may not re-tone severity**.
- `.ops-money` keeps `flex: 1 0 auto`; the untrusted dim, stale banner, `deriveOpsVerdict`, and every testid are unchanged.
- **521 tests green** (34 files), `tsc -b` clean.
- Verified in the preview harness across **NOMINAL / STRESS / UNVERIFIED / LIVE** on both surfaces — including the data-poor state, where all four KPIs correctly read "—" with their reasons, and the phone's stress state (hatched STREAM DOWN, coral verdict field, breach card, "STILL TRUE? unknown — stream down"), which keeps full contrast because that screen gets read outdoors.

Producer note: this branch extends `services/slack-operator/src/arrivals-feed.ts` to pass the registry through (three states: absent / array / `agentsUnreadable`), so the roster appears after the monitor deploy — the board renders its own "not reported by this producer" line until then.

Supersedes #817 (the arrivals-only pass), whose work is included in this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
