### PR TITLE
feat(monitor): add arrivals and worker journeys

### DIFF
--- a/packages/monitor-ui/src/components/BoardView.tsx
+++ b/packages/monitor-ui/src/components/BoardView.tsx
@@ -16,6 +16,7 @@ import type { MonitorBoard } from "../lib/monitor/board-cache.js";
 import type { ProductHealth } from "../lib/monitor/product-health.js";
 import type { StreamStatus } from "../lib/monitor/live-stream.js";
 import { useProductHealth } from "../hooks/useProductHealth.js";
+import { useAdminDemand } from "../hooks/useAdminDemand.js";
 import { useIsMobileViewport } from "../lib/monitor/use-mobile-viewport.js";
 import { MobileBoard } from "./mobile/MobileBoard.js";
 import { OpsBoard } from "./ops/OpsBoard.js";
@@ -30,9 +31,10 @@ export interface BoardViewProps {
 }
 
 export function BoardView({ board, status, onRefresh, health }: BoardViewProps) {
-  const polled = useProductHealth({ enabled: health === undefined });
-  const productHealth = health ?? polled.health;
   const isMobileViewport = useIsMobileViewport();
+  const polled = useProductHealth({ enabled: health === undefined });
+  const demand = useAdminDemand({ enabled: health === undefined && !isMobileViewport });
+  const productHealth = health ?? polled.health;
 
   // A stream we cannot trust must not render as a calm board — the fake-green
   // rule applied to the transport itself. <OpsBoard> takes this as an input
@@ -86,6 +88,11 @@ export function BoardView({ board, status, onRefresh, health }: BoardViewProps) 
         streamStatus={status}
         streamDegraded={degraded}
         onRefresh={onRefresh}
+        adminDemand={demand.feed}
+        adminDemandWindow={demand.window}
+        adminDemandLoading={demand.isLoading}
+        adminDemandError={demand.error}
+        onAdminDemandWindowChange={demand.setWindow}
       />
     </div>
   );

--- a/packages/monitor-ui/src/components/ops/AdminDemandPanel.test.tsx
+++ b/packages/monitor-ui/src/components/ops/AdminDemandPanel.test.tsx
@@ -1,0 +1,167 @@
+// @vitest-environment jsdom
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render } from "@testing-library/react";
+
+import type { AdminDemandFeed } from "../../lib/monitor/admin-demand.js";
+import { AdminDemandPanel } from "./AdminDemandPanel.js";
+
+afterEach(cleanup);
+
+const TESTER_WALLET = "0xDeD3D610546DF151a6BB3D6ed119c3700ABC2146";
+
+function feed(): AdminDemandFeed {
+  const collectionSince = "2026-08-21T08:00:00.000Z";
+  return {
+    schemaVersion: "averray.monitor.arrivals-journeys.v1",
+    generatedAt: "2026-08-22T10:00:00.000Z",
+    collectionSince,
+    window: "48h",
+    timeline: {
+      schemaVersion: "averray.admin.arrivals.timeline.v1",
+      generatedAt: "2026-08-22T10:00:00.000Z",
+      collectionSince,
+      window: {
+        id: "48h",
+        bucket: "hour",
+        start: "2026-08-21T10:00:00.000Z",
+        end: "2026-08-22T10:00:00.000Z",
+        bucketCount: 48,
+        retentionDays: 30,
+        backfilled: false,
+      },
+      dimensions: {
+        surfaces: ["manifest", "onboarding", "jobs_reads", "mcp_initialize", "verify_profiles"],
+        clientSoftwareClasses: ["claude", "cursor", "codex", "browser", "mcp_bridge", "directory", "other_declared", "unidentified"],
+      },
+      buckets: [
+        {
+          start: "2026-08-22T08:00:00.000Z",
+          end: "2026-08-22T09:00:00.000Z",
+          total: 4,
+          counts: [
+            { surface: "manifest", clientClass: "claude", count: 2 },
+            { surface: "manifest", clientClass: "cursor", count: 1 },
+            { surface: "jobs_reads", clientClass: "browser", count: 1 },
+          ],
+        },
+        {
+          start: "2026-08-22T09:00:00.000Z",
+          end: "2026-08-22T10:00:00.000Z",
+          total: 2,
+          counts: [
+            { surface: "onboarding", clientClass: "unidentified", count: 1 },
+            { surface: "mcp_initialize", clientClass: "mcp_bridge", count: 1 },
+          ],
+        },
+      ],
+    },
+    journeys: {
+      schemaVersion: "averray.admin.worker-journeys.v1",
+      generatedAt: "2026-08-22T10:00:00.000Z",
+      collectionSince,
+      window: {
+        id: "recent_active",
+        backfilled: false,
+        sessionReadCap: 500,
+        eventReadCap: 2_000,
+        journeyEventPerWalletCap: 250,
+      },
+      scope: "operator",
+      identityBoundary: "identity begins at SIWE",
+      count: 1,
+      limit: 50,
+      journeys: [
+        {
+          wallet: TESTER_WALLET,
+          classification: "external",
+          classificationAuthority: "shared_self_identity_registry",
+          firstSeenAt: "2026-08-22T08:00:00.000Z",
+          lastActiveAt: "2026-08-22T08:29:00.000Z",
+          events: [
+            event("first_seen", "2026-08-22T08:00:00.000Z", "arrival_events"),
+            event("signed_in", "2026-08-22T08:01:00.000Z", "journey_events", 60_000),
+            event("preflighted", "2026-08-22T08:03:00.000Z", "journey_events", 120_000),
+            event("claimed", "2026-08-22T08:04:00.000Z", "claim_sessions", 60_000),
+            event("submitted", "2026-08-22T08:20:00.000Z", "claim_sessions", 960_000),
+            event("verified", "2026-08-22T08:25:00.000Z", "verification_events", 300_000),
+            { ...event("settled", "2026-08-22T08:27:00.000Z", "settlement_events", 120_000), txHash: "0x1234567890abcdef1234567890abcdef" },
+            event("withdrawal_intent", "2026-08-22T08:29:00.000Z", "journey_events", 120_000),
+          ],
+        },
+      ],
+    },
+  };
+}
+
+function event(type: "first_seen" | "signed_in" | "preflighted" | "claimed" | "submitted" | "verified" | "settled" | "withdrawal_intent", timestamp: string, sourceStore: string, durationFromPreviousMs?: number) {
+  return {
+    id: `${type}:${timestamp}`,
+    type,
+    timestamp,
+    sourceStore,
+    ...(durationFromPreviousMs === undefined ? {} : { durationFromPreviousMs }),
+  };
+}
+
+describe("AdminDemandPanel", () => {
+  it("renders every arrival surface as a client-class-stacked timeline", () => {
+    const { getByTestId, container } = render(
+      <AdminDemandPanel feed={feed()} window="48h" onWindowChange={() => undefined} />,
+    );
+    for (const surface of ["manifest", "onboarding", "jobs_reads", "mcp_initialize", "verify_profiles"]) {
+      expect(getByTestId(`ops-demand-surface-${surface}`)).toBeTruthy();
+    }
+    expect(container.querySelectorAll('.ops-demand-bar-stack > [data-client="claude"]')).toHaveLength(1);
+    expect(container.querySelectorAll('.ops-demand-bar-stack > [data-client="cursor"]')).toHaveLength(1);
+    expect(getByTestId("ops-demand-timeline").textContent).toContain("aggregate only");
+  });
+
+  it("switches between the ratified hourly and daily windows without an operational action", () => {
+    const onWindowChange = vi.fn();
+    const { getByLabelText } = render(
+      <AdminDemandPanel feed={feed()} window="48h" onWindowChange={onWindowChange} />,
+    );
+    fireEvent.change(getByLabelText("Arrivals timeline window"), { target: { value: "30d" } });
+    expect(onWindowChange).toHaveBeenCalledWith("30d");
+  });
+
+  it("renders the blind tester wallet as a complete expandable journey with durations and provenance", () => {
+    const { getByTestId, getByText } = render(
+      <AdminDemandPanel feed={feed()} window="48h" onWindowChange={() => undefined} />,
+    );
+    const journey = getByTestId(`ops-demand-journey-${TESTER_WALLET}`);
+    expect(journey.getAttribute("data-classification")).toBe("external");
+    fireEvent.click(journey.querySelector("summary")!);
+    for (const stage of ["arrived", "signed in", "preflighted", "claimed", "submitted", "verified", "settled", "withdrawal intent"]) {
+      expect(getByText(stage)).toBeTruthy();
+    }
+    expect(journey.textContent).toContain("+16m");
+    expect(journey.textContent).toContain("claim_sessions");
+    expect(journey.textContent).toContain("tx 0x12345678");
+  });
+
+  it("states the collection cut-over and never implies a backfill", () => {
+    const { getByTestId } = render(
+      <AdminDemandPanel feed={feed()} window="48h" onWindowChange={() => undefined} />,
+    );
+    expect(getByTestId("ops-demand-cutover").textContent).toContain("data begins");
+    expect(getByTestId("ops-demand-cutover").textContent).toContain("no backfill");
+  });
+
+  it("renders failed reads as unavailable rather than empty zeroes", () => {
+    const unavailable: AdminDemandFeed = {
+      schemaVersion: "averray.monitor.arrivals-journeys.v1",
+      generatedAt: "2026-08-22T10:00:00.000Z",
+      window: "48h",
+      timeline: { unavailable: "admin role refused" },
+      journeys: { unavailable: "admin role refused" },
+    };
+    const { getByTestId, queryByTestId } = render(
+      <AdminDemandPanel feed={unavailable} window="48h" onWindowChange={() => undefined} />,
+    );
+    expect(getByTestId("ops-demand-timeline-unavailable").textContent).toContain("admin role refused");
+    expect(getByTestId("ops-demand-journeys-unavailable").textContent).toContain("admin role refused");
+    expect(queryByTestId("ops-demand-surface-manifest")).toBeNull();
+  });
+});

--- a/packages/monitor-ui/src/components/ops/AdminDemandPanel.tsx
+++ b/packages/monitor-ui/src/components/ops/AdminDemandPanel.tsx
@@ -1,0 +1,266 @@
+import {
+  ARRIVAL_SURFACES,
+  CLIENT_SOFTWARE_CLASSES,
+  isUnavailable,
+  type AdminDemandFeed,
+  type AdminDemandWindow,
+  type ArrivalSurface,
+  type ArrivalTimeline,
+  type ClientSoftwareClass,
+  type WorkerJourney,
+  type WorkerJourneyEvent,
+} from "../../lib/monitor/admin-demand.js";
+
+export interface AdminDemandPanelProps {
+  feed: AdminDemandFeed | undefined;
+  window: AdminDemandWindow;
+  isLoading?: boolean;
+  error?: unknown;
+  onWindowChange: (window: AdminDemandWindow) => void;
+}
+
+const SURFACE_LABELS: Record<ArrivalSurface, string> = {
+  manifest: "manifest",
+  onboarding: "onboarding",
+  jobs_reads: "jobs reads",
+  mcp_initialize: "MCP initialize",
+  verify_profiles: "verify profiles",
+};
+
+const EVENT_LABELS: Record<WorkerJourneyEvent["type"], string> = {
+  first_seen: "arrived",
+  auth_nonce: "auth nonce",
+  signed_in: "signed in",
+  preflighted: "preflighted",
+  claimed: "claimed",
+  submitted: "submitted",
+  verified: "verified",
+  settled: "settled",
+  withdrawal_intent: "withdrawal intent",
+  gas_grant: "gas grant",
+};
+
+export function AdminDemandPanel({
+  feed,
+  window,
+  isLoading = false,
+  error,
+  onWindowChange,
+}: AdminDemandPanelProps) {
+  const currentFeed = feed?.window === window ? feed : undefined;
+  const collectionSince = currentFeed?.collectionSince
+    ?? (!currentFeed || isUnavailable(currentFeed.timeline) ? undefined : currentFeed.timeline.collectionSince)
+    ?? (!currentFeed || isUnavailable(currentFeed.journeys) ? undefined : currentFeed.journeys.collectionSince);
+
+  return (
+    <section className="ops-admin-demand" aria-label="Arrivals and worker journeys" data-testid="ops-admin-demand">
+      <header className="ops-admin-demand-head">
+        <span>
+          <strong>ARRIVALS &amp; JOURNEYS</strong>
+          <small>operator-only · pre-auth counts, wallet identity after SIWE</small>
+        </span>
+        <label className="ops-demand-window">
+          <span>window</span>
+          <select
+            aria-label="Arrivals timeline window"
+            value={window}
+            onChange={(event) => onWindowChange(event.currentTarget.value as AdminDemandWindow)}
+          >
+            <option value="48h">48h · hourly</option>
+            <option value="30d">30d · daily</option>
+          </select>
+        </label>
+      </header>
+
+      <p className="ops-demand-cutover" data-testid="ops-demand-cutover">
+        {collectionSince
+          ? <>data begins <time dateTime={collectionSince}>{formatCutover(collectionSince)}</time> · no backfill</>
+          : "data cut-over unavailable · no history is inferred"}
+      </p>
+
+      {!currentFeed ? (
+        <p className="ops-demand-status" role="status" data-testid="ops-demand-loading">
+          {error ? `ADMIN READ UNAVAILABLE — ${errorMessage(error)}` : isLoading ? "LOADING ADMIN READ…" : "AWAITING ADMIN READ"}
+        </p>
+      ) : (
+        <div className="ops-admin-demand-grid">
+          <TimelineView timeline={currentFeed.timeline} />
+          <JourneyList journeys={currentFeed.journeys} />
+        </div>
+      )}
+    </section>
+  );
+}
+
+function TimelineView({ timeline }: { timeline: AdminDemandFeed["timeline"] }) {
+  if (isUnavailable(timeline)) {
+    return <UnavailableBlock label="ARRIVAL TIMELINE" reason={timeline.unavailable} testId="ops-demand-timeline-unavailable" />;
+  }
+
+  const presentClasses = CLIENT_SOFTWARE_CLASSES.filter((clientClass) =>
+    timeline.buckets.some((bucket) => bucket.counts.some((count) => count.clientClass === clientClass && count.count > 0)),
+  );
+  return (
+    <section className="ops-demand-timeline" data-testid="ops-demand-timeline">
+      <div className="ops-demand-subhead">
+        <h4>PRE-AUTH ARRIVALS</h4>
+        <span>{timeline.window.bucketCount} {timeline.window.bucket} buckets · aggregate only</span>
+      </div>
+      <div className="ops-demand-strips">
+        {ARRIVAL_SURFACES.map((surface) => (
+          <SurfaceStrip key={surface} surface={surface} timeline={timeline} />
+        ))}
+      </div>
+      <div className="ops-demand-legend" aria-label="Client software classes">
+        {presentClasses.length > 0 ? presentClasses.map((clientClass) => (
+          <span key={clientClass} data-client={clientClass}>
+            <i aria-hidden />{softwareLabel(clientClass)}
+          </span>
+        )) : <span>no arrivals collected in this window</span>}
+      </div>
+    </section>
+  );
+}
+
+function SurfaceStrip({ surface, timeline }: { surface: ArrivalSurface; timeline: ArrivalTimeline }) {
+  const totals = timeline.buckets.map((bucket) => bucket.counts
+    .filter((count) => count.surface === surface)
+    .reduce((sum, count) => sum + count.count, 0));
+  const max = Math.max(1, ...totals);
+  const surfaceTotal = totals.reduce((sum, count) => sum + count, 0);
+  return (
+    <div className="ops-demand-strip" data-surface={surface} data-testid={`ops-demand-surface-${surface}`}>
+      <span className="ops-demand-strip-label">
+        <b>{SURFACE_LABELS[surface]}</b><small>{surfaceTotal}</small>
+      </span>
+      <span className="ops-demand-bars" aria-label={`${SURFACE_LABELS[surface]} arrivals by ${timeline.window.bucket}`}>
+        {timeline.buckets.map((bucket, index) => {
+          const counts = bucket.counts.filter((count) => count.surface === surface && count.count > 0);
+          const total = totals[index] ?? 0;
+          return (
+            <span
+              className="ops-demand-bar"
+              key={`${bucket.start}:${surface}`}
+              title={bucketTitle(bucket.start, total, counts)}
+              aria-label={bucketTitle(bucket.start, total, counts)}
+            >
+              {total > 0 ? (
+                <i className="ops-demand-bar-stack" style={{ height: `${Math.max(4, (total / max) * 100)}%` }} aria-hidden>
+                  {counts.map((count) => (
+                    <i
+                      key={count.clientClass}
+                      data-client={count.clientClass}
+                      style={{ height: `${(count.count / total) * 100}%` }}
+                    />
+                  ))}
+                </i>
+              ) : null}
+            </span>
+          );
+        })}
+      </span>
+    </div>
+  );
+}
+
+function JourneyList({ journeys }: { journeys: AdminDemandFeed["journeys"] }) {
+  if (isUnavailable(journeys)) {
+    return <UnavailableBlock label="WORKER JOURNEYS" reason={journeys.unavailable} testId="ops-demand-journeys-unavailable" />;
+  }
+  return (
+    <section className="ops-demand-journeys" data-testid="ops-demand-journeys">
+      <div className="ops-demand-subhead">
+        <h4>RECENT WORKER JOURNEYS</h4>
+        <span>{journeys.count} wallet{journeys.count === 1 ? "" : "s"} · shared identity registry</span>
+      </div>
+      {journeys.journeys.length === 0 ? (
+        <p className="ops-demand-empty">no post-SIWE journey recorded in this window</p>
+      ) : (
+        <div className="ops-demand-journey-list">
+          {journeys.journeys.map((journey) => <JourneyRow key={journey.wallet} journey={journey} />)}
+        </div>
+      )}
+    </section>
+  );
+}
+
+function JourneyRow({ journey }: { journey: WorkerJourney }) {
+  return (
+    <details className="ops-demand-journey" data-classification={journey.classification} data-testid={`ops-demand-journey-${journey.wallet}`}>
+      <summary>
+        <span className="ops-demand-wallet" title={journey.wallet}>{shortWallet(journey.wallet)}</span>
+        <span className="ops-demand-classification">{journey.classification}</span>
+        <span className="ops-demand-journey-depth">{journey.events.length} event{journey.events.length === 1 ? "" : "s"}</span>
+        <span className="ops-demand-journey-last">{journey.lastActiveAt ? formatTimestamp(journey.lastActiveAt) : "last activity unavailable"}</span>
+      </summary>
+      <ol className="ops-demand-events">
+        {journey.events.map((event) => (
+          <li key={event.id} data-event={event.type}>
+            <span className="ops-demand-event-chip">{EVENT_LABELS[event.type] ?? event.type}</span>
+            <span className="ops-demand-event-time">
+              <time dateTime={event.timestamp}>{formatTimestamp(event.timestamp)}</time>
+              {event.durationFromPreviousMs == null ? null : <b>+{formatDuration(event.durationFromPreviousMs)}</b>}
+            </span>
+            <span className="ops-demand-event-source">{event.sourceStore}</span>
+            {event.jobId ? <code title={event.jobId}>{shortId(event.jobId)}</code> : null}
+            {event.txHash ? <code title={event.txHash}>tx {shortId(event.txHash)}</code> : null}
+          </li>
+        ))}
+      </ol>
+    </details>
+  );
+}
+
+function UnavailableBlock({ label, reason, testId }: { label: string; reason: string; testId: string }) {
+  return (
+    <section className="ops-demand-unavailable" data-testid={testId}>
+      <strong>{label} UNAVAILABLE</strong>
+      <span>{reason}</span>
+    </section>
+  );
+}
+
+function bucketTitle(start: string, total: number, counts: ArrivalTimeline["buckets"][number]["counts"]): string {
+  const breakdown = counts.map((count) => `${softwareLabel(count.clientClass)} ${count.count}`).join(", ");
+  return `${formatTimestamp(start)} · ${total} arrival${total === 1 ? "" : "s"}${breakdown ? ` · ${breakdown}` : ""}`;
+}
+
+function softwareLabel(value: ClientSoftwareClass): string {
+  return value.replaceAll("_", " ");
+}
+
+function shortWallet(value: string): string {
+  return value.length > 16 ? `${value.slice(0, 8)}…${value.slice(-6)}` : value;
+}
+
+function shortId(value: string): string {
+  return value.length > 20 ? `${value.slice(0, 10)}…${value.slice(-8)}` : value;
+}
+
+function formatCutover(value: string): string {
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? value : date.toLocaleString(undefined, { dateStyle: "medium", timeStyle: "short" });
+}
+
+function formatTimestamp(value: string): string {
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? value : date.toLocaleString(undefined, {
+    month: "short",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: false,
+  });
+}
+
+function formatDuration(milliseconds: number): string {
+  if (milliseconds < 1_000) return `${Math.round(milliseconds)}ms`;
+  if (milliseconds < 60_000) return `${Math.round(milliseconds / 1_000)}s`;
+  if (milliseconds < 3_600_000) return `${Math.round(milliseconds / 60_000)}m`;
+  if (milliseconds < 86_400_000) return `${(milliseconds / 3_600_000).toFixed(milliseconds < 36_000_000 ? 1 : 0)}h`;
+  return `${(milliseconds / 86_400_000).toFixed(1)}d`;
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/packages/monitor-ui/src/components/ops/OpsBoard.tsx
+++ b/packages/monitor-ui/src/components/ops/OpsBoard.tsx
@@ -8,19 +8,21 @@
 //   PILLARS        the 8 probes, grouped, with their details
 //   NEXT           what to do; the fault line below which nothing is red
 //   OUTSIDE        both public arrival doors, condensed but not combined
-//   footer         incidents · LLM spend · "refresh is the only control"
+//   footer         incidents · LLM spend · read-only boundary
 //
 // Size follows priority, not chronology: the verdict is the only thing sized to
 // be read across a room, the money owns the middle band, the probe details sit
 // under it, and the least urgent number on the board — LLM spend — is one line
 // in the footer rather than the tall column it used to be.
 //
-// There are no controls here beyond Refresh. Commands and discussion live in
+// There are no operational controls here beyond Refresh. The arrivals window
+// selector changes only the read projection; commands and discussion live in
 // Buzz (docs/OPS_ONLY_PIVOT.md).
 
 import { opsSuggestions } from "../../lib/monitor/ops-suggestions.js";
 import type { MonitorBoard } from "../../lib/monitor/board-cache.js";
 import type { ProductHealth } from "../../lib/monitor/product-health.js";
+import type { AdminDemandFeed, AdminDemandWindow } from "../../lib/monitor/admin-demand.js";
 import { formatAgo, incidentRows, probeOpsTone } from "../../lib/monitor/ops-model.js";
 import { boardKpis, economicsLine } from "../../lib/monitor/ops-spec.js";
 import { outsiderPresence, type OutsiderBand } from "../../lib/monitor/arrivals-view.js";
@@ -30,6 +32,7 @@ import { PillarStrip } from "./PillarStrip.js";
 import { SolvencyPanel } from "./SolvencyPanel.js";
 import { BankLane } from "./BankLane.js";
 import { ArrivalsPanel } from "./ArrivalsPanel.js";
+import { AdminDemandPanel } from "./AdminDemandPanel.js";
 import { DepositPoolTile } from "./DepositPoolTile.js";
 
 export interface OpsBoardProps {
@@ -42,6 +45,11 @@ export interface OpsBoardProps {
   onRefresh?: (() => void) | undefined;
   /** Injected clock so every age label is deterministic to test. */
   nowMs?: number;
+  adminDemand?: AdminDemandFeed;
+  adminDemandWindow?: AdminDemandWindow;
+  adminDemandLoading?: boolean;
+  adminDemandError?: unknown;
+  onAdminDemandWindowChange?: (window: AdminDemandWindow) => void;
 }
 
 export function OpsBoard({
@@ -51,6 +59,11 @@ export function OpsBoard({
   streamDegraded = false,
   onRefresh,
   nowMs = Date.now(),
+  adminDemand,
+  adminDemandWindow = "48h",
+  adminDemandLoading = false,
+  adminDemandError,
+  onAdminDemandWindowChange = () => undefined,
 }: OpsBoardProps) {
   const verdict = opsVerdict({ health, streamDegraded, nowMs });
   const trust = trustRows({ health, streamDegraded, streamStatus, streamAt: board?.at, nowMs });
@@ -239,8 +252,7 @@ export function OpsBoard({
             words it had already written.
 
             TEXT ONLY. Each suggestion carries a `task` the operator could
-            approve, and this board is read-only by design — "refresh is the
-            only control" is one line below. Rendering the button here would
+            approve, and this board is read-only by design. Rendering the button here would
             break that promise; the sentence is the whole value anyway.
 
             NOTHING WHEN THERE IS NOTHING. An all-clear board shows no NEXT
@@ -266,11 +278,18 @@ export function OpsBoard({
             can page the operator. Both independent doors remain visible, and
             moving them refuses to recast a business outcome as a money fault. */}
         <ArrivalsPanel arrivals={health.arrivals} />
+        <AdminDemandPanel
+          feed={adminDemand}
+          window={adminDemandWindow}
+          isLoading={adminDemandLoading}
+          error={adminDemandError}
+          onWindowChange={onAdminDemandWindowChange}
+        />
 
         <div className="ops-foot">
           <span>INCIDENTS — {incidentSummary(health, nowMs)}</span>
           <span>{llmSummary(board)}</span>
-          <span>refresh is the only control · everything else is read-only</span>
+          <span>refresh is the only operational control · window selects a read</span>
         </div>
       </div>
     </div>

--- a/packages/monitor-ui/src/components/ops/money-lines-wired.test.ts
+++ b/packages/monitor-ui/src/components/ops/money-lines-wired.test.ts
@@ -91,12 +91,17 @@ describe("every money line is actually rendered", () => {
  * guard above exists for, one level up.
  */
 describe("every ops panel is mounted by the board", () => {
-  for (const panel of ["SolvencyPanel", "FlowPanel", "BankLane", "PillarStrip"] as const) {
+  for (const panel of ["SolvencyPanel", "FlowPanel", "BankLane", "PillarStrip", "AdminDemandPanel"] as const) {
     it(`OpsBoard mounts <${panel}>`, () => {
       const opsBoard = fs.readFileSync(path.join(dir, "OpsBoard.tsx"), "utf8");
       expect(opsBoard, `${panel} exists and is tested but the board never renders it`).toContain(`<${panel}`);
     });
   }
+
+  it("the shipped SPA still imports the ops stylesheet", () => {
+    const main = fs.readFileSync(path.join(dir, "..", "..", "main.tsx"), "utf8");
+    expect(main).toContain('import "./styles/hermes4-ops.css"');
+  });
 });
 
 /**

--- a/packages/monitor-ui/src/hooks/useAdminDemand.test.tsx
+++ b/packages/monitor-ui/src/hooks/useAdminDemand.test.tsx
@@ -1,0 +1,43 @@
+// @vitest-environment jsdom
+
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import type { AdminDemandFeed, AdminDemandWindow } from "../lib/monitor/admin-demand.js";
+import { useAdminDemand } from "./useAdminDemand.js";
+
+function unavailableFeed(window: AdminDemandWindow): AdminDemandFeed {
+  return {
+    schemaVersion: "averray.monitor.arrivals-journeys.v1",
+    generatedAt: "2026-08-22T10:00:00.000Z",
+    window,
+    timeline: { unavailable: "fixture" },
+    journeys: { unavailable: "fixture" },
+  };
+}
+
+describe("useAdminDemand", () => {
+  it("reads the monitor-authenticated proxy and refetches the selected window", async () => {
+    const fetcher = vi.fn(async (url: string) => unavailableFeed(url.includes("window=30d") ? "30d" : "48h"));
+    const { result } = renderHook(() => useAdminDemand({
+      url: "/monitor/admin-demand?fixture=journeys",
+      intervalMs: 0,
+      journeyLimit: 50,
+      fetcher,
+    }));
+
+    await waitFor(() => expect(result.current.feed?.window).toBe("48h"));
+    expect(fetcher).toHaveBeenCalledWith("/monitor/admin-demand?fixture=journeys&window=48h&limit=50");
+
+    act(() => result.current.setWindow("30d"));
+    await waitFor(() => expect(result.current.feed?.window).toBe("30d"));
+    expect(fetcher).toHaveBeenCalledWith("/monitor/admin-demand?fixture=journeys&window=30d&limit=50");
+  });
+
+  it("does not touch the admin feed when the desktop panel is disabled", () => {
+    const fetcher = vi.fn(async () => unavailableFeed("48h"));
+    const { result } = renderHook(() => useAdminDemand({ enabled: false, fetcher }));
+    expect(result.current.feed).toBeUndefined();
+    expect(fetcher).not.toHaveBeenCalled();
+  });
+});

--- a/packages/monitor-ui/src/hooks/useAdminDemand.ts
+++ b/packages/monitor-ui/src/hooks/useAdminDemand.ts
@@ -1,0 +1,62 @@
+import { useCallback, useState } from "react";
+import useSWR from "swr";
+import {
+  parseAdminDemandFeed,
+  type AdminDemandFeed,
+  type AdminDemandWindow,
+} from "../lib/monitor/admin-demand.js";
+
+const DEFAULT_URL = "/monitor/admin-demand";
+const DEFAULT_INTERVAL_MS = 60_000;
+const DEFAULT_JOURNEY_LIMIT = 50;
+
+export interface UseAdminDemandOptions {
+  url?: string;
+  intervalMs?: number;
+  journeyLimit?: number;
+  fetcher?: (url: string) => Promise<AdminDemandFeed>;
+  enabled?: boolean;
+}
+
+export interface AdminDemandState {
+  feed: AdminDemandFeed | undefined;
+  error: unknown;
+  isLoading: boolean;
+  window: AdminDemandWindow;
+  setWindow: (window: AdminDemandWindow) => void;
+  refresh: () => void;
+}
+
+async function defaultFetcher(url: string): Promise<AdminDemandFeed> {
+  const response = await fetch(url, { headers: { accept: "application/json" } });
+  if (!response.ok) throw new Error(`admin demand fetch failed: ${response.status}`);
+  return parseAdminDemandFeed(await response.json());
+}
+
+export function useAdminDemand(options: UseAdminDemandOptions = {}): AdminDemandState {
+  const {
+    url = DEFAULT_URL,
+    intervalMs = DEFAULT_INTERVAL_MS,
+    journeyLimit = DEFAULT_JOURNEY_LIMIT,
+    fetcher = defaultFetcher,
+    enabled = true,
+  } = options;
+  const [window, setWindow] = useState<AdminDemandWindow>("48h");
+  const requestUrl = enabled ? withQuery(url, window, journeyLimit) : null;
+  const { data, error, isLoading, mutate } = useSWR<AdminDemandFeed>(requestUrl, fetcher, {
+    refreshInterval: intervalMs,
+    revalidateOnFocus: false,
+    revalidateOnReconnect: true,
+    keepPreviousData: true,
+  });
+  const refresh = useCallback(() => {
+    void mutate();
+  }, [mutate]);
+
+  return { feed: data, error, isLoading, window, setWindow, refresh };
+}
+
+function withQuery(url: string, window: AdminDemandWindow, journeyLimit: number): string {
+  const separator = url.includes("?") ? "&" : "?";
+  return `${url}${separator}window=${encodeURIComponent(window)}&limit=${encodeURIComponent(String(journeyLimit))}`;
+}

--- a/packages/monitor-ui/src/lib/monitor/admin-demand.test.ts
+++ b/packages/monitor-ui/src/lib/monitor/admin-demand.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "vitest";
+
+import { parseAdminDemandFeed } from "./admin-demand.js";
+
+function payload() {
+  const collectionSince = "2026-08-22T10:00:00.000Z";
+  return {
+    schemaVersion: "averray.monitor.arrivals-journeys.v1",
+    generatedAt: "2026-08-22T11:00:00.000Z",
+    collectionSince,
+    window: "48h",
+    timeline: {
+      schemaVersion: "averray.admin.arrivals.timeline.v1",
+      generatedAt: "2026-08-22T11:00:00.000Z",
+      collectionSince,
+      window: {
+        id: "48h",
+        bucket: "hour",
+        start: "2026-08-20T11:00:00.000Z",
+        end: "2026-08-22T11:00:00.000Z",
+        bucketCount: 48,
+        retentionDays: 30,
+        backfilled: false,
+      },
+      dimensions: {
+        surfaces: ["manifest", "onboarding", "jobs_reads", "mcp_initialize", "verify_profiles"],
+        clientSoftwareClasses: ["claude", "cursor", "codex", "browser", "mcp_bridge", "directory", "other_declared", "unidentified"],
+      },
+      buckets: [{
+        start: "2026-08-22T10:00:00.000Z",
+        end: "2026-08-22T11:00:00.000Z",
+        total: 1,
+        counts: [{ surface: "manifest", clientClass: "browser", count: 1 }],
+      }],
+    },
+    journeys: {
+      schemaVersion: "averray.admin.worker-journeys.v1",
+      generatedAt: "2026-08-22T11:00:00.000Z",
+      collectionSince,
+      window: {
+        id: "recent_active",
+        backfilled: false,
+        sessionReadCap: 250,
+        eventReadCap: 500,
+        journeyEventPerWalletCap: 250,
+      },
+      scope: "operator",
+      identityBoundary: "Wallet identity begins at successful SIWE.",
+      count: 1,
+      limit: 50,
+      journeys: [{
+        wallet: "0xded3d610546df151a6bb3d6ed119c3700abc2146",
+        classification: "external",
+        classificationAuthority: "shared_self_identity_registry",
+        firstSeenAt: "2026-08-22T10:30:00.000Z",
+        lastActiveAt: "2026-08-22T10:30:00.000Z",
+        events: [{
+          id: "first-seen",
+          type: "first_seen",
+          timestamp: "2026-08-22T10:30:00.000Z",
+          sourceStore: "event-log",
+          durationFromPreviousMs: null,
+        }],
+      }],
+    },
+  };
+}
+
+describe("admin demand response parser", () => {
+  it("accepts the Part A first-event null duration without inventing elapsed time", () => {
+    const parsed = parseAdminDemandFeed(payload());
+    expect("unavailable" in parsed.journeys).toBe(false);
+    if ("unavailable" in parsed.journeys) throw new Error("unexpected unavailable fixture");
+    expect(parsed.journeys.journeys[0]?.events[0]?.durationFromPreviousMs).toBeNull();
+  });
+
+  it("rejects a client class outside the fixed aggregate taxonomy", () => {
+    const value = payload();
+    value.timeline.buckets[0]!.counts[0]!.clientClass = "raw-user-agent";
+    expect(() => parseAdminDemandFeed(value)).toThrow(/timeline count/u);
+  });
+
+  it("rejects a journey response that does not state operator scope", () => {
+    const value = payload();
+    value.journeys.scope = "public";
+    expect(() => parseAdminDemandFeed(value)).toThrow(/operator scope/u);
+  });
+});

--- a/packages/monitor-ui/src/lib/monitor/admin-demand.ts
+++ b/packages/monitor-ui/src/lib/monitor/admin-demand.ts
@@ -1,0 +1,314 @@
+export const ARRIVAL_SURFACES = [
+  "manifest",
+  "onboarding",
+  "jobs_reads",
+  "mcp_initialize",
+  "verify_profiles",
+] as const;
+
+export const CLIENT_SOFTWARE_CLASSES = [
+  "claude",
+  "cursor",
+  "codex",
+  "browser",
+  "mcp_bridge",
+  "directory",
+  "other_declared",
+  "unidentified",
+] as const;
+
+export type ArrivalSurface = typeof ARRIVAL_SURFACES[number];
+export type ClientSoftwareClass = typeof CLIENT_SOFTWARE_CLASSES[number];
+export type AdminDemandWindow = "48h" | "30d";
+
+export interface AdminDemandUnavailable {
+  unavailable: string;
+}
+
+export interface ArrivalTimelineCount {
+  surface: ArrivalSurface;
+  clientClass: ClientSoftwareClass;
+  count: number;
+}
+
+export interface ArrivalTimelineBucket {
+  start: string;
+  end: string;
+  total: number;
+  counts: ArrivalTimelineCount[];
+}
+
+export interface ArrivalTimeline {
+  schemaVersion: "averray.admin.arrivals.timeline.v1";
+  generatedAt: string;
+  collectionSince: string;
+  window: {
+    id: AdminDemandWindow;
+    bucket: "hour" | "day";
+    start: string;
+    end: string;
+    bucketCount: number;
+    retentionDays: number;
+    backfilled: false;
+  };
+  dimensions: {
+    surfaces: ArrivalSurface[];
+    clientSoftwareClasses: ClientSoftwareClass[];
+  };
+  buckets: ArrivalTimelineBucket[];
+}
+
+export type JourneyEventType =
+  | "first_seen"
+  | "auth_nonce"
+  | "signed_in"
+  | "preflighted"
+  | "claimed"
+  | "submitted"
+  | "verified"
+  | "settled"
+  | "withdrawal_intent"
+  | "gas_grant";
+
+const JOURNEY_EVENT_TYPES: readonly JourneyEventType[] = [
+  "first_seen",
+  "auth_nonce",
+  "signed_in",
+  "preflighted",
+  "claimed",
+  "submitted",
+  "verified",
+  "settled",
+  "withdrawal_intent",
+  "gas_grant",
+];
+
+export interface WorkerJourneyEvent {
+  id: string;
+  type: JourneyEventType;
+  timestamp: string;
+  sourceStore: string;
+  durationFromPreviousMs?: number | null;
+  sessionId?: string;
+  jobId?: string;
+  txHash?: string;
+  details?: Record<string, unknown>;
+}
+
+export interface WorkerJourney {
+  wallet: string;
+  classification: "external" | "operator-run" | "unknown";
+  classificationKind?: string;
+  classificationAuthority: "shared_self_identity_registry";
+  classificationEvidence?: unknown;
+  firstSeenAt?: string;
+  lastActiveAt?: string;
+  events: WorkerJourneyEvent[];
+}
+
+export interface WorkerJourneys {
+  schemaVersion: "averray.admin.worker-journeys.v1";
+  generatedAt: string;
+  collectionSince: string;
+  window: {
+    id: "wallet_retained_history" | "recent_active";
+    backfilled: false;
+    sessionReadCap: number;
+    eventReadCap: number;
+    journeyEventPerWalletCap: number;
+  };
+  scope: "operator";
+  identityBoundary: string;
+  count: number;
+  limit: number;
+  wallet?: string;
+  journeys: WorkerJourney[];
+}
+
+export interface AdminDemandFeed {
+  schemaVersion: "averray.monitor.arrivals-journeys.v1";
+  generatedAt: string;
+  collectionSince?: string;
+  window: AdminDemandWindow;
+  timeline: ArrivalTimeline | AdminDemandUnavailable;
+  journeys: WorkerJourneys | AdminDemandUnavailable;
+}
+
+export function isUnavailable(value: unknown): value is AdminDemandUnavailable {
+  return isRecord(value) && typeof value.unavailable === "string";
+}
+
+/** Fail closed on malformed admin data: the panel shows a read failure, not invented rows. */
+export function parseAdminDemandFeed(value: unknown): AdminDemandFeed {
+  if (!isRecord(value) || value.schemaVersion !== "averray.monitor.arrivals-journeys.v1") {
+    throw new Error("admin demand response has an unsupported schema");
+  }
+  if (value.window !== "48h" && value.window !== "30d") throw new Error("admin demand response has an invalid window");
+  return {
+    schemaVersion: value.schemaVersion,
+    generatedAt: requiredString(value.generatedAt, "generatedAt"),
+    ...(typeof value.collectionSince === "string" ? { collectionSince: value.collectionSince } : {}),
+    window: value.window,
+    timeline: parseTimelineOrUnavailable(value.timeline),
+    journeys: parseJourneysOrUnavailable(value.journeys),
+  };
+}
+
+function parseTimelineOrUnavailable(value: unknown): ArrivalTimeline | AdminDemandUnavailable {
+  if (isUnavailable(value)) return value;
+  if (!isRecord(value) || value.schemaVersion !== "averray.admin.arrivals.timeline.v1") {
+    throw new Error("arrival timeline is missing or malformed");
+  }
+  if (!isRecord(value.window) || (value.window.id !== "48h" && value.window.id !== "30d")) {
+    throw new Error("arrival timeline window is malformed");
+  }
+  if (value.window.bucket !== "hour" && value.window.bucket !== "day") throw new Error("arrival timeline bucket unit is malformed");
+  if (value.window.backfilled !== false) throw new Error("arrival timeline must state that it is not backfilled");
+  if (!isRecord(value.dimensions) || !Array.isArray(value.dimensions.surfaces)
+    || !Array.isArray(value.dimensions.clientSoftwareClasses)) {
+    throw new Error("arrival timeline dimensions are malformed");
+  }
+  if (!Array.isArray(value.buckets)) throw new Error("arrival timeline buckets are malformed");
+  const buckets = value.buckets.map((bucket, index) => parseTimelineBucket(bucket, index));
+  return {
+    schemaVersion: value.schemaVersion,
+    generatedAt: requiredString(value.generatedAt, "timeline.generatedAt"),
+    collectionSince: requiredString(value.collectionSince, "timeline.collectionSince"),
+    window: {
+      id: value.window.id,
+      bucket: value.window.bucket,
+      start: requiredString(value.window.start, "timeline.window.start"),
+      end: requiredString(value.window.end, "timeline.window.end"),
+      bucketCount: nonNegativeNumber(value.window.bucketCount, "timeline.window.bucketCount"),
+      retentionDays: nonNegativeNumber(value.window.retentionDays, "timeline.window.retentionDays"),
+      backfilled: false,
+    },
+    dimensions: {
+      surfaces: parseEnumArray(value.dimensions.surfaces, ARRIVAL_SURFACES, "timeline.dimensions.surfaces"),
+      clientSoftwareClasses: parseEnumArray(
+        value.dimensions.clientSoftwareClasses,
+        CLIENT_SOFTWARE_CLASSES,
+        "timeline.dimensions.clientSoftwareClasses",
+      ),
+    },
+    buckets,
+  };
+}
+
+function parseTimelineBucket(value: unknown, index: number): ArrivalTimelineBucket {
+  if (!isRecord(value) || !Array.isArray(value.counts)) throw new Error(`arrival timeline bucket ${index} is malformed`);
+  return {
+    start: requiredString(value.start, `buckets[${index}].start`),
+    end: requiredString(value.end, `buckets[${index}].end`),
+    total: nonNegativeNumber(value.total, `buckets[${index}].total`),
+    counts: value.counts.map((count, countIndex) => parseTimelineCount(count, index, countIndex)),
+  };
+}
+
+function parseTimelineCount(value: unknown, bucketIndex: number, countIndex: number): ArrivalTimelineCount {
+  if (!isRecord(value) || !ARRIVAL_SURFACES.includes(value.surface as ArrivalSurface)
+    || !CLIENT_SOFTWARE_CLASSES.includes(value.clientClass as ClientSoftwareClass)) {
+    throw new Error(`arrival timeline count ${bucketIndex}:${countIndex} is malformed`);
+  }
+  return {
+    surface: value.surface as ArrivalSurface,
+    clientClass: value.clientClass as ClientSoftwareClass,
+    count: nonNegativeNumber(value.count, `buckets[${bucketIndex}].counts[${countIndex}].count`),
+  };
+}
+
+function parseJourneysOrUnavailable(value: unknown): WorkerJourneys | AdminDemandUnavailable {
+  if (isUnavailable(value)) return value;
+  if (!isRecord(value) || value.schemaVersion !== "averray.admin.worker-journeys.v1" || !Array.isArray(value.journeys)) {
+    throw new Error("worker journeys are missing or malformed");
+  }
+  if (!isRecord(value.window) || (value.window.id !== "wallet_retained_history" && value.window.id !== "recent_active")) {
+    throw new Error("worker journey window is malformed");
+  }
+  if (value.window.backfilled !== false) throw new Error("worker journeys must state that they are not backfilled");
+  if (value.scope !== "operator") throw new Error("worker journeys escaped the operator scope");
+  return {
+    schemaVersion: value.schemaVersion,
+    generatedAt: requiredString(value.generatedAt, "journeys.generatedAt"),
+    collectionSince: requiredString(value.collectionSince, "journeys.collectionSince"),
+    window: {
+      id: value.window.id,
+      backfilled: false,
+      sessionReadCap: nonNegativeNumber(value.window.sessionReadCap, "journeys.window.sessionReadCap"),
+      eventReadCap: nonNegativeNumber(value.window.eventReadCap, "journeys.window.eventReadCap"),
+      journeyEventPerWalletCap: nonNegativeNumber(value.window.journeyEventPerWalletCap, "journeys.window.journeyEventPerWalletCap"),
+    },
+    scope: value.scope,
+    identityBoundary: requiredString(value.identityBoundary, "journeys.identityBoundary"),
+    count: nonNegativeNumber(value.count, "journeys.count"),
+    limit: nonNegativeNumber(value.limit, "journeys.limit"),
+    ...(typeof value.wallet === "string" ? { wallet: value.wallet } : {}),
+    journeys: value.journeys.map((journey, index) => parseJourney(journey, index)),
+  };
+}
+
+function parseJourney(value: unknown, index: number): WorkerJourney {
+  if (!isRecord(value) || !Array.isArray(value.events)) throw new Error(`worker journey ${index} is malformed`);
+  const classification = value.classification;
+  if (classification !== "external" && classification !== "operator-run" && classification !== "unknown") {
+    throw new Error(`worker journey ${index} has an invalid classification`);
+  }
+  if (value.classificationAuthority !== "shared_self_identity_registry") {
+    throw new Error(`worker journey ${index} has an invalid classification authority`);
+  }
+  return {
+    wallet: requiredString(value.wallet, `journeys[${index}].wallet`),
+    classification,
+    classificationAuthority: value.classificationAuthority,
+    ...(typeof value.classificationKind === "string" ? { classificationKind: value.classificationKind } : {}),
+    ...(value.classificationEvidence === undefined ? {} : { classificationEvidence: value.classificationEvidence }),
+    ...(typeof value.firstSeenAt === "string" ? { firstSeenAt: value.firstSeenAt } : {}),
+    ...(typeof value.lastActiveAt === "string" ? { lastActiveAt: value.lastActiveAt } : {}),
+    events: value.events.map((event, eventIndex) => parseJourneyEvent(event, index, eventIndex)),
+  };
+}
+
+function parseJourneyEvent(value: unknown, journeyIndex: number, eventIndex: number): WorkerJourneyEvent {
+  if (!isRecord(value)) throw new Error(`worker journey event ${journeyIndex}:${eventIndex} is malformed`);
+  const type = requiredString(value.type, `journeys[${journeyIndex}].events[${eventIndex}].type`);
+  if (!JOURNEY_EVENT_TYPES.includes(type as JourneyEventType)) {
+    throw new Error(`worker journey event ${journeyIndex}:${eventIndex} has an invalid type`);
+  }
+  const duration = value.durationFromPreviousMs;
+  if (duration !== undefined && duration !== null
+    && (typeof duration !== "number" || !Number.isFinite(duration) || duration < 0)) {
+    throw new Error(`worker journey event ${journeyIndex}:${eventIndex} has an invalid duration`);
+  }
+  return {
+    id: requiredString(value.id, `journeys[${journeyIndex}].events[${eventIndex}].id`),
+    type: type as JourneyEventType,
+    timestamp: requiredString(value.timestamp, `journeys[${journeyIndex}].events[${eventIndex}].timestamp`),
+    sourceStore: requiredString(value.sourceStore, `journeys[${journeyIndex}].events[${eventIndex}].sourceStore`),
+    ...(duration === undefined ? {} : { durationFromPreviousMs: duration as number | null }),
+    ...(typeof value.sessionId === "string" ? { sessionId: value.sessionId } : {}),
+    ...(typeof value.jobId === "string" ? { jobId: value.jobId } : {}),
+    ...(typeof value.txHash === "string" ? { txHash: value.txHash } : {}),
+    ...(isRecord(value.details) ? { details: value.details } : {}),
+  };
+}
+
+function requiredString(value: unknown, field: string): string {
+  if (typeof value !== "string" || !value) throw new Error(`${field} must be a non-empty string`);
+  return value;
+}
+
+function nonNegativeNumber(value: unknown, field: string): number {
+  if (typeof value !== "number" || !Number.isFinite(value) || value < 0) throw new Error(`${field} must be non-negative`);
+  return value;
+}
+
+function parseEnumArray<const T extends readonly string[]>(value: unknown[], allowed: T, field: string): Array<T[number]> {
+  if (value.some((item) => typeof item !== "string" || !allowed.includes(item as T[number]))) {
+    throw new Error(`${field} contains an unsupported value`);
+  }
+  return value as Array<T[number]>;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}

--- a/packages/monitor-ui/src/styles/hermes4-ops.css
+++ b/packages/monitor-ui/src/styles/hermes4-ops.css
@@ -1667,6 +1667,240 @@ body,
   color: var(--h4-tel) !important;
 }
 
+/* ---- ARRIVALS & JOURNEYS — prospective admin reads -----------------
+   Pre-auth is aggregate-only and post-SIWE is wallet-bound. These rows sit
+   below the fault line: they describe demand and progression, never health.
+   Client colours are categorical ink, not green/red verdict tones. */
+.ops-admin-demand {
+  display: grid;
+  gap: calc(7 * var(--ops-u));
+  padding: calc(8 * var(--ops-u)) calc(14 * var(--ops-u));
+  border: 1px solid var(--ops-rule);
+}
+.ops-admin-demand-head,
+.ops-demand-subhead {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: calc(12 * var(--ops-u));
+}
+.ops-admin-demand-head > span {
+  display: flex;
+  align-items: baseline;
+  gap: calc(9 * var(--ops-u));
+  flex-wrap: wrap;
+}
+.ops-admin-demand-head strong,
+.ops-demand-subhead h4 {
+  margin: 0;
+  font-family: var(--h4-font-display);
+  font-size: calc(13.5 * var(--ops-u));
+  font-weight: 700;
+  letter-spacing: 0.09em;
+  color: var(--h4-ink);
+}
+.ops-admin-demand-head small,
+.ops-demand-subhead span,
+.ops-demand-cutover {
+  font-family: var(--h4-font-mono);
+  font-size: calc(8.5 * var(--ops-u));
+  color: var(--h4-muted);
+}
+.ops-demand-window {
+  display: flex;
+  align-items: center;
+  gap: calc(5 * var(--ops-u));
+  font-family: var(--h4-font-mono);
+  font-size: calc(8.5 * var(--ops-u));
+  color: var(--h4-muted);
+}
+.ops-demand-window select {
+  padding: calc(3 * var(--ops-u)) calc(7 * var(--ops-u));
+  border: 1px solid var(--ops-hair);
+  border-radius: 6px;
+  color: var(--h4-ink-2);
+  background: var(--h4-paper-sunken);
+  font: inherit;
+}
+.ops-demand-window select:focus-visible {
+  outline: 2px solid var(--h4-ink-2);
+  outline-offset: 2px;
+}
+.ops-demand-cutover {
+  margin: 0;
+  padding-bottom: calc(5 * var(--ops-u));
+  border-bottom: 1px solid var(--ops-hair);
+  color: var(--h4-tel);
+}
+.ops-demand-status,
+.ops-demand-unavailable,
+.ops-demand-empty {
+  margin: 0;
+  padding: calc(8 * var(--ops-u)) calc(10 * var(--ops-u));
+  border: 1px solid var(--ops-hair);
+  background: var(--h4-paper-sunken);
+  font-family: var(--h4-font-mono);
+  font-size: calc(9.5 * var(--ops-u));
+  color: var(--h4-tel);
+}
+.ops-demand-unavailable {
+  display: grid;
+  gap: calc(3 * var(--ops-u));
+}
+.ops-demand-unavailable strong { letter-spacing: 0.07em; }
+.ops-admin-demand-grid {
+  display: grid;
+  gap: calc(10 * var(--ops-u));
+}
+.ops-demand-timeline,
+.ops-demand-journeys {
+  display: grid;
+  gap: calc(6 * var(--ops-u));
+  padding: calc(9 * var(--ops-u)) calc(11 * var(--ops-u));
+  border: 1px solid var(--ops-hair);
+  border-radius: 10px;
+  background: var(--h4-paper-sunken);
+}
+.ops-demand-subhead {
+  padding-bottom: calc(5 * var(--ops-u));
+  border-bottom: 1px solid var(--ops-hair);
+}
+.ops-demand-subhead h4 { font-size: calc(11 * var(--ops-u)); }
+.ops-demand-strips {
+  display: grid;
+  gap: calc(5 * var(--ops-u));
+}
+.ops-demand-strip {
+  display: grid;
+  grid-template-columns: calc(112 * var(--ops-u)) minmax(0, 1fr);
+  align-items: center;
+  gap: calc(8 * var(--ops-u));
+  min-width: 0;
+}
+.ops-demand-strip-label {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: calc(5 * var(--ops-u));
+  font-family: var(--h4-font-mono);
+  font-size: calc(8 * var(--ops-u));
+  color: var(--h4-muted);
+}
+.ops-demand-strip-label b {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-weight: 500;
+}
+.ops-demand-strip-label small { color: var(--h4-ink-2); }
+.ops-demand-bars {
+  display: grid;
+  grid-auto-flow: column;
+  grid-auto-columns: minmax(2px, 1fr);
+  align-items: end;
+  gap: 1px;
+  height: calc(28 * var(--ops-u));
+  border-bottom: 1px solid var(--ops-hair);
+}
+.ops-demand-bar {
+  display: flex;
+  align-items: end;
+  height: 100%;
+  min-width: 0;
+}
+.ops-demand-bar-stack {
+  display: flex;
+  flex-direction: column-reverse;
+  width: 100%;
+  min-height: 1px;
+  overflow: hidden;
+}
+.ops-demand-bar-stack > i,
+.ops-demand-legend i {
+  display: block;
+  background: var(--h4-faint);
+}
+.ops-demand-bar-stack > i[data-client="claude"], .ops-demand-legend [data-client="claude"] i { background: var(--h4-ag-claude); }
+.ops-demand-bar-stack > i[data-client="cursor"], .ops-demand-legend [data-client="cursor"] i { background: #8a6bb5; }
+.ops-demand-bar-stack > i[data-client="codex"], .ops-demand-legend [data-client="codex"] i { background: var(--h4-ag-codex); }
+.ops-demand-bar-stack > i[data-client="browser"], .ops-demand-legend [data-client="browser"] i { background: #8d7862; }
+.ops-demand-bar-stack > i[data-client="mcp_bridge"], .ops-demand-legend [data-client="mcp_bridge"] i { background: #4f7693; }
+.ops-demand-bar-stack > i[data-client="directory"], .ops-demand-legend [data-client="directory"] i { background: #9a6c65; }
+.ops-demand-bar-stack > i[data-client="other_declared"], .ops-demand-legend [data-client="other_declared"] i { background: var(--h4-ag-test); }
+.ops-demand-bar-stack > i[data-client="unidentified"], .ops-demand-legend [data-client="unidentified"] i { background: var(--h4-faint); }
+.ops-demand-legend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: calc(4 * var(--ops-u)) calc(9 * var(--ops-u));
+  font-family: var(--h4-font-mono);
+  font-size: calc(7.5 * var(--ops-u));
+  color: var(--h4-muted);
+}
+.ops-demand-legend span { display: inline-flex; align-items: center; gap: calc(3 * var(--ops-u)); }
+.ops-demand-legend i { width: calc(7 * var(--ops-u)); height: calc(7 * var(--ops-u)); }
+.ops-demand-journey-list { display: grid; gap: calc(4 * var(--ops-u)); }
+.ops-demand-journey {
+  border: 1px solid var(--ops-hair);
+  background: var(--h4-paper);
+}
+.ops-demand-journey summary {
+  display: grid;
+  grid-template-columns: calc(126 * var(--ops-u)) calc(82 * var(--ops-u)) calc(64 * var(--ops-u)) minmax(0, 1fr);
+  align-items: center;
+  gap: calc(8 * var(--ops-u));
+  padding: calc(6 * var(--ops-u)) calc(8 * var(--ops-u));
+  cursor: pointer;
+  list-style: none;
+  font-family: var(--h4-font-mono);
+  font-size: calc(8.5 * var(--ops-u));
+}
+.ops-demand-journey summary::-webkit-details-marker { display: none; }
+.ops-demand-wallet { color: var(--h4-ink); }
+.ops-demand-classification {
+  justify-self: start;
+  padding: calc(1 * var(--ops-u)) calc(5 * var(--ops-u));
+  border: 1px solid var(--ops-hair);
+  border-radius: 999px;
+  color: var(--h4-muted);
+}
+.ops-demand-journey[data-classification="external"] .ops-demand-classification { color: var(--h4-ink-2); }
+.ops-demand-journey-depth,
+.ops-demand-journey-last { color: var(--h4-muted); }
+.ops-demand-journey-last { justify-self: end; }
+.ops-demand-events {
+  display: grid;
+  gap: calc(3 * var(--ops-u));
+  margin: 0;
+  padding: calc(6 * var(--ops-u)) calc(8 * var(--ops-u)) calc(8 * var(--ops-u));
+  border-top: 1px solid var(--ops-hair);
+  list-style: none;
+}
+.ops-demand-events li {
+  display: grid;
+  grid-template-columns: calc(106 * var(--ops-u)) calc(138 * var(--ops-u)) calc(120 * var(--ops-u)) minmax(0, 1fr);
+  align-items: baseline;
+  gap: calc(8 * var(--ops-u));
+  font-family: var(--h4-font-mono);
+  font-size: calc(8 * var(--ops-u));
+  color: var(--h4-muted);
+}
+.ops-demand-event-chip {
+  padding: calc(2 * var(--ops-u)) calc(5 * var(--ops-u));
+  border: 1px solid var(--ops-hair);
+  color: var(--h4-ink-2);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+.ops-demand-event-time { display: flex; justify-content: space-between; gap: calc(4 * var(--ops-u)); }
+.ops-demand-event-time b { color: var(--h4-ink-2); font-weight: 500; }
+.ops-demand-event-source,
+.ops-demand-events code {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.ops-demand-events code { color: var(--h4-tel); font: inherit; }
+
 /* ---- BANK group ------------------------------------------------
    One frame asserts one treasury subject, not one instrument. The venue and
    depositor pool therefore keep separate cells, tones and absence rules, with
@@ -1915,6 +2149,19 @@ body,
     grid-template-columns: minmax(calc(120 * var(--ops-u)), 1fr) repeat(3, minmax(calc(48 * var(--ops-u)), auto));
     gap: calc(4 * var(--ops-u));
   }
+  .ops-admin-demand-head,
+  .ops-demand-subhead { align-items: flex-start; flex-direction: column; }
+  .ops-demand-strip { grid-template-columns: calc(88 * var(--ops-u)) minmax(0, 1fr); }
+  .ops-demand-journey summary {
+    grid-template-columns: minmax(0, 1fr) auto;
+  }
+  .ops-demand-journey-depth { display: none; }
+  .ops-demand-journey-last { grid-column: 1 / -1; justify-self: start; }
+  .ops-demand-events li {
+    grid-template-columns: minmax(calc(92 * var(--ops-u)), auto) minmax(0, 1fr);
+  }
+  .ops-demand-event-source,
+  .ops-demand-events code { grid-column: 2; }
 }
 
 /* ---- per-job economics -------------------------------------------
@@ -2025,7 +2272,7 @@ body,
 /* ---- NEXT — what to do about it ----------------------------------------
    The board named eleven things that were wrong and never once said what to
    do. This strip is the answer, and it sits directly above the footer that
-   promises "refresh is the only control" — deliberately: it TELLS, it does not
+   promises there are no operational controls here — deliberately: it TELLS, it does not
    ACT. The suggestions carry an approvable task; this surface renders only
    their sentence. */
 .ops-next {

--- a/services/slack-operator/src/admin-demand-feed.ts
+++ b/services/slack-operator/src/admin-demand-feed.ts
@@ -1,0 +1,154 @@
+export type AdminDemandWindow = "48h" | "30d";
+
+export interface AdminDemandAuthSession {
+  token: string;
+  expiresAt?: string;
+}
+
+export interface AdminDemandUnavailable {
+  unavailable: string;
+}
+
+export interface AdminDemandFeed {
+  schemaVersion: "averray.monitor.arrivals-journeys.v1";
+  generatedAt: string;
+  /** The later cut-over is the earliest point shared by both returned feeds. */
+  collectionSince?: string;
+  window: AdminDemandWindow;
+  timeline: unknown | AdminDemandUnavailable;
+  journeys: unknown | AdminDemandUnavailable;
+}
+
+interface ReadAdminDemandFeedOptions {
+  baseUrl: string;
+  window: AdminDemandWindow;
+  limit: number;
+  getSession: () => Promise<AdminDemandAuthSession>;
+  fetchImpl?: typeof fetch;
+  now?: () => Date;
+}
+
+/**
+ * Keeps the platform bearer on the server, beside the wallet that minted it.
+ * The monitor browser sees only the projected admin reads and never receives
+ * the token or a signing capability.
+ */
+export class AdminDemandSessionCache {
+  private session: AdminDemandAuthSession | undefined;
+  private pending: Promise<AdminDemandAuthSession> | undefined;
+
+  constructor(
+    private readonly login: () => Promise<AdminDemandAuthSession>,
+    private readonly now: () => number = Date.now,
+  ) {}
+
+  async get(): Promise<AdminDemandAuthSession> {
+    if (this.session && sessionRemainsUsable(this.session, this.now())) return this.session;
+    if (this.pending) return this.pending;
+
+    this.pending = this.login()
+      .then((session) => {
+        this.session = session;
+        return session;
+      })
+      .finally(() => {
+        this.pending = undefined;
+      });
+    return this.pending;
+  }
+}
+
+export async function readAdminDemandFeed(options: ReadAdminDemandFeedOptions): Promise<AdminDemandFeed> {
+  const generatedAt = (options.now ?? (() => new Date()))().toISOString();
+  let session: AdminDemandAuthSession;
+  try {
+    session = await options.getSession();
+  } catch (error) {
+    const reason = `admin SIWE session unavailable: ${errorMessage(error)}`;
+    return unavailableFeed(options.window, generatedAt, reason);
+  }
+
+  const baseUrl = options.baseUrl.replace(/\/+$/u, "");
+  const fetchImpl = options.fetchImpl ?? fetch;
+  const [timeline, journeys] = await Promise.all([
+    readAdminJson(
+      `${baseUrl}/admin/arrivals/timeline?window=${encodeURIComponent(options.window)}`,
+      session.token,
+      "arrivals timeline",
+      fetchImpl,
+    ),
+    readAdminJson(
+      `${baseUrl}/admin/worker-journeys?limit=${encodeURIComponent(String(options.limit))}`,
+      session.token,
+      "worker journeys",
+      fetchImpl,
+    ),
+  ]);
+  const collectionSince = sharedCollectionSince(timeline, journeys);
+
+  return {
+    schemaVersion: "averray.monitor.arrivals-journeys.v1",
+    generatedAt,
+    ...(collectionSince ? { collectionSince } : {}),
+    window: options.window,
+    timeline,
+    journeys,
+  };
+}
+
+async function readAdminJson(
+  url: string,
+  token: string,
+  label: string,
+  fetchImpl: typeof fetch,
+): Promise<unknown | AdminDemandUnavailable> {
+  try {
+    const response = await fetchImpl(url, {
+      headers: {
+        accept: "application/json",
+        authorization: `Bearer ${token}`,
+      },
+    });
+    if (!response.ok) return { unavailable: `${label} returned HTTP ${response.status}` };
+    return await response.json();
+  } catch (error) {
+    return { unavailable: `${label} unavailable: ${errorMessage(error)}` };
+  }
+}
+
+function unavailableFeed(window: AdminDemandWindow, generatedAt: string, reason: string): AdminDemandFeed {
+  return {
+    schemaVersion: "averray.monitor.arrivals-journeys.v1",
+    generatedAt,
+    window,
+    timeline: { unavailable: reason },
+    journeys: { unavailable: reason },
+  };
+}
+
+function sessionRemainsUsable(session: AdminDemandAuthSession, nowMs: number): boolean {
+  if (!session.token) return false;
+  if (!session.expiresAt) return false;
+  const expiresAtMs = Date.parse(session.expiresAt);
+  return Number.isFinite(expiresAtMs) && expiresAtMs > nowMs + 60_000;
+}
+
+function sharedCollectionSince(...feeds: Array<unknown | AdminDemandUnavailable>): string | undefined {
+  const times = feeds
+    .map((feed) => readCollectionSince(feed))
+    .filter((value): value is string => Boolean(value))
+    .map((value) => ({ value, at: Date.parse(value) }))
+    .filter((value) => Number.isFinite(value.at));
+  if (times.length === 0) return undefined;
+  return times.reduce((latest, current) => current.at > latest.at ? current : latest).value;
+}
+
+function readCollectionSince(value: unknown): string | undefined {
+  if (!value || typeof value !== "object" || Array.isArray(value) || "unavailable" in value) return undefined;
+  const collectionSince = (value as Record<string, unknown>).collectionSince;
+  return typeof collectionSince === "string" ? collectionSince : undefined;
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/services/slack-operator/src/index.ts
+++ b/services/slack-operator/src/index.ts
@@ -4,7 +4,7 @@ import path from "node:path";
 import fs from "node:fs";
 import { fileURLToPath } from "node:url";
 import { readFile } from "node:fs/promises";
-import { addressFromPrivateKey, logger, optionalEnv, query } from "@avg/mcp-common";
+import { addressFromPrivateKey, logger, optionalEnv, query, siweLogin } from "@avg/mcp-common";
 import { createDefaultWorkflowDeps } from "@avg/averray-mcp/default-workflow-runtime";
 import { invokeAgentTask } from "@avg/averray-mcp/agent-invocation";
 import { getHandoffMonitor, recordHandoffEvent } from "@avg/averray-mcp/handoff-events";
@@ -201,6 +201,11 @@ import type { TransportFailureRun } from "./probe-transport.js";
 import { deriveOpsVerdict } from "@avg/schemas";
 import { appendIncidents, readIncidents, reconcileIncidents } from "./product-health-incidents.js";
 import { readArrivalsFeed } from "./arrivals-feed.js";
+import {
+  AdminDemandSessionCache,
+  readAdminDemandFeed,
+  type AdminDemandWindow,
+} from "./admin-demand-feed.js";
 import { depositPoolUrlFromBankFeed, readDepositPoolFeed } from "./deposit-pool-feed.js";
 import {
   loadRemediationConfig,
@@ -371,6 +376,8 @@ function deriveProductHealthSigner(): string | undefined {
   }
 }
 const monitorConfig = parseMonitorConfig(process.env);
+const adminDemandApiBaseUrl = optionalEnv("AVERRAY_API_BASE_URL", "https://api.averray.com");
+const adminDemandSession = new AdminDemandSessionCache(() => siweLogin(adminDemandApiBaseUrl));
 const missionSpawnRoles = parseMissionSpawnRoles(process.env);
 // The Vite-built redesigned monitor SPA, served as the default board at
 // /monitor. At runtime index.js lives in services/slack-operator/dist, so
@@ -935,6 +942,35 @@ async function handleHttpRequest(request: http.IncomingMessage, response: http.S
       // omitted by JSON when the routine hasn't run a cycle yet).
       remediation: productHealthRemediation,
     });
+    return;
+  }
+  if (request.method === "GET" && url.pathname === "/monitor/admin-demand") {
+    if (!monitorConfig.enabled) {
+      writeJson(response, 404, { error: "monitor_disabled" });
+      return;
+    }
+    if (!isMonitorAuthorized(monitorConfig, request.headers, url)) {
+      writeJson(response, 401, { error: "monitor_unauthorized" });
+      return;
+    }
+    const requestedWindow = url.searchParams.get("window") ?? "48h";
+    if (requestedWindow !== "48h" && requestedWindow !== "30d") {
+      writeJson(response, 400, { error: "invalid_window", allowed: ["48h", "30d"] });
+      return;
+    }
+    const requestedLimit = Number.parseInt(url.searchParams.get("limit") ?? "25", 10);
+    if (!Number.isInteger(requestedLimit) || requestedLimit < 1 || requestedLimit > 100) {
+      writeJson(response, 400, { error: "invalid_limit", min: 1, max: 100 });
+      return;
+    }
+    const feed = await readAdminDemandFeed({
+      baseUrl: adminDemandApiBaseUrl,
+      window: requestedWindow as AdminDemandWindow,
+      limit: requestedLimit,
+      getSession: () => adminDemandSession.get(),
+    });
+    response.setHeader("cache-control", "private, no-store");
+    writeJson(response, 200, feed);
     return;
   }
   if (request.method === "GET" && url.pathname === "/monitor/decision-records") {

--- a/test/unit/admin-demand-feed.test.ts
+++ b/test/unit/admin-demand-feed.test.ts
@@ -1,0 +1,95 @@
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  AdminDemandSessionCache,
+  readAdminDemandFeed,
+} from "../../services/slack-operator/src/admin-demand-feed.js";
+
+const TIMELINE = {
+  schemaVersion: "averray.admin.arrivals.timeline.v1",
+  generatedAt: "2026-08-22T10:00:00.000Z",
+  collectionSince: "2026-08-21T08:00:00.000Z",
+  buckets: [],
+};
+
+const JOURNEYS = {
+  schemaVersion: "averray.admin.worker-journeys.v1",
+  generatedAt: "2026-08-22T10:00:00.000Z",
+  collectionSince: "2026-08-21T09:00:00.000Z",
+  journeys: [],
+};
+
+describe("admin arrivals and journeys feed", () => {
+  it("reads both Part A endpoints in parallel with one server-side SIWE bearer", async () => {
+    const pending: Array<() => void> = [];
+    const fetchImpl = vi.fn(async (url: string | URL | Request, init?: RequestInit) => {
+      await new Promise<void>((resolve) => pending.push(resolve));
+      const body = String(url).includes("arrivals/timeline") ? TIMELINE : JOURNEYS;
+      expect(new Headers(init?.headers).get("authorization")).toBe("Bearer admin-session");
+      return new Response(JSON.stringify(body), { status: 200 });
+    });
+
+    const reading = readAdminDemandFeed({
+      baseUrl: "https://api.example.test/",
+      window: "48h",
+      limit: 50,
+      getSession: async () => ({ token: "admin-session", expiresAt: "2026-08-22T12:00:00.000Z" }),
+      fetchImpl: fetchImpl as typeof fetch,
+      now: () => new Date("2026-08-22T10:01:00.000Z"),
+    });
+
+    await vi.waitFor(() => expect(fetchImpl).toHaveBeenCalledTimes(2));
+    pending.splice(0).forEach((resolve) => resolve());
+    const feed = await reading;
+
+    expect(fetchImpl.mock.calls.map(([url]) => String(url))).toEqual([
+      "https://api.example.test/admin/arrivals/timeline?window=48h",
+      "https://api.example.test/admin/worker-journeys?limit=50",
+    ]);
+    expect(feed.collectionSince).toBe("2026-08-21T09:00:00.000Z");
+    expect(feed.timeline).toEqual(TIMELINE);
+    expect(feed.journeys).toEqual(JOURNEYS);
+  });
+
+  it("keeps one failed admin read explicit without hiding the other feed", async () => {
+    const fetchImpl = vi.fn(async (url: string | URL | Request) => String(url).includes("arrivals/timeline")
+      ? new Response("forbidden", { status: 403 })
+      : new Response(JSON.stringify(JOURNEYS), { status: 200 }));
+    const feed = await readAdminDemandFeed({
+      baseUrl: "https://api.example.test",
+      window: "30d",
+      limit: 25,
+      getSession: async () => ({ token: "not-admin" }),
+      fetchImpl: fetchImpl as typeof fetch,
+    });
+    expect(feed.timeline).toEqual({ unavailable: "arrivals timeline returned HTTP 403" });
+    expect(feed.journeys).toEqual(JOURNEYS);
+  });
+
+  it("single-flights login and renews before the cached bearer expires", async () => {
+    let nowMs = Date.parse("2026-08-22T10:00:00.000Z");
+    const login = vi.fn(async () => ({ token: `session-${login.mock.calls.length}`, expiresAt: "2026-08-22T10:10:00.000Z" }));
+    const cache = new AdminDemandSessionCache(login, () => nowMs);
+
+    const [first, second] = await Promise.all([cache.get(), cache.get()]);
+    expect(first.token).toBe(second.token);
+    expect(login).toHaveBeenCalledTimes(1);
+
+    nowMs = Date.parse("2026-08-22T10:09:30.000Z");
+    await cache.get();
+    expect(login).toHaveBeenCalledTimes(2);
+  });
+
+  it("keeps the browser route behind the existing monitor authorization guard", () => {
+    const source = fs.readFileSync(path.resolve("services/slack-operator/src/index.ts"), "utf8");
+    const routeStart = source.indexOf('url.pathname === "/monitor/admin-demand"');
+    const routeEnd = source.indexOf("return;", source.indexOf("readAdminDemandFeed", routeStart));
+    const route = source.slice(routeStart, routeEnd);
+    expect(routeStart).toBeGreaterThan(0);
+    expect(route, "admin payload must never bypass the operator board auth boundary").toContain("isMonitorAuthorized");
+    expect(route).toContain("readAdminDemandFeed");
+    expect(route, "wallet journeys must not land in a shared browser or proxy cache").toContain('"cache-control", "private, no-store"');
+  });
+});


### PR DESCRIPTION
## What changed

- Adds a monitor-authenticated /monitor/admin-demand proxy that mints and caches a short-lived SIWE session server-side, then reads the Part A arrivals timeline and worker journeys in parallel.
- Adds the operator-only Arrivals & journeys panel: 48h hourly / 30d daily surface strips stacked by client class, plus expandable wallet journeys with source-store provenance, between-step durations, and shared-registry external/operator-run labels.
- Preserves cut-over honesty and failure states: the UI says when collection begins, never backfills, rejects malformed taxonomy/scope data, and renders unavailable reads rather than zero activity.
- Keeps the split board composition and the main.tsx hermes4-ops.css import intact.

## Checks

- npm run typecheck
- npm test — 3093 passed, 37 skipped
- npm --workspace packages/monitor-ui run build

## Surfaces

- Backend: slack-operator read-only monitor proxy only.
- Frontend: operator monitor SPA only.
- No public-page, Caddy, contract, indexer, settlement, or revenue-surface changes.

## Rollout

- Depends on averray-agent/agent PR #1229 being deployed first so the two admin endpoints exist.
- No new environment variables or VPS secrets. The proxy reuses AVERRAY_API_BASE_URL, AGENT_WALLET_PRIVATE_KEY, shared SIWE, and the existing monitor authorization boundary. If that wallet is not granted the platform admin role, both reads stay visibly unavailable.
- Human deployment only through ops/deploy-monitor.sh after review and Part A rollout.

## Rollback

- Revert this commit and redeploy through ops/deploy-monitor.sh. The prior arrivals panel and all existing product-health paths are otherwise unchanged.

## Limits

- Prospective data only. The UI explicitly renders the Part A collectionSince cut-over and does not synthesize earlier history.
- Pre-auth data remains aggregate surface/software-class counts. Wallet identity appears only in the post-SIWE journey response.