### PR TITLE
feat(board): OUTSIDE signal + phone verdict mark (follow-up to #818)

### DIFF
--- a/packages/monitor-ui/src/components/ops/ArrivalsPanel.tsx
+++ b/packages/monitor-ui/src/components/ops/ArrivalsPanel.tsx
@@ -12,11 +12,17 @@
 // so would make canaries look like demand and compare unlike instrumentation.
 
 import { formatAgo } from "../../lib/monitor/ops-model.js";
-import { doorJourneys } from "../../lib/monitor/arrivals-view.js";
+import {
+  doorJourneys,
+  outsiderRoster,
+  type OutsiderBand,
+  type OutsiderRow,
+} from "../../lib/monitor/arrivals-view.js";
 import type {
   ArrivalOperatorView,
   ArrivalOperatorDoorRow,
   ArrivalsBlock,
+  ArrivalsSnapshot,
 } from "../../lib/monitor/product-health.js";
 
 export interface ArrivalsPanelProps {
@@ -116,6 +122,8 @@ export function ArrivalsPanel({ arrivals }: ArrivalsPanelProps) {
 
         <JourneyPanel view={operatorView} />
       </section>
+
+      <Roster arrivals={arrivals} generatedAtMs={generatedAtMs} />
 
       <div className="ops-arrivals-secondary">
         <section className="ops-arrivals-owned" data-testid="ops-arrivals-ours">
@@ -277,6 +285,116 @@ function JourneyPanel({ view }: { view: ArrivalOperatorView }) {
           ))}
         </div>
       )}
+    </div>
+  );
+}
+
+const BAND_LABEL: Record<OutsiderBand, string> = {
+  worked: "WORKED",
+  engaged: "LOOKED",
+  knocked: "KNOCKED",
+};
+
+/**
+ * WHO SHOWED UP — the named identities, deepest first.
+ *
+ * The counts above answer "how many"; this answers "who, and what did they
+ * actually do" — the only question on this panel an operator can learn from.
+ * Every row carries the routes it called, because that is what separates an
+ * outsider walking the gold path from a scanner asking for /wp-login.php, and
+ * no count can tell them apart.
+ *
+ * ── IT SAYS WHAT IT IS ────────────────────────────────────────────────────
+ *
+ * The registry names what it could attribute; the door tables count distinct
+ * wallets. They do not agree (live: a handful named against 164 counted), so
+ * the header says "the ones we can name" rather than letting a short list
+ * quietly contradict the number above it.
+ */
+function Roster({ arrivals, generatedAtMs }: { arrivals: ArrivalsSnapshot; generatedAtMs: number }) {
+  const roster = outsiderRoster(arrivals);
+  // Absent registry vs unreadable registry vs nobody named — three different
+  // facts, three different lines. None of them is an empty list.
+  if (!roster) {
+    return (
+      <section className="ops-roster" data-testid="ops-arrivals-roster">
+        <div className="ops-arrivals-block-head">
+          <h3>WHO SHOWED UP</h3>
+          <span>named identities · what they called</span>
+        </div>
+        <p className="ops-roster-absent" data-testid="ops-arrivals-roster-absent">
+          {arrivals.agentsUnreadable
+            ? `IDENTITY REGISTRY UNREADABLE — ${arrivals.agentsUnreadable}`
+            : "identity registry not reported by this producer — the counts above are all that was measured"}
+        </p>
+      </section>
+    );
+  }
+
+  return (
+    <section className="ops-roster" data-testid="ops-arrivals-roster">
+      <div className="ops-arrivals-block-head">
+        <h3>WHO SHOWED UP</h3>
+        <span>the ones we can name · a subset of the counts above</span>
+      </div>
+
+      <div className="ops-roster-bands" data-testid="ops-roster-bands">
+        {(["worked", "engaged", "knocked"] as const).map((band) => (
+          <span className="ops-roster-band" key={band} data-band={band}>
+            <b>{roster.counts[band]}</b>
+            {BAND_LABEL[band]}
+          </span>
+        ))}
+      </div>
+
+      {roster.rows.length === 0 ? (
+        <p className="ops-roster-absent" data-testid="ops-arrivals-roster-empty">
+          no outsider identity in the registry — ours and unclaimable are counted apart
+        </p>
+      ) : (
+        <div className="ops-roster-rows">
+          {roster.rows.map((row) => (
+            <RosterRow key={row.key} row={row} generatedAtMs={generatedAtMs} />
+          ))}
+        </div>
+      )}
+      {roster.more > 0 ? (
+        <p className="ops-roster-more" data-testid="ops-arrivals-roster-more">
+          +{roster.more} more named in the registry
+        </p>
+      ) : null}
+    </section>
+  );
+}
+
+function RosterRow({ row, generatedAtMs }: { row: OutsiderRow; generatedAtMs: number }) {
+  return (
+    <div className="ops-roster-row" data-band={row.band} data-testid={`ops-roster-${row.key}`}>
+      <span className="ops-roster-depth" data-band={row.band}>
+        {row.furthestStage}
+      </span>
+      <span className="ops-roster-who">
+        <b>{row.label}</b>
+        <small>
+          {row.doors.length > 0 ? `${row.doors.join(" + ").toUpperCase()} · ` : ""}
+          {row.calls} call{row.calls === 1 ? "" : "s"} · last {formatAgo(row.lastSeenMs, generatedAtMs)}
+        </small>
+      </span>
+      {/* What they actually called. Verbatim, never characterised — a request
+          for /wp-login.php on a service that has no WordPress is evidence, and
+          it reads better as itself than as any label this board could invent. */}
+      <span className="ops-roster-routes">
+        {row.routesUnrecorded ? (
+          <em>no routes recorded for this identity</em>
+        ) : (
+          row.topRoutes.map((r) => (
+            <span className="ops-roster-route" key={r.route} title={`${r.route} — ${r.calls} calls`}>
+              {r.route}
+              <i>{r.calls}</i>
+            </span>
+          ))
+        )}
+      </span>
     </div>
   );
 }

--- a/packages/monitor-ui/src/components/ops/OpsBoard.tsx
+++ b/packages/monitor-ui/src/components/ops/OpsBoard.tsx
@@ -23,6 +23,7 @@ import type { MonitorBoard } from "../../lib/monitor/board-cache.js";
 import type { ProductHealth } from "../../lib/monitor/product-health.js";
 import { formatAgo, incidentRows, probeOpsTone } from "../../lib/monitor/ops-model.js";
 import { boardKpis, economicsLine } from "../../lib/monitor/ops-spec.js";
+import { outsiderPresence, type OutsiderBand } from "../../lib/monitor/arrivals-view.js";
 import { opsVerdict, staleAfterMs, trustRows } from "../../lib/monitor/ops-spec.js";
 import { FlowPanel } from "./FlowPanel.js";
 import { PillarStrip } from "./PillarStrip.js";
@@ -177,6 +178,23 @@ export function OpsBoard({
           ))}
         </div>
 
+        {/* ── OUTSIDE ──────────────────────────────────────────────────
+            Someone who is not us is at the door, and how far in they got.
+
+            THE FAULT LINE STILL HOLDS. The full ARRIVALS panel stays below
+            everything that can page an operator — demand is a business
+            outcome and must never be recast as a money fault. What sits here
+            is a PRESENCE line, and it is deliberately built out of the
+            board's neutral ink rather than its status palette: it cannot be
+            mistaken for a probe, because nothing on it is ever sage or coral.
+
+            It earns the position because it is the one thing on this board
+            nobody else reports. Every panel above answers "is our money
+            safe"; this answers "is anyone out there", and an outsider who
+            reached `submitted` while the operator was looking at gas is the
+            single most consequential thing that can happen on a quiet day. */}
+        <OutsidePresence arrivals={health.arrivals} nowMs={nowMs} />
+
         <div className="ops-money">
           <SolvencyPanel solvency={health.solvency} gas={health.gas} payout={health.flow?.payout} />
           <FlowPanel flow={health.flow} externalFunnel={health.externalFunnel} lifecycle={health.lifecycle} nowMs={nowMs} />
@@ -255,6 +273,60 @@ export function OpsBoard({
           <span>refresh is the only control · everything else is read-only</span>
         </div>
       </div>
+    </div>
+  );
+}
+
+const PRESENCE_COPY: Record<OutsiderBand, { verb: string; note: string }> = {
+  worked: { verb: "worked", note: "an outsider claimed or submitted — this is demand" },
+  engaged: { verb: "looked around", note: "reached us and got as far as identifying" },
+  knocked: { verb: "knocked", note: "reached the door and went no further" },
+};
+
+/**
+ * OUTSIDE — the presence line.
+ *
+ * Renders nothing at all when the producer sends no registry: this strip is
+ * an addition, and a board that predates it must not grow a permanent "not
+ * reported" bar across its top band. The ARRIVALS panel below says so in its
+ * own words, which is the right place for that sentence.
+ */
+function OutsidePresence({ arrivals, nowMs }: { arrivals: ProductHealth["arrivals"]; nowMs: number }) {
+  const presence = outsiderPresence(arrivals, nowMs);
+  if (!presence || presence.band == null) return null;
+  const copy = PRESENCE_COPY[presence.band];
+
+  return (
+    <div className="ops-outside" data-band={presence.band} data-live={presence.live ? "yes" : "no"} data-testid="ops-outside">
+      <span className="ops-outside-key">OUTSIDE</span>
+      {/* The pulse marks RECENT, not healthy — it is ink, like everything
+          else on this line, and it stops when the activity stops. */}
+      <i className="ops-outside-pulse" aria-hidden />
+      <span className="ops-outside-lead">
+        deepest: someone <b>{copy.verb}</b>
+      </span>
+      {/* The counts are the registry's whole observation window, not today.
+          "1 worked" with no window stated reads as this morning, and the
+          registry has never meant that. */}
+      <span className="ops-outside-counts">
+        {(["worked", "engaged", "knocked"] as const)
+          .filter((b) => presence.counts[b] > 0)
+          .map((b) => `${presence.counts[b]} ${PRESENCE_COPY[b].verb}`)
+          .join(" · ")}
+        <small>
+          {presence.observingSinceMs == null
+            ? " since observing began"
+            : ` since ${new Date(presence.observingSinceMs).toISOString().slice(0, 10)}`}
+        </small>
+      </span>
+      {/* Aged against the PRODUCER's clock, the same one the roster below
+          uses — two clocks put two ages for one event on one screen. */}
+      <span className="ops-outside-when">
+        {presence.lastSeenMs == null
+          ? "no activity time reported"
+          : `last ${formatAgo(presence.lastSeenMs, presence.asOfMs)}`}
+      </span>
+      <span className="ops-outside-note">{copy.note}</span>
     </div>
   );
 }

--- a/packages/monitor-ui/src/lib/monitor/arrivals-view.test.ts
+++ b/packages/monitor-ui/src/lib/monitor/arrivals-view.test.ts
@@ -91,3 +91,135 @@ describe("doorJourneys — the wallet half only, per-door scale", () => {
     expect(http!.stages).toEqual([]);
   });
 });
+
+// ── the named-identity roster ───────────────────────────────────────────────
+
+import { OPS_FIXTURE_ARRIVALS } from "./ops-fixtures.js";
+import { outsiderBand, outsiderLabel, outsiderPresence, outsiderRoster } from "./arrivals-view.js";
+
+describe("outsiderRoster — who showed up, and what they called", () => {
+  test("ours and unclaimable never enter the roster", () => {
+    // A self-marked canary read as an arrival manufactures demand evidence;
+    // an ambiguous caller cannot be claimed by either side.
+    const roster = outsiderRoster(OPS_FIXTURE_ARRIVALS)!;
+    const keys = roster.rows.map((r) => r.key);
+    expect(keys).not.toContain("client:averray-canary@1.0");
+    expect(keys).not.toContain("client:Anthropic-ClaudeAI");
+    expect(keys).toHaveLength(3);
+  });
+
+  test("depth orders the roster — work first, knocks last", () => {
+    const roster = outsiderRoster(OPS_FIXTURE_ARRIVALS)!;
+    expect(roster.rows.map((r) => r.band)).toEqual(["worked", "engaged", "knocked"]);
+    expect(roster.counts).toEqual({ worked: 1, engaged: 1, knocked: 1 });
+  });
+
+  test("the routes come through verbatim, busiest first", () => {
+    // This is the whole point: a counter cannot tell the gold path from a
+    // scanner, and the routes can.
+    const roster = outsiderRoster(OPS_FIXTURE_ARRIVALS)!;
+    const worker = roster.rows.find((r) => r.band === "worked")!;
+    expect(worker.topRoutes[0]).toEqual({ route: "POST /auth/nonce", calls: 39 });
+    expect(worker.topRoutes.map((r) => r.route)).toContain("POST /jobs/submit");
+
+    const knocker = roster.rows.find((r) => r.band === "knocked")!;
+    expect(knocker.topRoutes.map((r) => r.route)).toContain("GET /wp-login.php");
+    // …and it is never characterised — the row carries the route, not a label.
+    expect(JSON.stringify(knocker)).not.toMatch(/hostile|attack|malicious|scanner/i);
+  });
+
+  test("an identity with no recorded routes says so instead of showing none", () => {
+    const bare = {
+      ...OPS_FIXTURE_ARRIVALS,
+      agents: [{ ...OPS_FIXTURE_ARRIVALS.agents![0]!, tools: {} }],
+    };
+    const row = outsiderRoster(bare)!.rows[0]!;
+    expect(row.routesUnrecorded).toBe(true);
+    expect(row.topRoutes).toEqual([]);
+  });
+
+  test("no registry is null — never an empty roster", () => {
+    // "We cannot see who arrived" and "nobody arrived" are the two states
+    // this panel exists to keep apart.
+    const { agents: _agents, ...withoutAgents } = OPS_FIXTURE_ARRIVALS;
+    expect(outsiderRoster(withoutAgents)).toBeNull();
+    expect(outsiderRoster(undefined)).toBeNull();
+    expect(outsiderRoster({ unavailable: "feed down" })).toBeNull();
+  });
+
+  test("caps the rows and counts the remainder rather than hiding it", () => {
+    const roster = outsiderRoster(OPS_FIXTURE_ARRIVALS, 2)!;
+    expect(roster.rows).toHaveLength(2);
+    expect(roster.more).toBe(1);
+    // The band counts still describe EVERY outsider, not just the shown ones.
+    expect(roster.counts.knocked).toBe(1);
+  });
+});
+
+describe("outsiderLabel — named from what the producer gave", () => {
+  const base = OPS_FIXTURE_ARRIVALS.agents![0]!;
+  test("a declared client name wins, with its version", () => {
+    expect(outsiderLabel({ ...base, name: "mcpbeat", version: "0.1" })).toBe("mcpbeat 0.1");
+  });
+  test("a wallet is shortened the way the board shortens addresses", () => {
+    expect(outsiderLabel({ ...base, name: null, wallet: "0x191c000000000000000000000000000000003b0e" }))
+      .toBe("0x191c…3b0e");
+  });
+  test("an unattributed key is called what it is, never dressed up", () => {
+    expect(outsiderLabel({ ...base, name: null, wallet: null, key: "anon:7eba341801e4" }))
+      .toBe("unattributed caller");
+  });
+});
+
+describe("outsiderBand", () => {
+  test("claimed, submitted and settled are work", () => {
+    for (const s of ["claimed", "submitted", "settled"]) expect(outsiderBand(s)).toBe("worked");
+  });
+  test("an unknown stage falls to the floor, never up", () => {
+    expect(outsiderBand("teleported")).toBe("knocked");
+  });
+});
+
+describe("outsiderPresence — the top-band signal", () => {
+  const NOW_P = OPS_FIXTURE_ARRIVALS.generatedAtMs!;
+  test("reports the deepest band anyone reached", () => {
+    const p = outsiderPresence(OPS_FIXTURE_ARRIVALS, NOW_P)!;
+    expect(p.band).toBe("worked");
+    expect(p.counts.worked).toBe(1);
+    expect(p.live).toBe(true);
+  });
+
+  test("ages are measured against the PRODUCER's clock, not the reader's", () => {
+    // Two clocks put two ages for one event on one screen — the strip and the
+    // roster below it disagreed by a minute the first time they rendered.
+    const p = outsiderPresence(OPS_FIXTURE_ARRIVALS, NOW_P + 9 * 60_000)!;
+    expect(p.asOfMs).toBe(OPS_FIXTURE_ARRIVALS.generatedAtMs);
+    // …so a reader's clock running on is not what decides `live` either.
+    expect(p.live).toBe(true);
+  });
+
+  test("live is a window against that clock, not a vibe", () => {
+    const stale = {
+      ...OPS_FIXTURE_ARRIVALS,
+      generatedAtMs: OPS_FIXTURE_ARRIVALS.generatedAtMs! + 5 * 3_600_000,
+    };
+    expect(outsiderPresence(stale, NOW_P)!.live).toBe(false);
+  });
+
+  test("the counts carry the window they were measured over", () => {
+    const p = outsiderPresence(OPS_FIXTURE_ARRIVALS, NOW_P)!;
+    expect(p.observingSinceMs).toBe(OPS_FIXTURE_ARRIVALS.observingSinceMs);
+  });
+
+  test("no registry → null, so the strip renders nothing at all", () => {
+    const { agents: _drop, ...withoutAgents } = OPS_FIXTURE_ARRIVALS;
+    expect(outsiderPresence(withoutAgents, NOW_P)).toBeNull();
+  });
+
+  test("a registry with only ours in it reports nobody outside", () => {
+    const onlySelf = { ...OPS_FIXTURE_ARRIVALS, agents: OPS_FIXTURE_ARRIVALS.agents!.filter((a) => a.self) };
+    const p = outsiderPresence(onlySelf, NOW_P)!;
+    expect(p.band).toBeNull();
+    expect(p.counts).toEqual({ worked: 0, engaged: 0, knocked: 0 });
+  });
+});

--- a/packages/monitor-ui/src/lib/monitor/arrivals-view.ts
+++ b/packages/monitor-ui/src/lib/monitor/arrivals-view.ts
@@ -14,7 +14,7 @@
 //   · the two doors carry different windows and different cut-overs, so each
 //     door scales to its OWN maximum and nothing ever sums or compares them.
 
-import type { ArrivalOperatorView } from "./product-health.js";
+import type { ArrivalAgent, ArrivalOperatorView, ArrivalsBlock } from "./product-health.js";
 
 export interface JourneyStageView {
   stage: string;
@@ -59,4 +59,190 @@ export function doorJourneys(view: ArrivalOperatorView): DoorJourneyView[] {
       })),
     };
   });
+}
+
+// ── WHO SHOWED UP — the named-identity roster ───────────────────────────────
+//
+// The registry (`arrivals.agents`) is the only per-identity evidence the board
+// gets. It answers what every count above it cannot: an outsider that reached
+// `submitted` by calling /auth/nonce → /jobs/claim → /jobs/submit is demand;
+// an anonymous caller that made 127 requests in 18 seconds asking for
+// /wp-login.php and /.env is a scanner. Both are "an outsider reached us", and
+// only the routes tell them apart.
+//
+// ── THE THREE BANDS ARE DERIVED FROM ONE FIELD ────────────────────────────
+//
+// Depth comes from `furthestStage`, which the producer decides. Nothing here
+// infers intent from a route, a name, or a key prefix: the roster shows what
+// was called and lets the operator read it. Calling something "hostile" would
+// be a judgement this board has no evidence for — `GET /wp-login.php` on a
+// service that has no WordPress is evidence, and it speaks for itself.
+
+/** The stages that mean an outsider did WORK, not just looked around. */
+const WORKED_STAGES = new Set(["claimed", "submitted", "settled"]);
+/** Reached us and got as far as identifying — interest, not yet work. */
+const ENGAGED_STAGES = new Set(["browsed", "evaluated", "identified", "authenticated"]);
+
+export type OutsiderBand = "worked" | "engaged" | "knocked";
+
+export interface OutsiderRow {
+  key: string;
+  /** "mcpbeat 0.1" · "0x191c…3b0e" · "unattributed caller" — never invented. */
+  label: string;
+  band: OutsiderBand;
+  furthestStage: string;
+  calls: number;
+  lastSeenMs: number;
+  firstSeenMs: number;
+  doors: string[];
+  /** Busiest routes/tools first, capped. Empty when none were recorded. */
+  topRoutes: Array<{ route: string; calls: number }>;
+  /** True when nothing at all was recorded — "none recorded", never "none". */
+  routesUnrecorded: boolean;
+}
+
+export interface OutsiderRoster {
+  /** Newest activity first, within band order: worked → engaged → knocked. */
+  rows: OutsiderRow[];
+  counts: Record<OutsiderBand, number>;
+  /** Named identities beyond the cap, still in the registry. Never hidden. */
+  more: number;
+}
+
+/** Which band a stage falls in. Unknown stages are `knocked` — the floor. */
+export function outsiderBand(stage: string): OutsiderBand {
+  if (WORKED_STAGES.has(stage)) return "worked";
+  if (ENGAGED_STAGES.has(stage)) return "engaged";
+  return "knocked";
+}
+
+/**
+ * A readable name for an identity, from what the producer actually gave.
+ *
+ * Order is deliberate: a declared client name is what the caller told us, a
+ * wallet is what they proved, and an unattributed key is neither. The key's
+ * own prefix is never dressed up — `anon:7eba…` becomes "unattributed
+ * caller", which is what it is.
+ */
+export function outsiderLabel(agent: ArrivalAgent): string {
+  if (agent.name) return agent.version ? `${agent.name} ${agent.version}` : agent.name;
+  if (agent.wallet) return `${agent.wallet.slice(0, 6)}…${agent.wallet.slice(-4)}`;
+  if (agent.key.startsWith("wallet:")) {
+    const w = agent.key.slice(7);
+    return w.length > 12 ? `${w.slice(0, 6)}…${w.slice(-4)}` : w;
+  }
+  return "unattributed caller";
+}
+
+/**
+ * The roster, outsiders only, deepest band first and newest within it.
+ *
+ * `null` when the producer sent no registry — the caller says so rather than
+ * drawing an empty list, because "we cannot see who arrived" and "nobody
+ * arrived" are the two states this whole panel exists to keep apart.
+ */
+export function outsiderRoster(
+  arrivals: ArrivalsBlock | undefined,
+  max = 8,
+  maxRoutes = 4,
+): OutsiderRoster | null {
+  if (!arrivals || "unavailable" in arrivals || !arrivals.agents) return null;
+
+  // Ours and ambiguous never enter: a self-marked probe read as an arrival
+  // manufactures demand evidence, and an ambiguous one cannot be claimed.
+  const outsiders = arrivals.agents.filter((a) => !a.self && !a.ambiguous);
+  const bandRank: Record<OutsiderBand, number> = { worked: 0, engaged: 1, knocked: 2 };
+
+  const rows: OutsiderRow[] = outsiders
+    .map((agent) => {
+      const routes = Object.entries(agent.tools ?? {})
+        .filter(([, n]) => typeof n === "number" && n > 0)
+        .sort((a, b) => b[1] - a[1]);
+      return {
+        key: agent.key,
+        label: outsiderLabel(agent),
+        band: outsiderBand(agent.furthestStage),
+        furthestStage: agent.furthestStage,
+        calls: agent.calls,
+        lastSeenMs: agent.lastSeenMs,
+        firstSeenMs: agent.firstSeenMs,
+        doors: agent.doors ?? [],
+        topRoutes: routes.slice(0, maxRoutes).map(([route, calls]) => ({ route, calls })),
+        routesUnrecorded: routes.length === 0,
+      };
+    })
+    .sort((a, b) => bandRank[a.band] - bandRank[b.band] || b.lastSeenMs - a.lastSeenMs);
+
+  const counts: Record<OutsiderBand, number> = { worked: 0, engaged: 0, knocked: 0 };
+  for (const row of rows) counts[row.band] += 1;
+
+  return { rows: rows.slice(0, max), counts, more: Math.max(0, rows.length - max) };
+}
+
+export interface OutsiderPresence {
+  /** The deepest band any named outsider reached. */
+  band: OutsiderBand | null;
+  counts: Record<OutsiderBand, number>;
+  /** Epoch ms of the most recent named outsider activity; null when none. */
+  lastSeenMs: number | null;
+  /**
+   * The clock every age on this strip is measured against — the PRODUCER's,
+   * never the reader's. See below.
+   */
+  asOfMs: number;
+  /** True while that activity is inside the live window (default 1h). */
+  live: boolean;
+  /**
+   * Epoch ms the registry has been observing since, when the producer says.
+   * The counts are all-time against this, and the strip states it: "1 worked"
+   * with no window reads as today, and the registry has never meant that.
+   */
+  observingSinceMs: number | null;
+}
+
+/**
+ * The glanceable version, for the top band: is anyone out there, how deep did
+ * they get, and how long ago?
+ *
+ * ── ONE CLOCK, AND IT IS THE PRODUCER'S ───────────────────────────────────
+ *
+ * `lastSeenMs` is a producer timestamp, so its age is measured against
+ * `generatedAtMs` — the same snapshot clock the trust panel uses, for the same
+ * reason: a reader's clock ticking on its own keeps a dead feed looking alive,
+ * and mixing the two puts two different ages for ONE event on one screen. That
+ * is not hypothetical — this strip and the roster below it disagreed by a
+ * minute the first time they rendered together.
+ *
+ * `null` when the registry is absent — the strip renders nothing at all rather
+ * than a confident zero.
+ */
+export function outsiderPresence(
+  arrivals: ArrivalsBlock | undefined,
+  fallbackNowMs: number,
+  liveWindowMs = 3_600_000,
+): OutsiderPresence | null {
+  const roster = outsiderRoster(arrivals, Number.MAX_SAFE_INTEGER);
+  if (!roster || !arrivals || "unavailable" in arrivals) return null;
+  // The producer's own clock when it sent one; the reader's only as a last
+  // resort, and then it is the same clock the rest of the board falls back to.
+  const asOfMs = arrivals.generatedAtMs ?? fallbackNowMs;
+  const lastSeenMs = roster.rows.reduce<number | null>(
+    (acc, r) => (acc == null || r.lastSeenMs > acc ? r.lastSeenMs : acc),
+    null,
+  );
+  const band: OutsiderBand | null = roster.counts.worked > 0
+    ? "worked"
+    : roster.counts.engaged > 0
+      ? "engaged"
+      : roster.counts.knocked > 0
+        ? "knocked"
+        : null;
+  return {
+    band,
+    counts: roster.counts,
+    lastSeenMs,
+    asOfMs,
+    live: lastSeenMs != null && asOfMs - lastSeenMs <= liveWindowMs,
+    observingSinceMs: arrivals.observingSinceMs ?? null,
+  };
 }

--- a/packages/monitor-ui/src/lib/monitor/ops-fixtures.ts
+++ b/packages/monitor-ui/src/lib/monitor/ops-fixtures.ts
@@ -623,4 +623,96 @@ export const OPS_FIXTURE_ARRIVALS: ArrivalsSnapshot = {
       },
     },
   },
+  // THE NAMED-IDENTITY REGISTRY, shaped like the live one on 2026-08-17.
+  //
+  // Three real cases, because the panel exists to tell them apart:
+  //   · a wallet that walked the gold path to `submitted` — demand
+  //   · a client that browsed and stopped — interest
+  //   · an unattributed caller that made 127 requests in 18 seconds asking
+  //     for /wp-login.php and /.env. It is an outsider by every count on
+  //     this board, and it is emphatically not demand. Only the routes say so.
+  //
+  // Route names and shapes are transcribed from the live producer; the wallet
+  // is a real observed outsider, truncated in the same way the board shows it.
+  agents: [
+    {
+      key: "wallet:0x191c000000000000000000000000000000003b0e",
+      wallet: "0x191c000000000000000000000000000000003b0e",
+      name: "averray-reference-agent",
+      version: "0.4",
+      era: "modern",
+      self: false,
+      firstSeenMs: FIXTURE_NOW - 3 * DAY,
+      lastSeenMs: FIXTURE_NOW - 7 * MIN,
+      furthestStage: "submitted",
+      calls: 310,
+      tools: {
+        "GET /jobs/preflight": 35,
+        "POST /auth/nonce": 39,
+        "POST /jobs/claim": 11,
+        "POST /jobs/submit": 11,
+      },
+      doors: ["http"],
+    },
+    {
+      key: "client:mcpbeat@0.1",
+      name: "mcpbeat",
+      version: "0.1",
+      era: "legacy",
+      self: false,
+      firstSeenMs: FIXTURE_NOW - 6 * DAY,
+      lastSeenMs: FIXTURE_NOW - 4 * HOUR,
+      furthestStage: "browsed",
+      calls: 828,
+      tools: { listJobs: 812, getPlatformCapabilities: 16 },
+      doors: ["mcp"],
+    },
+    {
+      key: "anon:7eba341801e4",
+      name: null,
+      version: null,
+      era: "legacy",
+      self: false,
+      firstSeenMs: FIXTURE_NOW - 51 * MIN,
+      lastSeenMs: FIXTURE_NOW - 51 * MIN,
+      furthestStage: "reached",
+      calls: 127,
+      tools: {
+        "GET /wp-login.php": 1,
+        "GET /.env": 1,
+        "GET /wp-content/plugins/hellopress/wp_filemanager.php": 1,
+        "GET /vendor/phpunit/phpunit/src/Util/PHP/eval-stdin.php": 1,
+      },
+      doors: ["http"],
+    },
+    // One of ours, and one unclaimable — present so the filter is exercised:
+    // neither may ever appear in the roster or the presence line.
+    {
+      key: "client:averray-canary@1.0",
+      name: "averray-canary",
+      version: "1.0",
+      era: "modern",
+      self: true,
+      firstSeenMs: FIXTURE_NOW - 9 * DAY,
+      lastSeenMs: FIXTURE_NOW - 12 * MIN,
+      furthestStage: "settled",
+      calls: 44,
+      tools: { "POST /jobs/claim": 2 },
+      doors: ["http"],
+    },
+    {
+      key: "client:Anthropic-ClaudeAI",
+      name: "Anthropic/ClaudeAI",
+      version: null,
+      era: "modern",
+      self: false,
+      ambiguous: true,
+      firstSeenMs: FIXTURE_NOW - 2 * DAY,
+      lastSeenMs: FIXTURE_NOW - 30 * MIN,
+      furthestStage: "evaluated",
+      calls: 18,
+      tools: { listJobs: 18 },
+      doors: ["mcp"],
+    },
+  ],
 };

--- a/packages/monitor-ui/src/lib/monitor/product-health.ts
+++ b/packages/monitor-ui/src/lib/monitor/product-health.ts
@@ -489,6 +489,43 @@ export interface ArrivalsSnapshot {
   clients: ArrivalClient[];
   /** Verdict-first projection derived by the shared self-identity registry. */
   operatorView?: ArrivalOperatorView | { unavailable: string };
+  /**
+   * The named-identity registry (see `ArrivalAgent`). Absent on a producer
+   * that does not emit it; `agentsUnreadable` when it was there and could not
+   * be parsed — a finding, never rendered as "nobody arrived".
+   */
+  agents?: ArrivalAgent[];
+  agentsUnreadable?: string;
+}
+
+/**
+ * ONE NAMED IDENTITY, across both doors — who arrived, how deep, and what
+ * they actually called.
+ *
+ * This is the only per-identity evidence on the board. It is what separates
+ * an outsider walking the gold path from a scanner asking for `/wp-login.php`,
+ * which no counter can do.
+ *
+ * SCOPED, NEVER AN ENUMERATION: the registry names what it could attribute,
+ * while the door tables count distinct wallets, and the two do not agree. Any
+ * surface rendering these rows must say which it is showing.
+ */
+export interface ArrivalAgent {
+  key: string;
+  wallet?: string | null;
+  name: string | null;
+  version: string | null;
+  era: string | null;
+  self: boolean;
+  ambiguous?: boolean;
+  firstSeenMs: number;
+  lastSeenMs: number;
+  /** `settled` is reachable here and is NOT one of ARRIVAL_STAGES. */
+  furthestStage: string;
+  calls: number;
+  /** Route or tool name → call count. Empty when nothing was recorded. */
+  tools: Record<string, number>;
+  doors?: string[];
 }
 
 /** A reading and a failure are mutually exclusive; neither becomes zero. */

--- a/packages/monitor-ui/src/styles/hermes4-direction-b.css
+++ b/packages/monitor-ui/src/styles/hermes4-direction-b.css
@@ -414,6 +414,24 @@
   border-radius: 18px;
   color: #0e1114;
 }
+/* The square punched out of the verdict field was the one element on this
+   screen with no meaning — a solid block of the page ground, sitting inside
+   a rounded card. It becomes the kit's brand mark, the same chip the desktop
+   top bar wears, so the phone's loudest surface carries the same anchor. */
+.hm-ph-verdict-head i {
+  display: grid;
+  place-items: center;
+  border-radius: var(--b-r-chip);
+  background: #0e1114;
+}
+.hm-ph-verdict-head i::after {
+  content: "A";
+  font-family: var(--h4-font-display);
+  font-weight: 700;
+  font-size: 15px;
+  letter-spacing: 0;
+  color: var(--h4-ink);
+}
 .hm-ph-trust {
   margin: 8px 12px 0;
   border-radius: 999px;

--- a/packages/monitor-ui/src/styles/hermes4-direction-b.css
+++ b/packages/monitor-ui/src/styles/hermes4-direction-b.css
@@ -395,6 +395,202 @@
 }
 
 /* =========================================================
+   OUTSIDE — presence, and the roster it summarises.
+
+   The one band on this board that is NOT about our money. It is
+   built from neutral ink on purpose: sage would read as "healthy"
+   and coral as "page someone", and an outsider arriving is neither.
+   Depth is carried by WEIGHT and a left rule, not by status hue —
+   which also means it stays legible to anyone who cannot separate
+   the status colours at all.
+   ========================================================= */
+.ops-outside {
+  display: flex;
+  align-items: baseline;
+  gap: calc(12 * var(--ops-u));
+  flex-wrap: wrap;
+  padding: calc(9 * var(--ops-u)) calc(16 * var(--ops-u));
+  border: 1px solid var(--ops-rule);
+  border-left: 3px solid var(--h4-ink-2);
+  border-radius: var(--b-r-card);
+  background: var(--h4-paper);
+  font-family: var(--h4-font-mono);
+  font-size: calc(11.5 * var(--ops-u));
+  color: var(--h4-ink-2);
+}
+/* Depth as weight: a knock is a hairline, work is the full ink rule. */
+.ops-outside[data-band="knocked"] { border-left-color: var(--h4-faint); }
+.ops-outside[data-band="engaged"] { border-left-color: var(--h4-muted); }
+.ops-outside[data-band="worked"]  { border-left-color: var(--h4-ink); }
+.ops-outside-key {
+  font-family: var(--h4-font-display);
+  font-size: calc(10 * var(--ops-u));
+  font-weight: 800;
+  letter-spacing: 0.16em;
+  color: var(--h4-muted);
+}
+/* Recent, not healthy. Ink, and it stops when the activity does. */
+.ops-outside-pulse {
+  width: calc(7 * var(--ops-u));
+  height: calc(7 * var(--ops-u));
+  flex: none;
+  border-radius: 50%;
+  background: var(--h4-faint);
+}
+.ops-outside[data-live="yes"] .ops-outside-pulse {
+  background: var(--h4-ink);
+  animation: ops-outside-pulse 2.6s ease-in-out infinite;
+}
+@keyframes ops-outside-pulse {
+  0%, 100% { opacity: 1; transform: scale(1); }
+  50%      { opacity: 0.35; transform: scale(0.72); }
+}
+@media (prefers-reduced-motion: reduce) {
+  .ops-outside[data-live="yes"] .ops-outside-pulse { animation: none; }
+}
+/* A FROZEN READING MUST NOT ANIMATE.
+   Everything below the stale banner dims, but a pulsing dot goes on reading
+   as "happening now" at 72% opacity — animation is the one property dimming
+   does not soften. While the board is untrusted the pulse stops and drops to
+   the faint step, so the strip says what the rest of the screen says. */
+.ops-content[data-dim="yes"] .ops-outside-pulse {
+  animation: none;
+  background: var(--h4-faint);
+}
+.ops-outside-lead { color: var(--h4-ink); }
+.ops-outside-lead b {
+  font-family: var(--h4-font-display);
+  font-size: calc(15 * var(--ops-u));
+  font-weight: 700;
+  letter-spacing: 0.02em;
+}
+.ops-outside[data-band="worked"] .ops-outside-lead b { font-size: calc(18 * var(--ops-u)); }
+.ops-outside-counts { color: var(--h4-muted); }
+.ops-outside-when { color: var(--h4-muted); }
+.ops-outside-note {
+  margin-left: auto;
+  font-size: calc(10 * var(--ops-u));
+  color: var(--h4-tel);
+}
+
+/* ---- the roster ------------------------------------------------- */
+.ops-roster {
+  grid-column: 1 / -1;
+  padding-top: calc(9 * var(--ops-u));
+  border-top: 1px solid var(--ops-hair);
+}
+.ops-roster-bands {
+  display: flex;
+  gap: calc(8 * var(--ops-u));
+  margin: calc(8 * var(--ops-u)) 0 calc(4 * var(--ops-u));
+}
+.ops-roster-band {
+  display: inline-flex;
+  align-items: baseline;
+  gap: calc(6 * var(--ops-u));
+  padding: calc(3 * var(--ops-u)) calc(11 * var(--ops-u));
+  border: 1px solid var(--ops-hair);
+  border-radius: 999px;
+  background: var(--h4-tel-chip);
+  font-family: var(--h4-font-display);
+  font-size: calc(9.5 * var(--ops-u));
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  color: var(--h4-muted);
+}
+.ops-roster-band b {
+  font-family: var(--h4-font-mono);
+  font-size: calc(13 * var(--ops-u));
+  font-weight: 700;
+  color: var(--h4-ink-2);
+}
+.ops-roster-band[data-band="worked"] { border-color: var(--h4-line-strong); color: var(--h4-ink); }
+.ops-roster-band[data-band="worked"] b { color: var(--h4-ink); }
+
+.ops-roster-rows { display: grid; gap: calc(4 * var(--ops-u)); }
+.ops-roster-row {
+  display: grid;
+  grid-template-columns: calc(96 * var(--ops-u)) minmax(0, 1.1fr) minmax(0, 2fr);
+  gap: calc(12 * var(--ops-u));
+  align-items: baseline;
+  padding: calc(6 * var(--ops-u)) calc(10 * var(--ops-u));
+  border-left: 2px solid var(--h4-faint);
+  border-radius: 0 var(--b-r-chip) var(--b-r-chip) 0;
+  background: var(--h4-paper-sunken);
+}
+.ops-roster-row[data-band="engaged"] { border-left-color: var(--h4-muted); }
+.ops-roster-row[data-band="worked"] { border-left-color: var(--h4-ink); background: var(--h4-tel-chip); }
+.ops-roster-depth {
+  font-family: var(--h4-font-display);
+  font-size: calc(10 * var(--ops-u));
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--h4-muted);
+}
+.ops-roster-row[data-band="worked"] .ops-roster-depth { color: var(--h4-ink); }
+.ops-roster-who { min-width: 0; }
+.ops-roster-who b {
+  display: block;
+  font-family: var(--h4-font-mono);
+  font-size: calc(11.5 * var(--ops-u));
+  font-weight: 600;
+  color: var(--h4-ink);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.ops-roster-who small {
+  font-family: var(--h4-font-mono);
+  font-size: calc(9 * var(--ops-u));
+  color: var(--h4-muted);
+}
+/* The routes, verbatim. This is the evidence — it is not characterised
+   anywhere, because a request for /wp-login.php reads better as itself
+   than as any label this board could invent for it. */
+.ops-roster-routes {
+  display: flex;
+  flex-wrap: wrap;
+  gap: calc(4 * var(--ops-u));
+  min-width: 0;
+}
+.ops-roster-route {
+  display: inline-flex;
+  align-items: baseline;
+  gap: calc(5 * var(--ops-u));
+  max-width: 100%;
+  padding: calc(1 * var(--ops-u)) calc(7 * var(--ops-u));
+  border: 1px solid var(--ops-hair);
+  border-radius: var(--b-r-chip);
+  font-family: var(--h4-font-mono);
+  font-size: calc(9.5 * var(--ops-u));
+  color: var(--h4-ink-2);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.ops-roster-route i { font-style: normal; color: var(--h4-muted); }
+.ops-roster-routes em {
+  font-family: var(--h4-font-mono);
+  font-size: calc(9.5 * var(--ops-u));
+  font-style: normal;
+  color: var(--h4-tel);
+}
+.ops-roster-absent,
+.ops-roster-more {
+  margin: calc(8 * var(--ops-u)) 0 0;
+  font-family: var(--h4-font-mono);
+  font-size: calc(10 * var(--ops-u));
+  line-height: 1.45;
+  color: var(--h4-tel);
+}
+
+@media (max-width: 1240px) {
+  .ops-roster-row { grid-template-columns: calc(84 * var(--ops-u)) minmax(0, 1fr); }
+  .ops-roster-routes { grid-column: 1 / -1; }
+}
+
+/* =========================================================
    THE PHONE, on the same ground.
    The phone board keeps every rule that makes it a phone board — the
    filled verdict field, full contrast when untrusted, one-line lanes —

--- a/packages/monitor-ui/src/styles/ops-scaling.test.ts
+++ b/packages/monitor-ui/src/styles/ops-scaling.test.ts
@@ -32,8 +32,25 @@ const RULES = CSS.replace(/\/\*[\s\S]*?\*\//g, "");
  * looks right on the laptop it was written on, and freezes on the wall. A
  * layer that skins the board must scale with it.
  */
-const DIRECTION_B = readFileSync(fileURLToPath(new URL("./hermes4-direction-b.css", import.meta.url)), "utf8")
-  .replace(/\/\*[\s\S]*?\*\//g, "");
+const DIRECTION_B_FILE = readFileSync(fileURLToPath(new URL("./hermes4-direction-b.css", import.meta.url)), "utf8");
+const DIRECTION_B = DIRECTION_B_FILE.replace(/\/\*[\s\S]*?\*\//g, "");
+
+/**
+ * The layer skins TWO surfaces with two different sizing systems, and the
+ * split is load-bearing rather than stylistic: `--ops-u` is declared on
+ * `.ops-board`, so a phone rule written in it resolves to NOTHING. The board
+ * half must scale; the phone half must not reference the scaled unit at all.
+ *
+ * The file marks the boundary with the phone banner, so the test reads the
+ * same divider a human does.
+ */
+const PHONE_MARKER = "THE PHONE, on the same ground";
+const [BOARD_HALF, PHONE_HALF] = (() => {
+  const at = DIRECTION_B_FILE.indexOf(PHONE_MARKER);
+  expect(at, "the phone section's banner is the boundary this test reads").toBeGreaterThan(0);
+  const strip = (s: string) => s.replace(/\/\*[\s\S]*?\*\//g, "");
+  return [strip(DIRECTION_B_FILE.slice(0, at)), strip(DIRECTION_B_FILE.slice(at))];
+})();
 
 describe("--ops-u — the scaled pixel", () => {
   test("resolves to exactly 1px below 1920, so 1440x900 is untouched", () => {
@@ -68,15 +85,23 @@ describe("--ops-u — the scaled pixel", () => {
 });
 
 describe("the Direction B layer obeys the same contract", () => {
-  test("every font-size scales, except the KPI figure's own curve", () => {
+  test("every board font-size scales, except the KPI figure's own curve", () => {
     // The KPI value is sized by viewport like the verdict is: it is meant to
     // be read across the room, one tier below the verdict itself.
-    const fixed = [...DIRECTION_B.matchAll(/font-size:\s*([^;]+);/g)]
+    const fixed = [...BOARD_HALF.matchAll(/font-size:\s*([^;]+);/g)]
       .map((m) => m[1]!.trim())
       .filter((v) => !v.includes("var(--ops-u)"))
       .filter((v) => !/^clamp\(24px,\s*2\.1vw,\s*calc\(36 \* var\(--ops-u\)\)\)$/.test(v))
       .filter((v) => v !== "inherit");
     expect(fixed, "a fixed font-size freezes at 4K — express it in var(--ops-u)").toEqual([]);
+  });
+
+  test("the phone half never reaches for the board's scaled unit", () => {
+    // `--ops-u` is declared on `.ops-board`. A phone rule written in it does
+    // not fall back — it resolves to nothing, and the size silently vanishes.
+    // The phone is a fixed 390px surface and sizes in real px, exactly as
+    // hermes4-mobile.css already does.
+    expect(PHONE_HALF, "the phone has no --ops-u to read").not.toMatch(/--ops-u/);
   });
 
   test("no border in the layer is expressed in the scaled unit", () => {

--- a/services/slack-operator/src/arrivals-feed.ts
+++ b/services/slack-operator/src/arrivals-feed.ts
@@ -69,6 +69,46 @@ export interface ArrivalClient {
   tools: Record<string, number>;
 }
 
+/**
+ * ONE NAMED IDENTITY, across both doors.
+ *
+ * The platform has emitted this registry all along and this normalizer threw
+ * it away — the return object below is a fixed allowlist, so `agents` fell off
+ * the edge of it in silence. What was lost is the only per-identity evidence
+ * the board can get: WHO arrived, HOW DEEP they went, and WHICH routes they
+ * called. Live, that is the difference between an outsider walking the gold
+ * path (`/auth/nonce` → `/jobs/claim` → `/jobs/submit`) and a scanner asking
+ * for `/wp-login.php` — two facts no counter can tell apart, and the second is
+ * one an operator very much wants to see.
+ *
+ * SCOPED, NEVER AN ENUMERATION. This registry names what it can attribute; the
+ * door tables count distinct wallets. The two do not agree and are not meant
+ * to (live: 7 wallet-keyed outsiders here against 164 counted at `identified`).
+ * The board must therefore render this as "the ones we can name", never as
+ * "the outsiders" — a roster that contradicts the counts beside it is worse
+ * than no roster.
+ */
+export interface ArrivalAgent {
+  key: string;
+  /** Present only when the identity resolved to a wallet. */
+  wallet?: string | null;
+  name: string | null;
+  version: string | null;
+  era: string | null;
+  self: boolean;
+  ambiguous?: boolean;
+  firstSeenMs: number;
+  lastSeenMs: number;
+  /** `settled` is reachable here and is NOT one of ARRIVAL_STAGES. */
+  furthestStage: string;
+  calls: number;
+  /** Route or tool name → call count. Empty when nothing was recorded. */
+  tools: Record<string, number>;
+  /** Which front doors this identity was seen at. */
+  doors?: string[];
+  attributionSources?: ArrivalAttributionCounts;
+}
+
 export interface ArrivalsSnapshot {
   schemaVersion: typeof ARRIVALS_SCHEMA_VERSION;
   generatedAtMs?: number;
@@ -108,6 +148,21 @@ export interface ArrivalsSnapshot {
     furthestAmbiguous?: ArrivalStage;
   };
   clients: ArrivalClient[];
+  /**
+   * The named-identity registry — see ArrivalAgent.
+   *
+   * THREE STATES, kept apart on purpose. Absent means the producer does not
+   * emit it (older platform). An array means we read it. `agentsUnreadable`
+   * means it was there and we could not parse it — which is a finding, not an
+   * absence, and must not render as "nobody arrived".
+   *
+   * A malformed entry here does NOT take the whole arrivals block down the way
+   * a malformed client does: this registry is an addition to a panel that
+   * already worked without it, and failing the funnel closed over a new
+   * optional field would be a worse trade than reporting the field unreadable.
+   */
+  agents?: ArrivalAgent[];
+  agentsUnreadable?: string;
 }
 
 /** The platform snapshot verbatim, or why there is no reading. */
@@ -305,7 +360,67 @@ export function normalizeArrivalsFeed(body: unknown): ArrivalsBlock {
       ...(furthestAmbiguous === undefined ? {} : { furthestAmbiguous }),
     },
     clients,
+    ...normalizeAgents(value.agents),
   };
+}
+
+/**
+ * The named-identity registry, or the reason there isn't one.
+ *
+ * Absent → `{}`, so an older producer simply has no field. Present but not an
+ * array, or holding an entry we cannot read → `agentsUnreadable`, because "we
+ * could not parse the roster" and "nobody arrived" must never render alike.
+ * `self` is required for the same reason it is on a client: coercing a missing
+ * mark would silently promote our own probe into an outsider.
+ */
+function normalizeAgents(
+  raw: unknown,
+): { agents: ArrivalAgent[] } | { agentsUnreadable: string } | Record<string, never> {
+  if (raw === undefined || raw === null) return {};
+  if (!Array.isArray(raw)) {
+    return { agentsUnreadable: "identity registry unreadable — agents is not an array" };
+  }
+  const agents: ArrivalAgent[] = [];
+  for (const entry of raw) {
+    if (!entry || typeof entry !== "object") {
+      return { agentsUnreadable: "identity registry unreadable — an entry is not an object" };
+    }
+    const value = entry as Record<string, unknown>;
+    const firstSeenMs = count(value.firstSeenMs);
+    const lastSeenMs = count(value.lastSeenMs);
+    const calls = count(value.calls);
+    const tools = toolCounts(value.tools);
+    if (
+      typeof value.key !== "string" || !value.key.trim() ||
+      !nullableString(value.name) || !nullableString(value.version) || !nullableString(value.era) ||
+      typeof value.self !== "boolean" ||
+      (value.ambiguous !== undefined && typeof value.ambiguous !== "boolean") ||
+      typeof value.furthestStage !== "string" || !value.furthestStage.trim() ||
+      firstSeenMs === undefined || lastSeenMs === undefined || calls === undefined ||
+      tools === undefined
+    ) {
+      return { agentsUnreadable: "identity registry unreadable — an entry has invalid fields" };
+    }
+    const doors = Array.isArray(value.doors)
+      ? value.doors.filter((d): d is string => typeof d === "string")
+      : undefined;
+    agents.push({
+      key: value.key,
+      ...(value.wallet === undefined ? {} : { wallet: nullableString(value.wallet) ? (value.wallet as string | null) : null }),
+      name: value.name,
+      version: value.version,
+      era: value.era,
+      self: value.self,
+      ...(value.ambiguous === undefined ? {} : { ambiguous: value.ambiguous }),
+      firstSeenMs,
+      lastSeenMs,
+      furthestStage: value.furthestStage,
+      calls,
+      tools,
+      ...(doors === undefined ? {} : { doors }),
+    });
+  }
+  return { agents };
 }
 
 function stageCounts(


### PR DESCRIPTION
Follow-up to #818, which merged at `6c385e6` while these two commits were still on the branch. Without them, Direction B ships without the feature the OUTSIDE review was about.

## 1. `fix(board)` — the phone's verdict mark, and the sizing split it exposed

The square punched out of the phone's verdict field was the one element on that screen with no meaning — a block of page ground inside a rounded card. It becomes the kit's brand mark, the same chip the desktop top bar wears.

Writing it caught something better than the fix: the scaling guard failed on a raw `15px`, correct for the phone and wrong for the board, and the reason is load-bearing — **`--ops-u` is declared on `.ops-board`, so a phone rule written in it does not fall back; it resolves to nothing and the size silently vanishes.** The guard now reads the file's own phone banner as the boundary: the board half must scale, the phone half must never reference the scaled unit.

## 2. `feat(board)` — OUTSIDE: who is probing us, and how deep they got

**The data was already there and we threw it away.** The platform emits a per-identity registry (`agents[]`) on every arrivals read; `arrivals-feed.ts` returns a fixed allowlist, so it fell off the edge in silence. Live, that registry holds both an outsider walking the gold path (`/auth/nonce` → `/jobs/claim` → `/jobs/submit`, 310 calls) and an unattributed caller that made 127 requests in 18 seconds asking for `/wp-login.php` and `/.env`. Every counter on the board renders those two identically — only the routes tell them apart, so the routes are what the roster shows, verbatim.

- **OUTSIDE strip** under the KPI row: deepest band reached, counts with their window, age, and a pulse meaning RECENT. Neutral ink on purpose — sage would read as healthy and coral as page-someone, and an arrival is neither. Depth is carried by weight and a left rule, so it survives anyone who cannot separate the status hues.
- **WHO SHOWED UP**: `worked / looked / knocked`, each identity with door, calls, age, top routes. Nothing characterised — "hostile" is a judgement the board has no evidence for; `GET /wp-login.php` on a service with no WordPress is evidence.
- The fault line holds: the full panel stays below everything that can page an operator.
- Ours and ambiguous identities can never enter either surface.

### Truth-boundary findings — three, all fixed here

1. **Two clocks, one event.** The strip aged `lastSeenMs` against the reader's clock while the roster used the producer's — they disagreed by a minute on their first render together. Both now use the snapshot clock.
2. **A frozen reading animated.** Dimming does not soften animation, so the pulse kept reading as "happening now" under the stale banner. It stops while the board is untrusted.
3. **Counts with no window.** "1 worked" reads as today; the registry never meant that. The strip states what it observed since.

Absent registry, unreadable registry, and no-outsiders-named stay three different sentences — none of them an empty list.

## Verification

521 tests green (34 files), `tsc -b` clean, verified in the preview across NOMINAL / STRESS / UNVERIFIED / LIVE on desktop and phone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
